### PR TITLE
Fix Provider scope issue causing app crash

### DIFF
--- a/free_flight_log_app/lib/main.dart
+++ b/free_flight_log_app/lib/main.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'dart:io' show Platform;
 import 'presentation/screens/splash_screen.dart';
 import 'services/timezone_service.dart';
+import 'core/dependency_injection.dart';
+import 'providers/flight_provider.dart';
+import 'providers/site_provider.dart';
+import 'providers/wing_provider.dart';
 
 void main() {
   // Ensure Flutter is initialized
@@ -26,6 +31,84 @@ class FreeFlightLogApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    return const AppInitializer();
+  }
+}
+
+class AppInitializer extends StatefulWidget {
+  const AppInitializer({super.key});
+
+  @override
+  State<AppInitializer> createState() => _AppInitializerState();
+}
+
+class _AppInitializerState extends State<AppInitializer> {
+  bool _isInitialized = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _initialize();
+  }
+
+  Future<void> _initialize() async {
+    try {
+      // Configure dependencies
+      await configureDependencies();
+      
+      if (mounted) {
+        setState(() {
+          _isInitialized = true;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _error = e.toString();
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // If initialized, wrap entire app with providers
+    if (_isInitialized) {
+      return MultiProvider(
+        providers: [
+          ChangeNotifierProvider(
+            create: (_) => serviceLocator<FlightProvider>(),
+          ),
+          ChangeNotifierProvider(
+            create: (_) => serviceLocator<SiteProvider>(),
+          ),
+          ChangeNotifierProvider(
+            create: (_) => serviceLocator<WingProvider>(),
+          ),
+        ],
+        child: MaterialApp(
+          title: 'Free Flight Log',
+          theme: ThemeData(
+            colorScheme: ColorScheme.fromSeed(
+              seedColor: Colors.blue,
+              brightness: Brightness.light,
+            ),
+            useMaterial3: true,
+          ),
+          darkTheme: ThemeData(
+            colorScheme: ColorScheme.fromSeed(
+              seedColor: Colors.blue,
+              brightness: Brightness.dark,
+            ),
+            useMaterial3: true,
+          ),
+          home: const SplashScreen(),
+        ),
+      );
+    }
+    
+    // Show loading or error within MaterialApp for theming
     return MaterialApp(
       title: 'Free Flight Log',
       theme: ThemeData(
@@ -42,7 +125,34 @@ class FreeFlightLogApp extends StatelessWidget {
         ),
         useMaterial3: true,
       ),
-      home: const SplashScreen(), // Start with splash screen
+      home: Scaffold(
+        body: Center(
+          child: _error != null
+              ? Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(
+                      Icons.error_outline,
+                      size: 64,
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+                    const SizedBox(height: 16),
+                    Text('Failed to initialize: $_error'),
+                    const SizedBox(height: 16),
+                    ElevatedButton(
+                      onPressed: () {
+                        setState(() {
+                          _error = null;
+                        });
+                        _initialize();
+                      },
+                      child: const Text('Retry'),
+                    ),
+                  ],
+                )
+              : const CircularProgressIndicator(),
+        ),
+      ),
     );
   }
 }

--- a/free_flight_log_app/lib/presentation/screens/splash_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/splash_screen.dart
@@ -1,12 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-import '../../providers/flight_provider.dart';
-import '../../providers/site_provider.dart';
-import '../../providers/wing_provider.dart';
-import '../../core/dependency_injection.dart';
 import 'flight_list_screen.dart';
 
-/// Lightweight splash screen that handles async initialization
+/// Lightweight splash screen that shows loading and then navigates
 class SplashScreen extends StatefulWidget {
   const SplashScreen({super.key});
 
@@ -15,98 +10,28 @@ class SplashScreen extends StatefulWidget {
 }
 
 class _SplashScreenState extends State<SplashScreen> {
-  bool _isInitialized = false;
-  String? _error;
-
   @override
   void initState() {
     super.initState();
-    // Start initialization immediately
-    _initialize();
+    // Navigate to main screen after a brief delay
+    _navigateToMain();
   }
 
-  Future<void> _initialize() async {
-    try {
-      // Configure dependencies
-      await configureDependencies();
-      
-      // If successful, navigate to main app
-      if (mounted) {
-        setState(() {
-          _isInitialized = true;
-        });
-      }
-    } catch (e) {
-      if (mounted) {
-        setState(() {
-          _error = e.toString();
-        });
-      }
+  Future<void> _navigateToMain() async {
+    // Short delay to show splash
+    await Future.delayed(const Duration(milliseconds: 500));
+    
+    if (mounted) {
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute(
+          builder: (context) => const FlightListScreen(),
+        ),
+      );
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    // If initialized, show the main app with providers
-    if (_isInitialized) {
-      return MultiProvider(
-        providers: [
-          ChangeNotifierProvider(
-            create: (_) => serviceLocator<FlightProvider>(),
-          ),
-          ChangeNotifierProvider(
-            create: (_) => serviceLocator<SiteProvider>(),
-          ),
-          ChangeNotifierProvider(
-            create: (_) => serviceLocator<WingProvider>(),
-          ),
-        ],
-        child: const FlightListScreen(),
-      );
-    }
-    
-    // If error, show error screen
-    if (_error != null) {
-      return Scaffold(
-        body: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(24.0),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(
-                  Icons.error_outline,
-                  size: 64,
-                  color: Theme.of(context).colorScheme.error,
-                ),
-                const SizedBox(height: 16),
-                Text(
-                  'Failed to initialize app',
-                  style: Theme.of(context).textTheme.headlineSmall,
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  _error!,
-                  style: Theme.of(context).textTheme.bodyMedium,
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 24),
-                ElevatedButton(
-                  onPressed: () {
-                    setState(() {
-                      _error = null;
-                    });
-                    _initialize();
-                  },
-                  child: const Text('Retry'),
-                ),
-              ],
-            ),
-          ),
-        ),
-      );
-    }
-    
     // Show simple loading screen
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.primary,


### PR DESCRIPTION
## Summary
- Fixed critical app crash caused by Provider scope issue during navigation
- Restructured app initialization to ensure providers wrap all routes
- Improved error handling during app startup

## Problem
The app was crashing with a "Could not find the correct Provider<FlightProvider>" error when navigating from the splash screen to the flight list screen. This happened because providers were only wrapping the SplashScreen widget, but navigation creates a new route context outside of that provider scope.

## Solution
Moved the Provider initialization to wrap the entire MaterialApp instead of just the SplashScreen. This ensures all routes in the app have access to the providers.

### Changes Made:
1. Created new `AppInitializer` widget to handle dependency injection
2. Moved MultiProvider to wrap MaterialApp at the app root level
3. Simplified SplashScreen to only handle navigation timing
4. Added proper error handling with retry capability during initialization

## Test Plan
- [x] App starts without Provider errors
- [x] Navigation from splash to flight list works correctly
- [x] All screens can access providers properly
- [x] Error states show retry button if initialization fails

🤖 Generated with [Claude Code](https://claude.ai/code)