### PR TITLE
Fix IGC file selection UX issues

### DIFF
--- a/free_flight_log_app/lib/presentation/screens/igc_import_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/igc_import_screen.dart
@@ -465,10 +465,8 @@ class _IgcImportScreenState extends State<IgcImportScreen> {
         actions: [
           TextButton(
             onPressed: () {
-              Navigator.of(context).pop();
-              if (summary.successCount > 0) {
-                Navigator.of(context).pop(true); // Return to flight list
-              }
+              Navigator.of(context).pop();  // Close dialog
+              Navigator.of(context).pop(true); // Always return to flight list
             },
             child: const Text('OK'),
           ),


### PR DESCRIPTION
## Summary
Fixes issue #55 - Long delay and no feedback when selecting multiple IGC files
- Prevents double-clicks and provides immediate visual feedback during file selection
- Fixes import screen not closing when all files are skipped

## Changes

### File Selection UX Improvements
- Added `_isSelectingFiles` state to prevent double-clicks during file picker operation
- Show immediate loading spinner and "Selecting Files..." text on button
- Display status message "Loading list of selected files..." below button
- Added 30-second timeout to prevent permanent UI lockup
- Show file count when processing selected files

### Import Flow Fix
- Removed unnecessary condition that prevented screen from closing when all files were skipped
- Import screen now always returns to flight list after showing results

## Test Plan
- [x] Build and run on Android device
- [x] Test selecting multiple IGC files - verify loading feedback appears
- [x] Test double-click prevention - button should be disabled during selection
- [x] Test timeout - long file selections should timeout after 30 seconds
- [ ] Test "Skip All" duplicates - verify screen closes after showing results
- [ ] Test mixed import results - verify screen closes in all cases
- [ ] Test on different devices/screen sizes

## Before/After

**Before:**
- No feedback during file selection, app appears frozen
- Could double-click and cause errors
- Screen stayed open when all files were skipped

**After:**
- Immediate visual feedback with spinner and status text
- Button disabled during selection, preventing errors
- Consistent behavior - always returns to flight list after import

Fixes #55

🤖 Generated with [Claude Code](https://claude.ai/code)