### PR TITLE
Fix: Refresh site names on home screen after editing

### DIFF
--- a/free_flight_log_app/lib/presentation/screens/flight_list_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/flight_list_screen.dart
@@ -383,11 +383,15 @@ class _FlightListScreenState extends State<FlightListScreen> {
                       ),
                     );
                   } else if (value == 'sites') {
-                    Navigator.of(context).push(
+                    final result = await Navigator.of(context).push<bool>(
                       MaterialPageRoute(
                         builder: (context) => const ManageSitesScreen(),
                       ),
                     );
+                    // Reload flights if sites were modified
+                    if (result == true && mounted) {
+                      await _loadFlights();
+                    }
                   } else if (value == 'statistics') {
                     Navigator.of(context).push(
                       MaterialPageRoute(

--- a/free_flight_log_app/lib/presentation/screens/manage_sites_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/manage_sites_screen.dart
@@ -230,6 +230,8 @@ class _ManageSitesScreenState extends State<ManageSitesScreen> {
       if (mounted) {
         if (success) {
           UiUtils.showSuccessMessage(context, 'Site "${result.name}" updated');
+          // Return true to indicate sites were modified
+          Navigator.of(context).pop(true);
         } else {
           if (errorMessage != null) {
             UiUtils.showErrorDialog(context, 'Error', errorMessage);


### PR DESCRIPTION
## Summary
- Fixed issue where site names weren't updating on the home screen after editing them in manage sites screen
- ManageSitesScreen now returns `true` when a site is successfully edited
- FlightListScreen awaits the result and reloads flights if sites were modified

## Test plan
- [x] Open the app and navigate to the flight list (home screen)
- [x] Go to Menu → Manage Sites
- [x] Edit any site name 
- [x] Return to the home screen
- [x] Verify that the updated site name appears immediately in the flight list

🤖 Generated with [Claude Code](https://claude.ai/code)