### PR TITLE
Replace trail duration slider with dropdown

### DIFF
--- a/free_flight_log_app/assets/cesium/cesium.js
+++ b/free_flight_log_app/assets/cesium/cesium.js
@@ -486,12 +486,11 @@ class FlightDataSource extends Cesium.CustomDataSource {
         });
         
         this._ribbonEnabled = false;
+        // Trail duration in seconds - defaults to 3 minutes if not configured
         this._ribbonSeconds = (window.cesiumConfig?.savedTrailDuration || 180);
-        
     }
     
     enableRibbonMode(enabled) {
-        
         this._ribbonEnabled = enabled;
         this.staticCurtainEntity.show = !enabled;
         this.dynamicCurtainEntity.show = enabled;
@@ -504,7 +503,6 @@ class FlightDataSource extends Cesium.CustomDataSource {
         const windowSize = this._calculateRibbonWindow();
         const startIdx = Math.max(0, index - windowSize + 1);
         const positions = this.positions.slice(startIdx, index + 1);
-        
         
         return positions;
     }
@@ -522,11 +520,11 @@ class FlightDataSource extends Cesium.CustomDataSource {
         const viewer = cesiumApp?.viewer;
         if (!viewer) return 100;
         
-        const speedMultiplier = viewer.clock.multiplier || 1;
-        const flightSeconds = this._ribbonSeconds; // Trail duration in flight time, not affected by playback speed
+        // Trail duration in flight time, not affected by playback speed
+        // Note: speedMultiplier was removed as trail duration should be constant regardless of playback speed
+        const flightSeconds = this._ribbonSeconds;
         const pointsPerSecond = this.igcPoints.length / this.totalDuration;
         const windowSize = Math.ceil(flightSeconds * pointsPerSecond);
-        
         
         return windowSize;
     }

--- a/free_flight_log_app/assets/cesium/cesium.js
+++ b/free_flight_log_app/assets/cesium/cesium.js
@@ -486,10 +486,12 @@ class FlightDataSource extends Cesium.CustomDataSource {
         });
         
         this._ribbonEnabled = false;
-        this._ribbonSeconds = 3.0;
+        this._ribbonSeconds = (window.cesiumConfig?.savedTrailDuration || 180);
+        
     }
     
     enableRibbonMode(enabled) {
+        
         this._ribbonEnabled = enabled;
         this.staticCurtainEntity.show = !enabled;
         this.dynamicCurtainEntity.show = enabled;
@@ -501,7 +503,10 @@ class FlightDataSource extends Cesium.CustomDataSource {
         
         const windowSize = this._calculateRibbonWindow();
         const startIdx = Math.max(0, index - windowSize + 1);
-        return this.positions.slice(startIdx, index + 1);
+        const positions = this.positions.slice(startIdx, index + 1);
+        
+        
+        return positions;
     }
     
     _getTrailAltitudes(currentTime) {
@@ -518,9 +523,12 @@ class FlightDataSource extends Cesium.CustomDataSource {
         if (!viewer) return 100;
         
         const speedMultiplier = viewer.clock.multiplier || 1;
-        const flightSeconds = this._ribbonSeconds * speedMultiplier;
+        const flightSeconds = this._ribbonSeconds; // Trail duration in flight time, not affected by playback speed
         const pointsPerSecond = this.igcPoints.length / this.totalDuration;
-        return Math.ceil(flightSeconds * pointsPerSecond);
+        const windowSize = Math.ceil(flightSeconds * pointsPerSecond);
+        
+        
+        return windowSize;
     }
     
     _findTimeIndex(time) {

--- a/free_flight_log_app/lib/presentation/screens/preferences_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/preferences_screen.dart
@@ -77,8 +77,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
   }
 
   bool _isValidTrailDuration(int? value) {
-    const validDurations = [60, 120, 180, 240, 300];
-    return value != null && validDurations.contains(value);
+    return value != null && PreferencesHelper.validCesiumTrailDurations.contains(value);
   }
 
   Future<void> _savePreference<T>(

--- a/free_flight_log_app/lib/presentation/screens/preferences_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/preferences_screen.dart
@@ -280,19 +280,24 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
                     }
                   },
                 ),
-                _buildSliderRow(
+                _buildDropdownRow<int>(
                   'Trail Duration',
-                  'How long the flight trail remains visible (seconds)',
-                  _cesiumTrailDuration?.toDouble(),
-                  10.0,
-                  300.0,
-                  29,
-                  (value) => '${value.round()}s',
+                  'How long the flight trail remains visible',
+                  _cesiumTrailDuration,
+                  [
+                    const DropdownMenuItem(value: 60, child: Text('1 minute')),
+                    const DropdownMenuItem(value: 120, child: Text('2 minutes')),
+                    const DropdownMenuItem(value: 180, child: Text('3 minutes')),
+                    const DropdownMenuItem(value: 240, child: Text('4 minutes')),
+                    const DropdownMenuItem(value: 300, child: Text('5 minutes')),
+                  ],
                   (value) {
-                    setState(() {
-                      _cesiumTrailDuration = value.round();
-                    });
-                    _savePreference('trail duration', value.round(), PreferencesHelper.setCesiumTrailDuration);
+                    if (value != null) {
+                      setState(() {
+                        _cesiumTrailDuration = value;
+                      });
+                      _savePreference('trail duration', value, PreferencesHelper.setCesiumTrailDuration);
+                    }
                   },
                 ),
                 _buildDropdownRow<double>(

--- a/free_flight_log_app/lib/presentation/screens/preferences_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/preferences_screen.dart
@@ -76,6 +76,11 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
     return value != null && validModes.contains(value);
   }
 
+  bool _isValidTrailDuration(int? value) {
+    const validDurations = [60, 120, 180, 240, 300];
+    return value != null && validDurations.contains(value);
+  }
+
   Future<void> _savePreference<T>(
     String prefName, 
     T value, 
@@ -283,7 +288,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
                 _buildDropdownRow<int>(
                   'Trail Duration',
                   'How long the flight trail remains visible',
-                  _cesiumTrailDuration,
+                  _isValidTrailDuration(_cesiumTrailDuration) ? _cesiumTrailDuration : null,
                   [
                     const DropdownMenuItem(value: 60, child: Text('1 minute')),
                     const DropdownMenuItem(value: 120, child: Text('2 minutes')),

--- a/free_flight_log_app/lib/presentation/widgets/cesium_3d_map_inappwebview.dart
+++ b/free_flight_log_app/lib/presentation/widgets/cesium_3d_map_inappwebview.dart
@@ -66,7 +66,7 @@ class _Cesium3DMapInAppWebViewState extends State<Cesium3DMapInAppWebView>
   bool _savedTerrainEnabled = true;
   bool _savedNavigationHelpDialogOpen = false;
   bool _savedFlyThroughMode = false;
-  int _savedTrailDuration = 5;
+  int _savedTrailDuration = PreferencesHelper.defaultCesiumTrailDuration;
   double? _savedQuality;
   
   // User token for premium maps
@@ -116,7 +116,7 @@ class _Cesium3DMapInAppWebViewState extends State<Cesium3DMapInAppWebView>
       final terrainEnabled = await PreferencesHelper.getCesiumTerrainEnabled() ?? true;
       final navigationHelpDialogOpen = await PreferencesHelper.getCesiumNavigationHelpDialog() ?? false;
       final flyThroughMode = await PreferencesHelper.getCesiumFlyThroughMode() ?? false;
-      final trailDuration = await PreferencesHelper.getCesiumTrailDuration() ?? 30;
+      final trailDuration = await PreferencesHelper.getCesiumTrailDuration() ?? PreferencesHelper.defaultCesiumTrailDuration;
       final quality = await PreferencesHelper.getCesiumQuality() ?? 1.0;
       
       // Load user token and validation status

--- a/free_flight_log_app/lib/utils/preferences_helper.dart
+++ b/free_flight_log_app/lib/utils/preferences_helper.dart
@@ -12,6 +12,9 @@ class PreferencesHelper {
   static const String cesiumTrailDurationKey = 'cesium_trail_duration';
   static const String cesiumQualityKey = 'cesium_quality';
   
+  // Default values
+  static const int defaultCesiumTrailDuration = 60; // 1 minute in seconds
+  
   // Cesium Ion Token preferences (for premium maps)
   static const String cesiumUserTokenKey = 'cesium_user_token';
   static const String cesiumTokenValidatedKey = 'cesium_token_validated';
@@ -99,9 +102,9 @@ class PreferencesHelper {
     final prefs = await SharedPreferences.getInstance();
     // Check if the preference has been set before
     if (!prefs.containsKey(cesiumTrailDurationKey)) {
-      // First time - set default to 30 seconds
-      await prefs.setInt(cesiumTrailDurationKey, 30);
-      return 30;
+      // First time - set default to 1 minute
+      await prefs.setInt(cesiumTrailDurationKey, defaultCesiumTrailDuration);
+      return defaultCesiumTrailDuration;
     }
     return prefs.getInt(cesiumTrailDurationKey);
   }

--- a/free_flight_log_app/lib/utils/preferences_helper.dart
+++ b/free_flight_log_app/lib/utils/preferences_helper.dart
@@ -13,7 +13,7 @@ class PreferencesHelper {
   static const String cesiumQualityKey = 'cesium_quality';
   
   // Default values
-  static const int defaultCesiumTrailDuration = 60; // 1 minute in seconds
+  static const int defaultCesiumTrailDuration = 180; // 3 minutes in seconds
   
   // Cesium Ion Token preferences (for premium maps)
   static const String cesiumUserTokenKey = 'cesium_user_token';
@@ -102,7 +102,7 @@ class PreferencesHelper {
     final prefs = await SharedPreferences.getInstance();
     // Check if the preference has been set before
     if (!prefs.containsKey(cesiumTrailDurationKey)) {
-      // First time - set default to 1 minute
+      // First time - set default to 3 minutes
       await prefs.setInt(cesiumTrailDurationKey, defaultCesiumTrailDuration);
       return defaultCesiumTrailDuration;
     }

--- a/free_flight_log_app/lib/utils/preferences_helper.dart
+++ b/free_flight_log_app/lib/utils/preferences_helper.dart
@@ -14,6 +14,7 @@ class PreferencesHelper {
   
   // Default values
   static const int defaultCesiumTrailDuration = 180; // 3 minutes in seconds
+  static const List<int> validCesiumTrailDurations = [60, 120, 180, 240, 300]; // 1-5 minutes in seconds
   
   // Cesium Ion Token preferences (for premium maps)
   static const String cesiumUserTokenKey = 'cesium_user_token';


### PR DESCRIPTION
Replaces the trail duration slider with a dropdown containing 1-5 minute preset options.

## Changes
- Replaced slider with dropdown in preferences screen
- Added 5 preset options: 1, 2, 3, 4, and 5 minutes
- Fixes popup message issue when adjusting trail duration
- Follows existing dropdown patterns in preferences screen

Resolves #112

Generated with [Claude Code](https://claude.ai/code)