### PR TITLE
Fix: Restore separate 5-second and 15-second climb rate calculations

### DIFF
--- a/free_flight_log_app/lib/presentation/widgets/cesium_3d_map_inappwebview.dart
+++ b/free_flight_log_app/lib/presentation/widgets/cesium_3d_map_inappwebview.dart
@@ -1299,7 +1299,7 @@ class _Cesium3DMapInAppWebViewState extends State<Cesium3DMapInAppWebView>
       // Convert track points to JavaScript format
       final jsPoints = widget.trackPoints!.map((point) {
         // Handle Map objects (which is what we're getting from flight_track_widget)
-        double lat, lon, alt, climbRate;
+        double lat, lon, alt, climbRate, climbRate5s, climbRate15s;
         String timezone, timestamp;
         
         if (point is Map) {
@@ -1307,6 +1307,8 @@ class _Cesium3DMapInAppWebViewState extends State<Cesium3DMapInAppWebView>
           lon = (point['longitude'] ?? 0.0).toDouble();
           alt = (point['altitude'] ?? 0.0).toDouble();
           climbRate = (point['climbRate'] ?? 0.0).toDouble();
+          climbRate5s = (point['climbRate5s'] ?? 0.0).toDouble();
+          climbRate15s = (point['climbRate15s'] ?? 0.0).toDouble();
           timezone = point['timezone'] ?? '+00:00';
           timestamp = point['timestamp'] ?? '';
         } else {
@@ -1315,11 +1317,13 @@ class _Cesium3DMapInAppWebViewState extends State<Cesium3DMapInAppWebView>
           lon = (point.longitude ?? 0.0).toDouble();
           alt = (point.altitude ?? 0.0).toDouble();
           climbRate = (point.climbRate ?? 0.0).toDouble();
+          climbRate5s = (point.climbRate5s ?? 0.0).toDouble();
+          climbRate15s = (point.climbRate15s ?? 0.0).toDouble();
           timezone = point.timezone ?? '+00:00';
           timestamp = point.timestamp ?? '';
         }
         
-        return '{latitude:$lat,longitude:$lon,altitude:$alt,climbRate:$climbRate,timestamp:"$timestamp",timezone:"$timezone"}';
+        return '{latitude:$lat,longitude:$lon,altitude:$alt,climbRate:$climbRate,climbRate5s:$climbRate5s,climbRate15s:$climbRate15s,timestamp:"$timestamp",timezone:"$timezone"}';
       }).join(',');
       
       // Log first and last points for debugging

--- a/free_flight_log_app/lib/presentation/widgets/flight_statistics_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/flight_statistics_widget.dart
@@ -101,7 +101,7 @@ class FlightStatisticsWidget extends StatelessWidget {
                 if (flight.maxClimbRate5Sec != null)
                   Expanded(
                     child: _buildStatItem(
-                      'Max Climb (15s)',
+                      'Max Climb (5s)',
                       '${flight.maxClimbRate5Sec!.toStringAsFixed(1)} m/s',
                       Icons.trending_up,
                       context,
@@ -110,7 +110,7 @@ class FlightStatisticsWidget extends StatelessWidget {
                 if (flight.maxSinkRate5Sec != null)
                   Expanded(
                     child: _buildStatItem(
-                      'Max Sink (15s)',
+                      'Max Sink (5s)',
                       '${flight.maxSinkRate5Sec!.toStringAsFixed(1)} m/s',
                       Icons.trending_down,
                       context,

--- a/free_flight_log_app/lib/presentation/widgets/flight_track_3d_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/flight_track_3d_widget.dart
@@ -176,8 +176,10 @@ class _FlightTrack3DWidgetState extends State<FlightTrack3DWidget> {
 
     // Convert IgcPoints to format expected by Cesium widget with timestamps and climb rates
     final trackPointsForCesium = _trackPoints.map((point) {
-      // Use the virtual properties if available, otherwise fall back to calculated values
+      // Use the virtual properties for all three climb rates
       final climbRate = point.climbRate;
+      final climbRate5s = point.climbRate5s;
+      final climbRate15s = point.climbRate15s;
       
       return {
         'latitude': point.latitude,
@@ -187,6 +189,8 @@ class _FlightTrack3DWidgetState extends State<FlightTrack3DWidget> {
         'pressureAltitude': point.pressureAltitude,
         'timestamp': _formatTimestampWithTimezone(point.timestamp, _timezone),
         'climbRate': climbRate,
+        'climbRate5s': climbRate5s,
+        'climbRate15s': climbRate15s,
         'groundSpeed': point.groundSpeed,
         'timezone': _timezone ?? '+00:00',  // Pass timezone to Cesium
       };

--- a/free_flight_log_app/lib/services/igc_import_service.dart
+++ b/free_flight_log_app/lib/services/igc_import_service.dart
@@ -171,6 +171,7 @@ class IgcImportService {
     final groundTrackDistance = igcData.calculateGroundTrackDistance();
     final straightDistance = igcData.calculateLaunchToLandingDistance();
     final climbRates = igcData.calculateClimbRates();
+    final climbRates5Sec = igcData.calculate5SecondMaxClimbRates();
     final climbRates15Sec = igcData.calculate15SecondMaxClimbRates();
     
     // Get or create launch site with paragliding site matching
@@ -267,8 +268,8 @@ class IgcImportService {
       maxAltitude: igcData.maxAltitude,
       maxClimbRate: climbRates['maxClimb'],
       maxSinkRate: climbRates['maxSink'],
-      maxClimbRate5Sec: climbRates15Sec['maxClimb15Sec'],
-      maxSinkRate5Sec: climbRates15Sec['maxSink15Sec'],
+      maxClimbRate5Sec: climbRates5Sec['maxClimb5Sec'],
+      maxSinkRate5Sec: climbRates5Sec['maxSink5Sec'],
       distance: groundTrackDistance,
       straightDistance: straightDistance,
       trackLogPath: trackLogPath,


### PR DESCRIPTION
## Summary
- Restored distinct 5-second and 15-second climb rate calculations that were previously merged together
- Fixed UI labels to correctly show "5s" for 5-second averages instead of incorrectly showing "15s"
- Enhanced IGC point data model with virtual getters for all three climb rate types (instantaneous, 5s, 15s)

## Changes
- Removed `@deprecated` markers from 5-second climb rate methods in `igc_file.dart`
- Implemented proper 5-second average calculation distinct from 15-second calculation
- Added virtual getters `climbRate5s` and `climbRate15s` to `IgcPoint` class for efficient access
- Fixed flight statistics widget labels to correctly display "5s" instead of "15s"
- Updated Cesium 3D visualization to receive all three climb rate values for better flight analysis

## Test Plan
- [ ] Verify IGC file import correctly calculates separate 5s and 15s climb rates
- [ ] Check flight statistics display shows correct "5s" labels
- [ ] Confirm Cesium 3D view receives all three climb rate values
- [ ] Test with sample flights to ensure climb rate calculations are accurate

🤖 Generated with [Claude Code](https://claude.ai/code)