### PR TITLE
fix: center app logo in Android splash screen

### DIFF
--- a/free_flight_log_app/android/app/src/main/res/drawable-v21/launch_background.xml
+++ b/free_flight_log_app/android/app/src/main/res/drawable-v21/launch_background.xml
@@ -3,10 +3,10 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="?android:colorBackground" />
 
-    <!-- You can insert your own image assets here -->
-    <!-- <item>
+    <!-- Centered app icon for splash screen -->
+    <item>
         <bitmap
             android:gravity="center"
-            android:src="@mipmap/launch_image" />
-    </item> -->
+            android:src="@mipmap/ic_launcher" />
+    </item>
 </layer-list>

--- a/free_flight_log_app/android/app/src/main/res/drawable/launch_background.xml
+++ b/free_flight_log_app/android/app/src/main/res/drawable/launch_background.xml
@@ -3,10 +3,10 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@android:color/white" />
 
-    <!-- You can insert your own image assets here -->
-    <!-- <item>
+    <!-- Centered app icon for splash screen -->
+    <item>
         <bitmap
             android:gravity="center"
-            android:src="@mipmap/launch_image" />
-    </item> -->
+            android:src="@mipmap/ic_launcher" />
+    </item>
 </layer-list>


### PR DESCRIPTION
Fixes #108

## Changes
- Enable and center app icon in native Android splash screen
- Update both launch_background.xml files to show ic_launcher
- Logo now displays centered instead of missing/misaligned

The splash screen will now properly display the centered app logo while the Flutter app is loading.

----
🤖 Generated with [Claude Code](https://claude.ai/code)