### PR TITLE
Fix animation reset when play clicked at end

### DIFF
--- a/free_flight_log_app/assets/cesium/cesium.js
+++ b/free_flight_log_app/assets/cesium/cesium.js
@@ -741,8 +741,23 @@ function setupTimeBasedAnimation(points) {
     // Force scene rendering on each frame to ensure pilot updates
     viewer.scene.requestRenderMode = false;  // Disable request render mode to force continuous rendering
     
+    // Track animation state for play-at-end detection
+    let wasAnimating = false;
+    
     // Add clock tick listener to update statistics label
     viewer.clock.onTick.addEventListener(function(clock) {
+        // Check if we just started playing from the end
+        const atEnd = Cesium.JulianDate.compare(clock.currentTime, clock.stopTime) >= 0;
+        const justStartedPlaying = clock.shouldAnimate && !wasAnimating;
+        
+        if (atEnd && justStartedPlaying) {
+            // Reset to start when play is clicked at end
+            clock.currentTime = clock.startTime.clone();
+            cesiumLog.info('Animation reset to start - play clicked at end');
+        }
+        
+        wasAnimating = clock.shouldAnimate;
+        
         // Force scene update
         viewer.scene.requestRender();
         


### PR DESCRIPTION
## Summary
- Fixes issue where clicking play at the end of flight animation did nothing
- Animation now resets to beginning and starts playing when play is clicked at end
- Resolves #19

## Implementation
- Keeps `CLAMPED` clock range to stop at end (avoids continuous looping)
- Adds state tracking with `wasAnimating` to detect play button clicks
- Resets `clock.currentTime` to `startTime` when play is clicked while at end

## Test plan
- [x] Open a flight with IGC track in Cesium view
- [x] Let animation play to the end
- [x] Click play button - animation should reset to start and begin playing
- [x] Verify animation still stops at end (no continuous looping)

🤖 Generated with [Claude Code](https://claude.ai/code)