### PR TITLE
Fix stats box positioning - display below viewport with Material Design styling

### DIFF
--- a/free_flight_log_app/assets/cesium/cesium.html
+++ b/free_flight_log_app/assets/cesium/cesium.html
@@ -45,8 +45,7 @@
             /* Flexbox for horizontal layout */
             display: none;
             align-items: center;
-            justify-content: center;
-            gap: 48px;
+            justify-content: space-evenly;
         }
         #statsContainer.visible {
             display: flex;

--- a/free_flight_log_app/assets/cesium/cesium.html
+++ b/free_flight_log_app/assets/cesium/cesium.html
@@ -5,14 +5,72 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <script src="https://cesium.com/downloads/cesiumjs/releases/1.127/Build/Cesium/Cesium.js"></script>
     <link href="https://cesium.com/downloads/cesiumjs/releases/1.127/Build/Cesium/Widgets/widgets.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <style>
-        html, body, #cesiumContainer {
+        html, body {
             width: 100%; 
             height: 100%; 
             margin: 0; 
             padding: 0; 
             overflow: hidden;
             font-family: sans-serif;
+            position: relative;
+        }
+        #cesiumContainer {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%; /* Full height by default */
+            transition: height 0.3s ease;
+        }
+        #cesiumContainer.with-stats {
+            height: calc(100% - 80px); /* Reduce height when stats are shown */
+        }
+        #statsContainer {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            height: 80px;
+            background-color: #121212;  /* Material Design 3 dark surface */
+            border-top: 1px solid #333333;
+            box-shadow: 0 -2px 4px rgba(0,0,0,0.3);  /* Darker shadow for dark theme */
+            padding: 12px 24px;
+            box-sizing: border-box;
+            display: none; /* Hidden by default, shown when track data is loaded */
+            font-family: 'Roboto', sans-serif;
+            color: #FFFFFF;  /* White text on dark background */
+            z-index: 10;
+            /* Flexbox for horizontal layout */
+            display: none;
+            align-items: center;
+            justify-content: center;
+            gap: 48px;
+        }
+        #statsContainer.visible {
+            display: flex;
+        }
+        #statsContainer .stat-item {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            min-width: 60px;
+        }
+        #statsContainer .material-icons {
+            font-size: 20px;
+            color: #4FC3F7; /* Light Blue 300 - matches dark theme primary */
+            margin-bottom: 4px;
+        }
+        #statsContainer .stat-value {
+            font-size: 12px;
+            font-weight: bold;
+            color: #FFFFFF; /* White text */
+            margin-bottom: 2px;
+        }
+        #statsContainer .stat-label {
+            font-size: 10px;
+            color: #B0B0B0; /* Light grey for labels */
         }
         #loadingOverlay {
             position: absolute;
@@ -29,6 +87,7 @@
 <body>
     <div id="cesiumContainer"></div>
     <div id="loadingOverlay">Loading Cesium Globe...</div>
+    <div id="statsContainer"></div>
     
     <script>{{JS_CONTENT}}</script>
     <script>


### PR DESCRIPTION
## Summary
- Fixes stats box positioning issue where it moved with map interactions
- Stats now display in a fixed container below the map (like 2D view)
- Styled to match Flight Statistics panel with Material Design icons
- Resolves #21

## Implementation
- Converted from Cesium entity label to HTML container below map
- Added Material Icons matching Flutter app (height, trending_up/down, speed, access_time)
- Styled to match dark theme Flight Statistics panel:
  - Dark background (#121212)
  - Light blue icons (#4FC3F7)
  - White values with grey labels
  - Vertical layout with icons above values
  - Even spacing across full width

## Changes
1. **HTML Structure**: Added stats container div below cesiumContainer
2. **CSS Styling**: Dark theme with Material Design colors and layout
3. **JavaScript**: Updates HTML content instead of Cesium entity
4. **Removed**: All positioning-related code (no longer needed)

## Test plan
- [x] Open flight with IGC track in Cesium 3D view
- [x] Verify stats appear in fixed container below map
- [x] Pan, rotate, zoom map - stats remain fixed
- [x] Play animation - stats update correctly
- [x] Stats spacing matches Flight Statistics panel
- [x] Icons and colors match dark theme

🤖 Generated with [Claude Code](https://claude.ai/code)