### PR TITLE
feat: add comprehensive preferences screen with proper default initialization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Free Flight Log is a free, android first, cross-platform application for 
+Free Flight Log is a free, android first, cross-platform application for
 logging, reporting, and visualising paraglider, hang glider, and microlight flights.
 This repository contains:
 
@@ -26,10 +26,12 @@ flutter analyze
 
 ## Flutter app testing commands
 
+Test the using `flutter_controller.sh` and monitoring the
+logging captured in the shell output
+Run flutter_controller.sh in the background
+Do not change directory or use full path name
+
 ```bash
-# Run the app on the device for testing/ Logging is captured in the shell output
-# Run in the backgrouind with default device = emulator
-# can run from any directory 
 flutter_controller.sh run [device]
 
 # reload the app after code changes
@@ -44,7 +46,6 @@ flutter_controller.sh q
 # Take screenshot from running app
 flutter screenshot -o screenshots/$(date +%Y%m%d_%H%M%S).png -d [device]
 ```
-
 
 ## Key Files
 
@@ -85,7 +86,7 @@ For detailed technical architecture, database schema, and implementation details
 - Use separation of concerns and DRY
 - Use free maps in development
 - Run the analyzer to check for errors
-- Add Claude readable logging for debugging erros and performance. 
+- Add Claude readable logging for debugging erros and performance.
 - Default to the emulator for testing
 - Test after implementing or updating a feature.
 - Follow the current implementation patterns.

--- a/documentation/internal/preferences.md
+++ b/documentation/internal/preferences.md
@@ -1,0 +1,51 @@
+
+# Cesium 3D Map Preferences
+
+- Scene Mode (cesium_scene_mode): 3D, 2D, or Columbus view - default: '3D'
+- Base Map (cesium_base_map): Selected imagery provider - default: 'Bing Maps Aerial'
+- Terrain Enabled (cesium_terrain_enabled): Whether terrain is shown - default: true
+- Navigation Help Dialog (cesium_navigation_help_dialog_open): Whether help dialog is open - default: false
+- Fly Through Mode (cesium_fly_through_mode): Whether fly-through animation is enabled - default: false
+- Trail Duration (cesium_trail_duration): How many seconds of trail to show - default: 5
+- Quality/Resolution (cesium_quality): Resolution scale (0.75, 1.0, 2.0)
+
+## Cesium Ion Token Preferences
+
+- User Token (cesium_user_token): User's own Cesium Ion token for premium maps
+- Token Validated (cesium_token_validated): Whether the token has been validated
+- Token Validation Date (cesium_token_validation_date): When the token was last validated
+
+  IGC Import Preferences:
+
+- Last Folder (igc_last_folder): Last folder used for IGC imports
+
+## How Preferences Are Used
+
+1. On Widget Initialization: The _loadPreferences() method in cesium_3d_map_inappwebview.dart loads all saved preferences when the widget initializes.
+2. Passed to JavaScript: Preferences are passed to the Cesium JavaScript code through the configuration object when loading the HTML:
+savedSceneMode: "$_savedSceneMode",
+savedBaseMap: "$_savedBaseMap",
+savedTerrainEnabled: $_savedTerrainEnabled,
+// etc...
+1. JavaScript Usage: The cesium.js file uses these preferences during initialization:
+
+- Scene mode determines the initial view
+- Base map selects the imagery provider
+- Terrain preference is checked but currently always loads terrain (line 854-857 in cesium.js)
+- Quality sets the resolution scale
+- Token determines if premium maps are available
+
+2. Runtime Updates: When users change settings in the Cesium view, JavaScript callbacks update the preferences:
+
+- Scene mode changes trigger onSceneModeChanged handler
+- Base map changes trigger onImageryProviderChanged handler
+- Other settings have their respective handlers
+
+## Key Issue with Terrain
+
+The current implementation in main branch:
+
+- Saves the terrain preference (_savedTerrainEnabled)
+- Passes it to JavaScript configuration
+- But always loads terrain regardless of the preference (line 854-857 in cesium.js forces terrain loading)
+- The preference is only used for progressive loading after 5 seconds (lines 913-921)3

--- a/free_flight_log_app/assets/cesium/cesium.js
+++ b/free_flight_log_app/assets/cesium/cesium.js
@@ -850,10 +850,10 @@ class CesiumFlightApp {
         
         // Create viewer with optimized settings
         this.viewer = new Cesium.Viewer("cesiumContainer", {
-            terrain: Cesium.Terrain.fromWorldTerrain({
+            terrain: config.savedTerrainEnabled ? Cesium.Terrain.fromWorldTerrain({
                 requestWaterMask: false,
                 requestVertexNormals: true
-            }),
+            }) : undefined,
             requestRenderMode: true,
             maximumRenderTimeChange: Infinity,
             resolutionScale: this.currentResolution,  // Apply adaptive resolution scaling

--- a/free_flight_log_app/lib/presentation/screens/flight_list_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/flight_list_screen.dart
@@ -13,6 +13,7 @@ import 'statistics_screen.dart';
 import 'database_settings_screen.dart';
 import 'about_screen.dart';
 import 'cesium_settings_demo_screen.dart';
+import 'preferences_screen.dart';
 
 class FlightListScreen extends StatefulWidget {
   const FlightListScreen({super.key});
@@ -415,6 +416,12 @@ class _FlightListScreenState extends State<FlightListScreen> {
                         builder: (context) => const CesiumSettingsDemoScreen(),
                       ),
                     );
+                  } else if (value == 'preferences') {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (context) => const PreferencesScreen(),
+                      ),
+                    );
                   }
                 },
                 itemBuilder: (context) => [
@@ -488,6 +495,16 @@ class _FlightListScreenState extends State<FlightListScreen> {
                         Icon(Icons.map),
                         SizedBox(width: 8),
                         Text('Premium Maps'),
+                      ],
+                    ),
+                  ),
+                  const PopupMenuItem(
+                    value: 'preferences',
+                    child: Row(
+                      children: [
+                        Icon(Icons.settings),
+                        SizedBox(width: 8),
+                        Text('Preferences'),
                       ],
                     ),
                   ),

--- a/free_flight_log_app/lib/presentation/screens/preferences_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/preferences_screen.dart
@@ -1,0 +1,536 @@
+import 'package:flutter/material.dart';
+import '../../utils/preferences_helper.dart';
+import '../../services/logging_service.dart';
+
+class PreferencesScreen extends StatefulWidget {
+  const PreferencesScreen({super.key});
+
+  @override
+  State<PreferencesScreen> createState() => _PreferencesScreenState();
+}
+
+class _PreferencesScreenState extends State<PreferencesScreen> {
+  // 3D Visualization preferences
+  String? _cesiumSceneMode;
+  String? _cesiumBaseMap;
+  bool? _cesiumTerrainEnabled;
+  bool? _cesiumNavigationHelpDialog;
+  bool? _cesiumFlyThroughMode;
+  int? _cesiumTrailDuration;
+  double? _cesiumQuality;
+  
+  
+  // Cesium Ion Token preferences
+  String? _cesiumUserToken;
+  bool? _cesiumTokenValidated;
+  DateTime? _cesiumTokenValidationDate;
+  
+  // Import preferences
+  String? _igcLastFolder;
+  
+  bool _isLoading = true;
+  bool _isSaving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPreferences();
+  }
+
+  Future<void> _loadPreferences() async {
+    try {
+      // Load 3D Visualization preferences
+      final sceneMode = await PreferencesHelper.getCesiumSceneMode();
+      final baseMap = await PreferencesHelper.getCesiumBaseMap();
+      final terrainEnabled = await PreferencesHelper.getCesiumTerrainEnabled();
+      final navHelpDialog = await PreferencesHelper.getCesiumNavigationHelpDialog();
+      final flyThroughMode = await PreferencesHelper.getCesiumFlyThroughMode();
+      final trailDuration = await PreferencesHelper.getCesiumTrailDuration();
+      final quality = await PreferencesHelper.getCesiumQuality();
+      
+      
+      // Load Cesium Ion Token preferences
+      final userToken = await PreferencesHelper.getCesiumUserToken();
+      final tokenValidated = await PreferencesHelper.getCesiumTokenValidated();
+      final tokenValidationDate = await PreferencesHelper.getCesiumTokenValidationDate();
+      
+      // Load Import preferences
+      final lastFolder = await PreferencesHelper.getIgcLastFolder();
+
+      if (mounted) {
+        setState(() {
+          _cesiumSceneMode = sceneMode;
+          _cesiumBaseMap = baseMap;
+          _cesiumTerrainEnabled = terrainEnabled;
+          _cesiumNavigationHelpDialog = navHelpDialog ?? false;
+          _cesiumFlyThroughMode = flyThroughMode ?? false;
+          _cesiumTrailDuration = trailDuration ?? 30; // Default 30 seconds
+          _cesiumQuality = quality ?? 1.0; // Default high quality
+          
+          _cesiumUserToken = userToken;
+          _cesiumTokenValidated = tokenValidated ?? false;
+          _cesiumTokenValidationDate = tokenValidationDate;
+          
+          _igcLastFolder = lastFolder;
+          
+          _isLoading = false;
+        });
+      }
+      
+      LoggingService.info('PreferencesScreen: Loaded preferences successfully');
+    } catch (e) {
+      LoggingService.error('PreferencesScreen: Failed to load preferences: $e');
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Failed to load preferences: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
+  bool _isValidBaseMap(String? value) {
+    const validMaps = ['openstreetmap', 'satellite', 'hybrid'];
+    return value != null && validMaps.contains(value);
+  }
+
+  bool _isValidSceneMode(String? value) {
+    const validModes = ['3D', 'Columbus', '2D'];
+    return value != null && validModes.contains(value);
+  }
+
+  Future<void> _savePreference<T>(
+    String prefName, 
+    T value, 
+    Future<void> Function(T) setter
+  ) async {
+    if (_isSaving) return;
+    
+    setState(() {
+      _isSaving = true;
+    });
+
+    try {
+      await setter(value);
+      LoggingService.info('PreferencesScreen: Saved $prefName = $value');
+      
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Saved $prefName'),
+            duration: const Duration(seconds: 1),
+          ),
+        );
+      }
+    } catch (e) {
+      LoggingService.error('PreferencesScreen: Failed to save $prefName: $e');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Failed to save $prefName: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSaving = false;
+        });
+      }
+    }
+  }
+
+  Widget _buildSection(String title, List<Widget> children, {bool collapsed = false}) {
+    return Card(
+      margin: const EdgeInsets.all(8.0),
+      child: ExpansionTile(
+        title: Text(
+          title,
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        initiallyExpanded: !collapsed,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+            child: Column(children: children),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSwitchRow(
+    String title,
+    String subtitle,
+    bool? value,
+    Function(bool) onChanged,
+  ) {
+    return ListTile(
+      title: Text(title),
+      subtitle: subtitle.isNotEmpty ? Text(subtitle) : null,
+      trailing: Switch(
+        value: value ?? false,
+        onChanged: onChanged,
+      ),
+      contentPadding: EdgeInsets.zero,
+    );
+  }
+
+  Widget _buildDropdownRow<T>(
+    String title,
+    String subtitle,
+    T? value,
+    List<DropdownMenuItem<T>> items,
+    Function(T?) onChanged,
+  ) {
+    return ListTile(
+      title: Text(title),
+      subtitle: subtitle.isNotEmpty ? Text(subtitle) : null,
+      trailing: DropdownButton<T>(
+        value: value,
+        items: items,
+        onChanged: onChanged,
+        hint: const Text('Select...'),
+      ),
+      contentPadding: EdgeInsets.zero,
+    );
+  }
+
+  Widget _buildSliderRow(
+    String title,
+    String subtitle,
+    double? value,
+    double min,
+    double max,
+    int? divisions,
+    String Function(double) labelBuilder,
+    Function(double) onChanged,
+  ) {
+    return ListTile(
+      title: Text(title),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (subtitle.isNotEmpty) Text(subtitle),
+          Slider(
+            value: value ?? min,
+            min: min,
+            max: max,
+            divisions: divisions,
+            label: labelBuilder(value ?? min),
+            onChanged: onChanged,
+          ),
+        ],
+      ),
+      contentPadding: EdgeInsets.zero,
+    );
+  }
+
+  void _showTokenDialog() {
+    final controller = TextEditingController(text: _cesiumUserToken ?? '');
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Cesium Ion Access Token'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text('Enter your Cesium Ion access token for premium imagery and terrain:'),
+              const SizedBox(height: 16),
+              TextField(
+                controller: controller,
+                obscureText: true,
+                decoration: const InputDecoration(
+                  hintText: 'Enter token...',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Cancel'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                final token = controller.text.trim();
+                if (token.isEmpty) {
+                  _removeToken();
+                } else {
+                  setState(() {
+                    _cesiumUserToken = token;
+                  });
+                  _savePreference('Cesium token', token, PreferencesHelper.setCesiumUserToken);
+                }
+                Navigator.of(context).pop();
+              },
+              child: const Text('Save'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _removeToken() {
+    setState(() {
+      _cesiumUserToken = null;
+      _cesiumTokenValidated = false;
+      _cesiumTokenValidationDate = null;
+    });
+    PreferencesHelper.removeCesiumUserToken();
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Cesium Ion token removed'),
+        duration: Duration(seconds: 1),
+      ),
+    );
+  }
+
+  Widget _buildTextFieldRow(
+    String title,
+    String subtitle,
+    String? value,
+    Function(String) onSubmitted, {
+    bool obscureText = false,
+    String? hintText,
+  }) {
+    return ListTile(
+      title: Text(title),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (subtitle.isNotEmpty) Text(subtitle),
+          const SizedBox(height: 8),
+          TextField(
+            controller: TextEditingController(text: value ?? ''),
+            obscureText: obscureText,
+            decoration: InputDecoration(
+              hintText: hintText,
+              border: const OutlineInputBorder(),
+              isDense: true,
+            ),
+            onSubmitted: onSubmitted,
+          ),
+        ],
+      ),
+      contentPadding: EdgeInsets.zero,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isLoading) {
+      return Scaffold(
+        appBar: AppBar(
+          title: const Text('Preferences'),
+          backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        ),
+        body: const Center(
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Preferences'),
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+      ),
+      body: Stack(
+        children: [
+          ListView(
+            children: [
+              // 3D Visualization Settings
+              _buildSection('3D Visualization', [
+                _buildSwitchRow(
+                  'Enable Terrain',
+                  'Show 3D terrain relief on maps',
+                  _cesiumTerrainEnabled,
+                  (value) {
+                    setState(() {
+                      _cesiumTerrainEnabled = value;
+                    });
+                    _savePreference('terrain enabled', value, PreferencesHelper.setCesiumTerrainEnabled);
+                  },
+                ),
+                _buildDropdownRow<String>(
+                  'Scene Mode',
+                  'How the 3D globe is displayed',
+                  _isValidSceneMode(_cesiumSceneMode) ? _cesiumSceneMode : null,
+                  [
+                    const DropdownMenuItem(value: '3D', child: Text('3D Globe')),
+                    const DropdownMenuItem(value: 'Columbus', child: Text('Columbus View')),
+                    const DropdownMenuItem(value: '2D', child: Text('2D Map')),
+                  ],
+                  (value) {
+                    if (value != null) {
+                      setState(() {
+                        _cesiumSceneMode = value;
+                      });
+                      _savePreference('scene mode', value, PreferencesHelper.setCesiumSceneMode);
+                    }
+                  },
+                ),
+                _buildDropdownRow<String>(
+                  'Base Map',
+                  'The background imagery to display',
+                  _isValidBaseMap(_cesiumBaseMap) ? _cesiumBaseMap : null,
+                  [
+                    const DropdownMenuItem(value: 'openstreetmap', child: Text('OpenStreetMap')),
+                    const DropdownMenuItem(value: 'satellite', child: Text('Satellite')),
+                    const DropdownMenuItem(value: 'hybrid', child: Text('Hybrid')),
+                  ],
+                  (value) {
+                    if (value != null) {
+                      setState(() {
+                        _cesiumBaseMap = value;
+                      });
+                      _savePreference('base map', value, PreferencesHelper.setCesiumBaseMap);
+                    }
+                  },
+                ),
+                _buildSwitchRow(
+                  'Navigation Help Dialog',
+                  'Show navigation help when opening 3D view',
+                  _cesiumNavigationHelpDialog,
+                  (value) {
+                    setState(() {
+                      _cesiumNavigationHelpDialog = value;
+                    });
+                    _savePreference('navigation help dialog', value, PreferencesHelper.setCesiumNavigationHelpDialog);
+                  },
+                ),
+                _buildSwitchRow(
+                  'Fly Through Mode',
+                  'Camera follows flight path during playback',
+                  _cesiumFlyThroughMode,
+                  (value) {
+                    setState(() {
+                      _cesiumFlyThroughMode = value;
+                    });
+                    _savePreference('fly through mode', value, PreferencesHelper.setCesiumFlyThroughMode);
+                  },
+                ),
+                _buildSliderRow(
+                  'Trail Duration',
+                  'How long the flight trail remains visible (seconds)',
+                  _cesiumTrailDuration?.toDouble(),
+                  10.0,
+                  300.0,
+                  29,
+                  (value) => '${value.round()}s',
+                  (value) {
+                    setState(() {
+                      _cesiumTrailDuration = value.round();
+                    });
+                    _savePreference('trail duration', value.round(), PreferencesHelper.setCesiumTrailDuration);
+                  },
+                ),
+                _buildDropdownRow<double>(
+                  'Rendering Quality',
+                  'Higher quality uses more resources',
+                  _cesiumQuality,
+                  [
+                    const DropdownMenuItem(value: 0.5, child: Text('Low')),
+                    const DropdownMenuItem(value: 1.0, child: Text('Medium')),
+                    const DropdownMenuItem(value: 1.5, child: Text('High')),
+                    const DropdownMenuItem(value: 2.0, child: Text('Ultra')),
+                  ],
+                  (value) {
+                    if (value != null) {
+                      setState(() {
+                        _cesiumQuality = value;
+                      });
+                      _savePreference('rendering quality', value, PreferencesHelper.setCesiumQuality);
+                    }
+                  },
+                ),
+              ]),
+
+              // Premium Maps Settings
+              _buildSection('Premium Maps', [
+                ListTile(
+                  title: const Text('Token Status'),
+                  subtitle: Text(
+                    _cesiumTokenValidated == true
+                        ? 'Valid premium token configured'
+                        : 'No token or invalid token',
+                  ),
+                  trailing: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        _cesiumTokenValidated == true ? Icons.check_circle : Icons.error,
+                        color: _cesiumTokenValidated == true ? Colors.green : Colors.red,
+                      ),
+                      const SizedBox(width: 8),
+                      ElevatedButton(
+                        onPressed: () => _showTokenDialog(),
+                        child: Text(_cesiumUserToken != null ? 'Update Token' : 'Add Token'),
+                      ),
+                    ],
+                  ),
+                  contentPadding: EdgeInsets.zero,
+                ),
+                if (_cesiumUserToken != null && _cesiumUserToken!.isNotEmpty)
+                  ListTile(
+                    title: const Text('Remove Token'),
+                    subtitle: const Text('Clear stored Cesium Ion token'),
+                    trailing: IconButton(
+                      icon: const Icon(Icons.delete),
+                      onPressed: () => _removeToken(),
+                    ),
+                    contentPadding: EdgeInsets.zero,
+                  ),
+              ], collapsed: true),
+
+              // Import Settings
+              _buildSection('Import Settings', [
+                ListTile(
+                  title: const Text('Last Import Folder'),
+                  subtitle: Text(_igcLastFolder ?? 'Not set'),
+                  trailing: _igcLastFolder != null
+                      ? IconButton(
+                          icon: const Icon(Icons.clear),
+                          onPressed: () {
+                            setState(() {
+                              _igcLastFolder = null;
+                            });
+                            PreferencesHelper.removeIgcLastFolder();
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content: Text('Cleared last import folder'),
+                                duration: Duration(seconds: 1),
+                              ),
+                            );
+                          },
+                        )
+                      : null,
+                  contentPadding: EdgeInsets.zero,
+                ),
+              ], collapsed: true),
+            ],
+          ),
+          if (_isSaving)
+            Container(
+              color: Colors.black26,
+              child: const Center(
+                child: CircularProgressIndicator(),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/free_flight_log_app/lib/presentation/screens/preferences_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/preferences_screen.dart
@@ -62,10 +62,10 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
           _cesiumSceneMode = sceneMode;
           _cesiumBaseMap = baseMap;
           _cesiumTerrainEnabled = terrainEnabled;
-          _cesiumNavigationHelpDialog = navHelpDialog ?? false;
+          _cesiumNavigationHelpDialog = navHelpDialog;
           _cesiumFlyThroughMode = flyThroughMode ?? false;
-          _cesiumTrailDuration = trailDuration ?? 30; // Default 30 seconds
-          _cesiumQuality = quality ?? 1.0; // Default high quality
+          _cesiumTrailDuration = trailDuration;
+          _cesiumQuality = quality;
           
           _cesiumUserToken = userToken;
           _cesiumTokenValidated = tokenValidated ?? false;

--- a/free_flight_log_app/lib/presentation/widgets/cesium_3d_map_inappwebview.dart
+++ b/free_flight_log_app/lib/presentation/widgets/cesium_3d_map_inappwebview.dart
@@ -116,8 +116,8 @@ class _Cesium3DMapInAppWebViewState extends State<Cesium3DMapInAppWebView>
       final terrainEnabled = await PreferencesHelper.getCesiumTerrainEnabled() ?? true;
       final navigationHelpDialogOpen = await PreferencesHelper.getCesiumNavigationHelpDialog() ?? false;
       final flyThroughMode = await PreferencesHelper.getCesiumFlyThroughMode() ?? false;
-      final trailDuration = await PreferencesHelper.getCesiumTrailDuration() ?? 5;
-      final quality = await PreferencesHelper.getCesiumQuality();
+      final trailDuration = await PreferencesHelper.getCesiumTrailDuration() ?? 30;
+      final quality = await PreferencesHelper.getCesiumQuality() ?? 1.0;
       
       // Load user token and validation status
       final userToken = await PreferencesHelper.getCesiumUserToken();

--- a/free_flight_log_app/lib/presentation/widgets/cesium_3d_map_inappwebview.dart
+++ b/free_flight_log_app/lib/presentation/widgets/cesium_3d_map_inappwebview.dart
@@ -909,16 +909,6 @@ class _Cesium3DMapInAppWebViewState extends State<Cesium3DMapInAppWebView>
                     viewer.scene.globe.loadingDescendantLimit = 10;
                     viewer.resolutionScale = 0.85;
                     
-                    // Add terrain if configured and not already added
-                    const terrainEnabled = window.cesiumConfig?.savedTerrainEnabled;
-                    if (terrainEnabled && (!viewer.terrainProvider || viewer.terrainProvider === viewer.scene.globe.ellipsoid)) {
-                        cesiumLog.debug('Adding terrain...');
-                        viewer.terrainProvider = Cesium.createWorldTerrain({
-                            requestWaterMask: false,
-                            requestVertexNormals: false,
-                            requestMetadata: false
-                        });
-                    }
                 }
                 viewer.scene.requestRender();
             };

--- a/free_flight_log_app/lib/utils/preferences_helper.dart
+++ b/free_flight_log_app/lib/utils/preferences_helper.dart
@@ -23,6 +23,12 @@ class PreferencesHelper {
   // Cesium 3D Map methods
   static Future<String?> getCesiumSceneMode() async {
     final prefs = await SharedPreferences.getInstance();
+    // Check if the preference has been set before
+    if (!prefs.containsKey(cesiumSceneModeKey)) {
+      // First time - set default to 3D
+      await prefs.setString(cesiumSceneModeKey, '3D');
+      return '3D';
+    }
     return prefs.getString(cesiumSceneModeKey);
   }
   
@@ -59,6 +65,12 @@ class PreferencesHelper {
   
   static Future<bool?> getCesiumNavigationHelpDialog() async {
     final prefs = await SharedPreferences.getInstance();
+    // Check if the preference has been set before
+    if (!prefs.containsKey(cesiumNavigationHelpDialogKey)) {
+      // First time - set default to false
+      await prefs.setBool(cesiumNavigationHelpDialogKey, false);
+      return false;
+    }
     return prefs.getBool(cesiumNavigationHelpDialogKey);
   }
   
@@ -79,6 +91,12 @@ class PreferencesHelper {
   
   static Future<int?> getCesiumTrailDuration() async {
     final prefs = await SharedPreferences.getInstance();
+    // Check if the preference has been set before
+    if (!prefs.containsKey(cesiumTrailDurationKey)) {
+      // First time - set default to 30 seconds
+      await prefs.setInt(cesiumTrailDurationKey, 30);
+      return 30;
+    }
     return prefs.getInt(cesiumTrailDurationKey);
   }
   
@@ -89,6 +107,12 @@ class PreferencesHelper {
   
   static Future<double?> getCesiumQuality() async {
     final prefs = await SharedPreferences.getInstance();
+    // Check if the preference has been set before
+    if (!prefs.containsKey(cesiumQualityKey)) {
+      // First time - set default to 1.0 (Medium)
+      await prefs.setDouble(cesiumQualityKey, 1.0);
+      return 1.0;
+    }
     return prefs.getDouble(cesiumQualityKey);
   }
 

--- a/free_flight_log_app/lib/utils/preferences_helper.dart
+++ b/free_flight_log_app/lib/utils/preferences_helper.dart
@@ -43,6 +43,12 @@ class PreferencesHelper {
   
   static Future<bool?> getCesiumTerrainEnabled() async {
     final prefs = await SharedPreferences.getInstance();
+    // Check if the preference has been set before
+    if (!prefs.containsKey(cesiumTerrainEnabledKey)) {
+      // First time - set default to true for flight visualization
+      await prefs.setBool(cesiumTerrainEnabledKey, true);
+      return true;
+    }
     return prefs.getBool(cesiumTerrainEnabledKey);
   }
   


### PR DESCRIPTION
## Summary
- Add comprehensive preferences screen accessible from main menu
- Implement proper default value initialization for all preferences on first app install
- Fix terrain loading preference to actually control terrain display in Cesium
- Update trail duration default from 5s to 30s for better user experience

## Changes Made
- **New preferences screen**: Full UI for managing 3D visualization, premium maps, and import settings
- **Default initialization**: Scene mode (3D), terrain (enabled), navigation help (disabled), trail duration (30s), quality (medium)
- **Terrain fix**: Cesium now respects the terrain enabled preference instead of always loading terrain
- **Menu integration**: Added preferences option to main menu for easy access

## Test plan
- [x] Verify preferences screen loads correctly
- [x] Verify default values are set on first app launch
- [x] Test terrain toggle works properly in 3D view
- [x] Verify preferences persist between app sessions
- [x] Test all preference controls (switches, dropdowns, sliders)

🤖 Generated with [Claude Code](https://claude.ai/code)