### PR TITLE
feat: Persist Cesium map user preferences (Issue #22)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,33 +11,11 @@ Free Flight Log is a cross-platform application for logging paraglider, hang gli
 - **Legacy Design Assets**: An old app design from December 2022 created in Appery.io (a visual app builder)
 - **Working Implementation**: Flutter app with database, UI screens, and core functionality
 
-## Project Status
-
-**IMPLEMENTATION COMPLETE** - The MVP has been successfully built and is functional:
-
-✅ **Completed Features:**
-
-- Flight logging with comprehensive form validation
-- SQLite database with full CRUD operations
-- Cross-platform support (Linux, Android, iOS, macOS, Windows)
-- Material Design 3 UI with proper theming
-- Flight list with statistics display
-- Repository pattern architecture implementation
-- Database initialization for all platforms
-- IGC file import with flight track visualization
-- Climb rate calculations (instantaneous and 15-second averaged)
-- Flight detail screens with comprehensive statistics
-- OpenStreetMap integration for cross-platform track display
-- Folder memory for IGC import workflow
-- Timezone support for IGC imports with proper time display
-- Track distance column in flight list for comprehensive flight analysis
-- Midnight crossing flight duration handling
 
 📋 **Planning Documents** (for reference):
 
 - Complete functional requirements (FUNCTIONAL_SPECIFICATION.md)
 - Technical architecture using Flutter/Dart (TECHNICAL_DESIGN.md)
-- Week-by-week MVP implementation plan (MVP_BUILD_PLAN.md)
 
 ## Quick Development Commands
 
@@ -49,16 +27,16 @@ cd ~/Projects/free_flight_log_app
 flutter pub get
 
 # Run on Linux desktop (recommended for development)
-flutter run -d linux --dart-define=flutter.flutter_map.unblockOSM="Our tile servers are not."
+flutter run -d linux"
 
 # Run on Android (device must be connected)
-flutter run -d pixel --dart-define=flutter.flutter_map.unblockOSM="Our tile servers are not."
+flutter run -d pixel"
 
 # Run on emulator:
-flutter run -d emulator-5554 --dart-define=flutter.flutter_map.unblockOSM="Our tile servers are not."
+flutter run -d emulator-5554
 
 # Get pixel screen shot
-adb -s 192.168.86.250:45781 exec-out screencap -p > /mnt/chromeos/MyFiles/Downloads/pixel_screenshot.png
+adb -s 192.168.86.250:45781 exec-out screencap -p > ~Projects/free_flight_log/screenshots/123456.png
 ```
 
 For comprehensive development setup, build commands, testing, and troubleshooting, see [DEVELOPMENT.md](DEVELOPMENT.md).
@@ -78,12 +56,7 @@ For detailed technical architecture, database schema, and implementation details
 
 For complete project history and detailed changelog, see [CHANGELOG.md](CHANGELOG.md).
 
-## Development Reminders
 
-- After running flutter review the output and fix
-- Prefer running app test in flutter on the pixel
-- The Bash tool doesn't support shell redirection operators like 2>&1 or pipes but it does capture stdout and stderr.
-- store documentation in the document directory
 
 ## Calculations
 
@@ -91,4 +64,9 @@ For complete project history and detailed changelog, see [CHANGELOG.md](CHANGELO
 - ALLWAYS use GPS for calculating Speed taking into account the time between readings.
 - If available use pressure for climb rate, otherwise use GPS, taking into account the time between readings.
   
+## Development Reminders
+
+- After running flutter ask the user if they want claude to review the output, look for root causes and fix
+- Prefer running app tests in flutter on the emulator
+- Store documentation in the document directory
 - Do not try to modularise cesium JS as ES6 Modules Don't Work in WebView

--- a/free_flight_log_app/lib/services/preferences_service.dart
+++ b/free_flight_log_app/lib/services/preferences_service.dart
@@ -6,6 +6,7 @@ class PreferencesService {
   static const String _sceneModeKey = 'cesium_scene_mode';
   static const String _terrainEnabledKey = 'cesium_terrain_enabled';
   static const String _baseMapKey = 'cesium_base_map';
+  static const String _navigationHelpDialogKey = 'cesium_navigation_help_dialog';
   
   // Scene mode constants
   static const String sceneMode2D = '2D';
@@ -134,6 +135,38 @@ class PreferencesService {
       return success;
     } catch (e) {
       LoggingService.error('PreferencesService', 'Failed to save base map: $e');
+      return false;
+    }
+  }
+  
+  // ============================================================================
+  // Navigation Help Dialog Preferences
+  // ============================================================================
+  
+  /// Get the navigation help dialog open state preference
+  Future<bool> getNavigationHelpDialogOpen() async {
+    try {
+      final prefs = await _getPrefs();
+      final isOpen = prefs.getBool(_navigationHelpDialogKey) ?? false;
+      LoggingService.debug('PreferencesService: Retrieved navigation help dialog state: $isOpen');
+      return isOpen;
+    } catch (e) {
+      LoggingService.error('PreferencesService', 'Failed to get navigation help dialog state: $e');
+      return false; // Default to closed
+    }
+  }
+  
+  /// Save the navigation help dialog open state preference
+  Future<bool> setNavigationHelpDialogOpen(bool isOpen) async {
+    try {
+      final prefs = await _getPrefs();
+      final success = await prefs.setBool(_navigationHelpDialogKey, isOpen);
+      if (success) {
+        LoggingService.debug('PreferencesService: Saved navigation help dialog state: $isOpen');
+      }
+      return success;
+    } catch (e) {
+      LoggingService.error('PreferencesService', 'Failed to save navigation help dialog state: $e');
       return false;
     }
   }


### PR DESCRIPTION
## Summary
- Implemented comprehensive preference persistence for Cesium 3D map view
- Settings now persist between sessions and across different flight tracks
- Uses native Cesium widgets for seamless integration

## Changes
- **Scene mode persistence**: 2D/3D/Columbus view selection is remembered
- **Base map/imagery layer**: User's preferred map style (Bing Aerial, OpenStreetMap, etc.) is saved
- **Terrain toggle**: Terrain enabled/disabled state persists
- **Navigation help dialog**: Dialog open/closed state is maintained across sessions
- **Info box**: Re-enabled for viewing entity information

## Technical Details
- Uses Cesium's native Knockout.js observables to detect user preference changes
- Preferences stored via Flutter's SharedPreferences service
- Settings automatically restored when map reopens
- No performance impact - changes only save on user interaction

## Fixes #22

## Test Plan
- [x] Open Cesium 3D map and change scene mode to 2D
- [x] Switch base map to OpenStreetMap
- [x] Disable terrain
- [x] Close navigation help dialog
- [x] Navigate away and return - verify settings persist
- [x] Restart app - verify settings still persist
- [x] Open different flight tracks - verify settings remain consistent

🤖 Generated with [Claude Code](https://claude.ai/code)