### PR TITLE
fix: expand Site map legend toggle hot zone to match Flight Track

### DIFF
--- a/free_flight_log_app/lib/utils/site_marker_utils.dart
+++ b/free_flight_log_app/lib/utils/site_marker_utils.dart
@@ -285,10 +285,11 @@ class SiteMarkerUtils {
         mainAxisSize: MainAxisSize.min,
         children: [
           // Toggle button
-          GestureDetector(
+          InkWell(
             onTap: onToggle,
-            child: Container(
-              padding: const EdgeInsets.all(8),
+            borderRadius: BorderRadius.circular(4),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [


### PR DESCRIPTION
Replace GestureDetector with InkWell for better touch feedback and larger clickable area in Site map legend toggle. This aligns the behavior with Flight Track legend toggle, making it easier for users to expand/collapse the legend.

Changes:
- Replace GestureDetector with InkWell in buildCollapsibleMapLegend()
- Add borderRadius for proper visual feedback
- Adjust padding to match Flight Track implementation
- Improves usability and consistency across map views

Fixes #99

🤖 Generated with [Claude Code](https://claude.ai/code)