### PR TITLE
Set default base map to satellite

### DIFF
--- a/free_flight_log_app/lib/utils/preferences_helper.dart
+++ b/free_flight_log_app/lib/utils/preferences_helper.dart
@@ -39,6 +39,12 @@ class PreferencesHelper {
   
   static Future<String?> getCesiumBaseMap() async {
     final prefs = await SharedPreferences.getInstance();
+    // Check if the preference has been set before
+    if (!prefs.containsKey(cesiumBaseMapKey)) {
+      // First time - set default to satellite
+      await prefs.setString(cesiumBaseMapKey, 'satellite');
+      return 'satellite';
+    }
     return prefs.getString(cesiumBaseMapKey);
   }
   


### PR DESCRIPTION
When the app first loads, the base map will now default to satellite view instead of requiring user to manually select it in preferences.

Updated PreferencesHelper.getCesiumBaseMap() to set 'satellite' as the default value when no preference has been set previously, following the same pattern used by other preference methods.

Fixes #96

Generated with [Claude Code](https://claude.ai/code)