### PR TITLE
Reset tooltips to default Material Design and fix site marker layout

### DIFF
--- a/free_flight_log_app/lib/main.dart
+++ b/free_flight_log_app/lib/main.dart
@@ -47,23 +47,6 @@ class _AppInitializerState extends State<AppInitializer> {
   List<String>? _sharedFiles;
 
   // Shared theme configurations to avoid duplication
-  static const TooltipThemeData _tooltipTheme = TooltipThemeData(
-    triggerMode: TooltipTriggerMode.longPress,
-    showDuration: Duration(seconds: 2),
-    waitDuration: Duration(seconds: 1),
-    preferBelow: false,
-    verticalOffset: 20,
-    margin: EdgeInsets.symmetric(horizontal: 16),
-    padding: EdgeInsets.symmetric(horizontal: 4, vertical: 2),
-    decoration: BoxDecoration(
-      borderRadius: BorderRadius.all(Radius.circular(4)),
-    ),
-    textStyle: TextStyle(
-      fontSize: 9,
-      height: 1.2,
-      fontWeight: FontWeight.w500,
-    ),
-  );
 
   static const PopupMenuThemeData _popupMenuTheme = PopupMenuThemeData(
     shape: RoundedRectangleBorder(
@@ -138,7 +121,6 @@ class _AppInitializerState extends State<AppInitializer> {
             brightness: Brightness.light,
           ),
           useMaterial3: true,
-          tooltipTheme: _tooltipTheme,
           popupMenuTheme: _popupMenuTheme,
         ),
         darkTheme: ThemeData(
@@ -147,7 +129,6 @@ class _AppInitializerState extends State<AppInitializer> {
             brightness: Brightness.dark,
           ),
           useMaterial3: true,
-          tooltipTheme: _tooltipTheme,
           popupMenuTheme: _popupMenuTheme,
         ),
           home: _sharedFiles != null && _sharedFiles!.isNotEmpty
@@ -165,7 +146,6 @@ class _AppInitializerState extends State<AppInitializer> {
           brightness: Brightness.light,
         ),
         useMaterial3: true,
-        tooltipTheme: _tooltipTheme,
         popupMenuTheme: _popupMenuTheme,
       ),
       darkTheme: ThemeData(
@@ -174,7 +154,6 @@ class _AppInitializerState extends State<AppInitializer> {
           brightness: Brightness.dark,
         ),
         useMaterial3: true,
-        tooltipTheme: _tooltipTheme,
         popupMenuTheme: _popupMenuTheme,
       ),
       home: Scaffold(

--- a/free_flight_log_app/lib/presentation/widgets/flight_statistics_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/flight_statistics_widget.dart
@@ -389,26 +389,7 @@ class _FlightStatisticsWidgetState extends State<FlightStatisticsWidget> {
 
     if (tooltip != null) {
       return Tooltip(
-        richMessage: WidgetSpan(
-          child: Container(
-            constraints: const BoxConstraints(maxWidth: 200),
-            child: Text(
-              tooltip,
-              style: const TextStyle(fontSize: 11, height: 1.2, color: Colors.white),
-            ),
-          ),
-        ),
-        triggerMode: TooltipTriggerMode.longPress,
-        showDuration: const Duration(seconds: 2),
-        waitDuration: const Duration(seconds: 1),
-        preferBelow: false,
-        verticalOffset: 20,
-        margin: const EdgeInsets.symmetric(horizontal: 16),
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-        decoration: BoxDecoration(
-          color: Colors.grey[800],
-          borderRadius: BorderRadius.circular(4),
-        ),
+        message: tooltip,
         child: statWidget,
       );
     }

--- a/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
@@ -677,22 +677,19 @@ class _FlightTrack2DWidgetState extends State<FlightTrack2DWidget> {
         point: LatLng(firstPoint.latitude, firstPoint.longitude),
         size: const Size(32, 32),
         disableDrag: true, // Disable drag functionality
-        builder: (ctx, point, isDragging) => AppTooltip(
-          message: _launchSite?.name ?? 'Launch Site',
-          child: Stack(
-            alignment: Alignment.center,
-            children: [
-              SiteMarkerUtils.buildLaunchMarkerIcon(
-                color: SiteMarkerUtils.launchColor,
-                size: SiteMarkerUtils.launchMarkerSize,
-              ),
-              const Icon(
-                Icons.flight_takeoff,
-                color: Colors.white,
-                size: 14,
-              ),
-            ],
-          ),
+        builder: (ctx, point, isDragging) => Stack(
+          alignment: Alignment.center,
+          children: [
+            SiteMarkerUtils.buildLaunchMarkerIcon(
+              color: SiteMarkerUtils.launchColor,
+              size: SiteMarkerUtils.launchMarkerSize,
+            ),
+            const Icon(
+              Icons.flight_takeoff,
+              color: Colors.white,
+              size: 14,
+            ),
+          ],
         ),
       ),
       // Landing marker
@@ -735,16 +732,14 @@ class _FlightTrack2DWidgetState extends State<FlightTrack2DWidget> {
       markers.add(
         DragMarker(
           point: LatLng(site.latitude, site.longitude),
-          size: const Size(SiteMarkerUtils.siteMarkerSize + 40, SiteMarkerUtils.siteMarkerSize + 20), // Container size for label
+          size: const Size(140, 80), // Fixed size to match Site Map
+          offset: const Offset(0, -SiteMarkerUtils.siteMarkerSize / 2), // Center the marker
           disableDrag: true, // Disable drag functionality
           builder: (ctx, point, isDragging) => Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              AppTooltip(
-                message: tooltip,
-                child: SiteMarkerUtils.buildSiteMarkerIcon(
-                  color: SiteMarkerUtils.flownSiteColor,
-                ),
+              SiteMarkerUtils.buildSiteMarkerIcon(
+                color: SiteMarkerUtils.flownSiteColor,
               ),
               SiteMarkerUtils.buildSiteLabel(
                 siteName: site.name,
@@ -762,16 +757,14 @@ class _FlightTrack2DWidgetState extends State<FlightTrack2DWidget> {
         markers.add(
           DragMarker(
             point: LatLng(site.latitude, site.longitude),
-            size: const Size(SiteMarkerUtils.siteMarkerSize + 40, SiteMarkerUtils.siteMarkerSize + 20), // Container size for label
+            size: const Size(140, 80), // Fixed size to match Site Map
+            offset: const Offset(0, -SiteMarkerUtils.siteMarkerSize / 2), // Center the marker
             disableDrag: true, // Disable drag functionality
             builder: (ctx, point, isDragging) => Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                AppTooltip(
-                  message: site.name,
-                  child: SiteMarkerUtils.buildSiteMarkerIcon(
-                    color: SiteMarkerUtils.newSiteColor,
-                  ),
+                SiteMarkerUtils.buildSiteMarkerIcon(
+                  color: SiteMarkerUtils.newSiteColor,
                 ),
                 SiteMarkerUtils.buildSiteLabel(
                   siteName: site.name,

--- a/free_flight_log_app/lib/utils/ui_utils.dart
+++ b/free_flight_log_app/lib/utils/ui_utils.dart
@@ -229,21 +229,9 @@ class AppTooltip extends StatelessWidget {
         child: child,
       );
     } else if (richMessage != null) {
-      // Rich tooltip with custom constraints
+      // Rich tooltip using default theme
       return Tooltip(
-        richMessage: WidgetSpan(
-          child: Container(
-            constraints: const BoxConstraints(maxWidth: 200),
-            child: DefaultTextStyle(
-              style: const TextStyle(
-                fontSize: 11,
-                height: 1.2,
-                color: Colors.white,
-              ),
-              child: richMessage!,
-            ),
-          ),
-        ),
+        richMessage: WidgetSpan(child: richMessage!),
         child: child,
       );
     }


### PR DESCRIPTION
## Summary
- Reset all tooltips to use Flutter's default Material Design dark theme
- Remove site marker tooltips from Flight Track 2D and Site Map
- Fix site marker bottom overflow issue with consistent sizing

## Changes Made
- **Remove custom tooltip configuration**: Deleted `TooltipThemeData` from `main.dart`
- **Simplify statistics tooltips**: Use default Material theme instead of custom styling
- **Remove site marker tooltips**: Cleaned up Flight Track 2D site markers
- **Remove launch marker tooltip**: Simplified launch marker display
- **Fix overflow issue**: Updated site marker sizing to match Site Map (140x80 with proper centering)
- **Consistent styling**: All tooltips now use Flutter's default dark theme appearance

## Test plan
- [x] Verify tooltips appear with default Material Design styling
- [x] Confirm site markers no longer show tooltips on long press
- [x] Check that site marker overflow issue is resolved
- [x] Test that statistics tooltips still work with improved styling
- [x] Verify launch marker no longer shows tooltip

🤖 Generated with [Claude Code](https://claude.ai/code)