### PR TITLE
fix: disable Cesium full screen button

### DIFF
--- a/free_flight_log_app/assets/cesium/cesium.js
+++ b/free_flight_log_app/assets/cesium/cesium.js
@@ -869,7 +869,7 @@ class CesiumFlightApp {
             navigationInstructionsInitiallyVisible: config.savedNavigationHelpDialogOpen || false,
             animation: false,
             timeline: true,
-            fullscreenButton: true,
+            fullscreenButton: false,
             vrButton: false,
             shadows: false,
             shouldAnimate: false,


### PR DESCRIPTION
Remove the full screen icon from the Cesium 3D map viewer by setting fullscreenButton to false in the viewer configuration.

Fixes #94

Generated with [Claude Code](https://claude.ai/code)