### PR TITLE
fix: Remove transparent backgrounds from screen menus

### DIFF
--- a/free_flight_log_app/lib/main.dart
+++ b/free_flight_log_app/lib/main.dart
@@ -56,25 +56,21 @@ class _AppInitializerState extends State<AppInitializer> {
     margin: EdgeInsets.symmetric(horizontal: 16),
     padding: EdgeInsets.symmetric(horizontal: 4, vertical: 2),
     decoration: BoxDecoration(
-      color: Color(0x80000000),
       borderRadius: BorderRadius.all(Radius.circular(4)),
     ),
     textStyle: TextStyle(
       fontSize: 9,
       height: 1.2,
-      color: Colors.white,
       fontWeight: FontWeight.w500,
     ),
   );
 
   static const PopupMenuThemeData _popupMenuTheme = PopupMenuThemeData(
-    color: Color(0x80000000),
     shape: RoundedRectangleBorder(
       borderRadius: BorderRadius.all(Radius.circular(4)),
     ),
     textStyle: TextStyle(
       fontSize: 9,
-      color: Colors.white,
       fontWeight: FontWeight.w500,
     ),
   );


### PR DESCRIPTION
Replace custom transparent styling with standard Material Design 3 theming:
- Remove Color(0x80000000) from PopupMenuThemeData and TooltipThemeData
- Remove hardcoded white text colors
- Let Material 3 handle proper surface colors and contrast

Fixes #98

Generated with [Claude Code](https://claude.ai/code)