### PR TITLE
Fix: Store FAI triangle points to optimize map rendering

### DIFF
--- a/free_flight_log_app/lib/data/datasources/database_helper.dart
+++ b/free_flight_log_app/lib/data/datasources/database_helper.dart
@@ -52,6 +52,7 @@ class DatabaseHelper {
         distance REAL,
         straight_distance REAL,
         fai_triangle_distance REAL,
+        fai_triangle_points TEXT,
         wing_id INTEGER,
         notes TEXT,
         track_log_path TEXT,

--- a/free_flight_log_app/lib/data/models/flight.dart
+++ b/free_flight_log_app/lib/data/models/flight.dart
@@ -1,6 +1,9 @@
 import 'dart:convert';
+import '../../services/logging_service.dart';
 
 class Flight {
+  // Constants
+  static const int expectedTrianglePoints = 3;
   final int? id;
   final DateTime date;
   final String launchTime;
@@ -288,15 +291,106 @@ class Flight {
     
     try {
       final List<dynamic> decoded = jsonDecode(faiTrianglePoints!);
-      return decoded.cast<Map<String, dynamic>>().map((point) {
+      
+      // Validate JSON structure
+      if (!_isValidTrianglePointsStructure(decoded)) {
+        LoggingService.warning('Flight.getParsedTrianglePoints: Invalid triangle points structure for flight $id');
+        return null;
+      }
+      
+      final points = decoded.cast<Map<String, dynamic>>().map((point) {
         return {
           'lat': (point['lat'] as num).toDouble(),
           'lng': (point['lng'] as num).toDouble(),
           'alt': (point['alt'] as num).toDouble(),
         };
       }).toList();
+      
+      // Validate that we have exactly 3 distinct points
+      if (!_isValidTriangle(points)) {
+        LoggingService.warning('Flight.getParsedTrianglePoints: Invalid triangle geometry for flight $id');
+        return null;
+      }
+      
+      return points;
     } catch (e) {
-      return null; // Return null if JSON parsing fails
+      LoggingService.warning('Flight.getParsedTrianglePoints: Failed to parse triangle points JSON for flight $id', e);
+      return null;
+    }
+  }
+
+  /// Validates that the decoded JSON structure is correct for triangle points
+  bool _isValidTrianglePointsStructure(List<dynamic> points) {
+    if (points.length != expectedTrianglePoints) {
+      return false;
+    }
+    
+    for (final point in points) {
+      if (point is! Map<String, dynamic>) {
+        return false;
+      }
+      
+      // Check required fields exist and are numeric
+      if (!point.containsKey('lat') || !point.containsKey('lng') || !point.containsKey('alt')) {
+        return false;
+      }
+      
+      if (point['lat'] is! num || point['lng'] is! num || point['alt'] is! num) {
+        return false;
+      }
+      
+      // Basic coordinate validation
+      final lat = point['lat'] as num;
+      final lng = point['lng'] as num;
+      if (lat < -90 || lat > 90 || lng < -180 || lng > 180) {
+        return false;
+      }
+    }
+    
+    return true;
+  }
+
+  /// Validates that the three points form a valid triangle (distinct points)
+  bool _isValidTriangle(List<Map<String, double>> points) {
+    if (points.length != expectedTrianglePoints) {
+      return false;
+    }
+    
+    // Check that all points are distinct (no two points are the same)
+    for (int i = 0; i < points.length; i++) {
+      for (int j = i + 1; j < points.length; j++) {
+        final p1 = points[i];
+        final p2 = points[j];
+        
+        // Consider points the same if they're within ~1 meter (very small lat/lng difference)
+        const double tolerance = 0.00001; // approximately 1 meter
+        if ((p1['lat']! - p2['lat']!).abs() < tolerance && 
+            (p1['lng']! - p2['lng']!).abs() < tolerance) {
+          return false;
+        }
+      }
+    }
+    
+    return true;
+  }
+
+  /// Helper method to encode triangle points to JSON
+  static String? encodeTrianglePointsToJson(List<dynamic> trianglePoints) {
+    if (trianglePoints.length != expectedTrianglePoints) {
+      return null;
+    }
+    
+    try {
+      return jsonEncode(
+        trianglePoints.map((point) => {
+          'lat': point.latitude,
+          'lng': point.longitude,
+          'alt': point.gpsAltitude,
+        }).toList()
+      );
+    } catch (e) {
+      LoggingService.error('Flight.encodeTrianglePointsToJson: Failed to encode triangle points', e);
+      return null;
     }
   }
 }

--- a/free_flight_log_app/lib/data/models/flight.dart
+++ b/free_flight_log_app/lib/data/models/flight.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 class Flight {
   final int? id;
   final DateTime date;
@@ -21,6 +23,7 @@ class Flight {
   final double? distance;
   final double? straightDistance;
   final double? faiTriangleDistance;
+  final String? faiTrianglePoints; // JSON string storing triangle points
   final int? wingId;
   final String? notes;
   final String? trackLogPath;
@@ -67,6 +70,7 @@ class Flight {
     this.distance,
     this.straightDistance,
     this.faiTriangleDistance,
+    this.faiTrianglePoints,
     this.wingId,
     this.notes,
     this.trackLogPath,
@@ -113,6 +117,7 @@ class Flight {
       'distance': distance,
       'straight_distance': straightDistance,
       'fai_triangle_distance': faiTriangleDistance,
+      'fai_triangle_points': faiTrianglePoints,
       'wing_id': wingId,
       'notes': notes,
       'track_log_path': trackLogPath,
@@ -160,6 +165,7 @@ class Flight {
       distance: map['distance']?.toDouble(),
       straightDistance: map['straight_distance']?.toDouble(),
       faiTriangleDistance: map['fai_triangle_distance']?.toDouble(),
+      faiTrianglePoints: map['fai_triangle_points'],
       wingId: map['wing_id'],
       notes: map['notes'],
       trackLogPath: map['track_log_path'],
@@ -206,6 +212,7 @@ class Flight {
     double? distance,
     double? straightDistance,
     double? faiTriangleDistance,
+    String? faiTrianglePoints,
     int? wingId,
     String? notes,
     String? trackLogPath,
@@ -249,6 +256,7 @@ class Flight {
       distance: distance ?? this.distance,
       straightDistance: straightDistance ?? this.straightDistance,
       faiTriangleDistance: faiTriangleDistance ?? this.faiTriangleDistance,
+      faiTrianglePoints: faiTrianglePoints ?? this.faiTrianglePoints,
       wingId: wingId ?? this.wingId,
       notes: notes ?? this.notes,
       trackLogPath: trackLogPath ?? this.trackLogPath,
@@ -269,5 +277,26 @@ class Flight {
       gpsFixQuality: gpsFixQuality ?? this.gpsFixQuality,
       recordingInterval: recordingInterval ?? this.recordingInterval,
     );
+  }
+  
+  /// Parse the JSON-stored FAI triangle points into a list of coordinate maps
+  /// Returns null if no triangle points are stored or if parsing fails
+  List<Map<String, double>>? getParsedTrianglePoints() {
+    if (faiTrianglePoints == null || faiTrianglePoints!.isEmpty) {
+      return null;
+    }
+    
+    try {
+      final List<dynamic> decoded = jsonDecode(faiTrianglePoints!);
+      return decoded.cast<Map<String, dynamic>>().map((point) {
+        return {
+          'lat': (point['lat'] as num).toDouble(),
+          'lng': (point['lng'] as num).toDouble(),
+          'alt': (point['alt'] as num).toDouble(),
+        };
+      }).toList();
+    } catch (e) {
+      return null; // Return null if JSON parsing fails
+    }
   }
 }

--- a/free_flight_log_app/lib/data/models/igc_file.dart
+++ b/free_flight_log_app/lib/data/models/igc_file.dart
@@ -578,7 +578,7 @@ class IgcFile {
     };
   }
 
-  /// Calculate FAI triangle using maximum area approach
+  /// Calculate triangle using maximum area approach
   /// Returns a map with triangle points and total distance
   Map<String, dynamic> calculateFaiTriangle() {
     if (trackPoints.length < 3) {
@@ -617,7 +617,7 @@ class IgcFile {
       };
     }
 
-    // Calculate triangle perimeter (FAI distance)
+    // Calculate triangle perimeter
     final distance1 = _haversineDistance(bestTriangle[0], bestTriangle[1]);
     final distance2 = _haversineDistance(bestTriangle[1], bestTriangle[2]);
     final distance3 = _haversineDistance(bestTriangle[2], bestTriangle[0]);

--- a/free_flight_log_app/lib/presentation/widgets/flight_statistics_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/flight_statistics_widget.dart
@@ -62,13 +62,13 @@ class _FlightStatisticsWidgetState extends State<FlightStatisticsWidget> {
               ),
               Expanded(
                 child: _buildStatItem(
-                  'FAI Triangle',
+                  'Triangle',
                   widget.flight.faiTriangleDistance != null 
                       ? '${widget.flight.faiTriangleDistance!.toStringAsFixed(1)} km'
                       : 'N/A',
                   Icons.change_history,
                   context,
-                  tooltip: 'FAI triangle distance using maximum area approximation',
+                  tooltip: 'A quick approximation and does not check for triangle closing or minimum side lengths',
                 ),
               ),
               Expanded(

--- a/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
@@ -596,7 +596,7 @@ class _FlightTrack2DWidgetState extends State<FlightTrack2DWidget> {
   }
 
   List<Polyline> _buildFaiTriangleLines() {
-    if (_faiTrianglePoints.length != 3) return [];
+    if (_faiTrianglePoints.length != Flight.expectedTrianglePoints) return [];
     
     // Convert IgcPoint to LatLng
     final p1 = LatLng(_faiTrianglePoints[0].latitude, _faiTrianglePoints[0].longitude);

--- a/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
@@ -321,19 +321,37 @@ class _FlightTrack2DWidgetState extends State<FlightTrack2DWidget> {
         return;
       }
 
-      // Calculate FAI triangle using the IGC parser
+      // Get FAI triangle points (optimized to use stored data first)
       List<IgcPoint> faiTrianglePoints = [];
-      try {
-        final igcParser = IgcParser();
-        final igcFile = await igcParser.parseFile(widget.flight.trackLogPath!);
-        final faiTriangle = igcFile.calculateFaiTriangle();
-        final trianglePoints = faiTriangle['trianglePoints'] as List<dynamic>?;
-        
-        if (trianglePoints != null && trianglePoints.length == 3) {
-          faiTrianglePoints = trianglePoints.cast<IgcPoint>();
+      
+      // Try to use pre-calculated triangle points from database (fast!)
+      final storedTrianglePoints = widget.flight.getParsedTrianglePoints();
+      if (storedTrianglePoints != null && storedTrianglePoints.length == 3) {
+        LoggingService.ui('FlightTrack2D', 'Using stored FAI triangle points (fast)');
+        // Convert stored coordinate maps to IgcPoint objects
+        faiTrianglePoints = storedTrianglePoints.map((point) => IgcPoint(
+          latitude: point['lat']!,
+          longitude: point['lng']!,
+          gpsAltitude: point['alt']!.toInt(),
+          pressureAltitude: 0,
+          timestamp: DateTime.now(), // Timestamp not needed for triangle display
+          isValid: true, // Stored points are assumed valid
+        )).toList();
+      } else {
+        // Fallback to calculation if no stored points (should be rare after reimport)
+        LoggingService.ui('FlightTrack2D', 'No stored triangle points, calculating from IGC (slow)');
+        try {
+          final igcParser = IgcParser();
+          final igcFile = await igcParser.parseFile(widget.flight.trackLogPath!);
+          final faiTriangle = igcFile.calculateFaiTriangle();
+          final trianglePoints = faiTriangle['trianglePoints'] as List<dynamic>?;
+          
+          if (trianglePoints != null && trianglePoints.length == 3) {
+            faiTrianglePoints = trianglePoints.cast<IgcPoint>();
+          }
+        } catch (e) {
+          LoggingService.ui('FlightTrack2D', 'Failed to calculate FAI triangle: $e');
         }
-      } catch (e) {
-        LoggingService.ui('FlightTrack2D', 'Failed to calculate FAI triangle: $e');
       }
 
       setState(() {

--- a/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
@@ -321,13 +321,13 @@ class _FlightTrack2DWidgetState extends State<FlightTrack2DWidget> {
         return;
       }
 
-      // Get FAI triangle points (optimized to use stored data first)
+      // Get triangle points (optimized to use stored data first)
       List<IgcPoint> faiTrianglePoints = [];
       
       // Try to use pre-calculated triangle points from database (fast!)
       final storedTrianglePoints = widget.flight.getParsedTrianglePoints();
       if (storedTrianglePoints != null && storedTrianglePoints.length == 3) {
-        LoggingService.ui('FlightTrack2D', 'Using stored FAI triangle points (fast)');
+        LoggingService.ui('FlightTrack2D', 'Using stored triangle points (fast)');
         // Convert stored coordinate maps to IgcPoint objects
         faiTrianglePoints = storedTrianglePoints.map((point) => IgcPoint(
           latitude: point['lat']!,
@@ -350,7 +350,7 @@ class _FlightTrack2DWidgetState extends State<FlightTrack2DWidget> {
             faiTrianglePoints = trianglePoints.cast<IgcPoint>();
           }
         } catch (e) {
-          LoggingService.ui('FlightTrack2D', 'Failed to calculate FAI triangle: $e');
+          LoggingService.ui('FlightTrack2D', 'Failed to calculate triangle: $e');
         }
       }
 
@@ -360,7 +360,7 @@ class _FlightTrack2DWidgetState extends State<FlightTrack2DWidget> {
         _isLoading = false;
       });
       
-      LoggingService.info('FlightTrack2DWidget: Loaded ${_trackPoints.length} track points, FAI triangle: ${_faiTrianglePoints.length} points');
+      LoggingService.info('FlightTrack2DWidget: Loaded ${_trackPoints.length} track points, triangle: ${_faiTrianglePoints.length} points');
     } catch (e) {
       LoggingService.error('FlightTrack2DWidget: Error loading track data', e);
       setState(() {

--- a/free_flight_log_app/lib/services/igc_import_service.dart
+++ b/free_flight_log_app/lib/services/igc_import_service.dart
@@ -198,15 +198,7 @@ class IgcImportService {
     String? faiTrianglePointsJson;
     if (faiTriangle['trianglePoints'] != null) {
       final trianglePoints = faiTriangle['trianglePoints'] as List<dynamic>;
-      if (trianglePoints.length == 3) {
-        faiTrianglePointsJson = jsonEncode(
-          trianglePoints.map((point) => {
-            'lat': point.latitude,
-            'lng': point.longitude,
-            'alt': point.gpsAltitude,
-          }).toList()
-        );
-      }
+      faiTrianglePointsJson = Flight.encodeTrianglePointsToJson(trianglePoints);
     }
     
     // Get or create launch site with paragliding site matching
@@ -481,15 +473,7 @@ class IgcImportService {
     String? faiTrianglePointsJson;
     if (faiTriangle['trianglePoints'] != null) {
       final trianglePoints = faiTriangle['trianglePoints'] as List<dynamic>;
-      if (trianglePoints.length == 3) {
-        faiTrianglePointsJson = jsonEncode(
-          trianglePoints.map((point) => {
-            'lat': point.latitude,
-            'lng': point.longitude,
-            'alt': point.gpsAltitude,
-          }).toList()
-        );
-      }
+      faiTrianglePointsJson = Flight.encodeTrianglePointsToJson(trianglePoints);
     }
     
     // Get or create launch site with paragliding site matching

--- a/free_flight_log_app/lib/services/igc_import_service.dart
+++ b/free_flight_log_app/lib/services/igc_import_service.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
@@ -193,6 +194,21 @@ class IgcImportService {
     final gpsStats = igcData.calculateGpsQuality();
     final faiTriangle = igcData.calculateFaiTriangle();
     
+    // Convert triangle points to JSON for storage
+    String? faiTrianglePointsJson;
+    if (faiTriangle['trianglePoints'] != null) {
+      final trianglePoints = faiTriangle['trianglePoints'] as List<dynamic>;
+      if (trianglePoints.length == 3) {
+        faiTrianglePointsJson = jsonEncode(
+          trianglePoints.map((point) => {
+            'lat': point.latitude,
+            'lng': point.longitude,
+            'alt': point.gpsAltitude,
+          }).toList()
+        );
+      }
+    }
+    
     // Get or create launch site with paragliding site matching
     Site? launchSite;
     if (igcData.launchSite != null) {
@@ -306,6 +322,7 @@ class IgcImportService {
       distance: groundTrackDistance,
       straightDistance: straightDistance,
       faiTriangleDistance: faiTriangle['triangleDistance'],
+      faiTrianglePoints: faiTrianglePointsJson,
       trackLogPath: trackLogPath,
       originalFilename: originalFilename,
       source: 'igc',
@@ -460,6 +477,21 @@ class IgcImportService {
     final gpsStats = igcData.calculateGpsQuality();
     final faiTriangle = igcData.calculateFaiTriangle();
     
+    // Convert triangle points to JSON for storage
+    String? faiTrianglePointsJson;
+    if (faiTriangle['trianglePoints'] != null) {
+      final trianglePoints = faiTriangle['trianglePoints'] as List<dynamic>;
+      if (trianglePoints.length == 3) {
+        faiTrianglePointsJson = jsonEncode(
+          trianglePoints.map((point) => {
+            'lat': point.latitude,
+            'lng': point.longitude,
+            'alt': point.gpsAltitude,
+          }).toList()
+        );
+      }
+    }
+    
     // Get or create launch site with paragliding site matching
     Site? launchSite;
     if (igcData.launchSite != null) {
@@ -551,6 +583,7 @@ class IgcImportService {
       distance: groundTrackDistance,
       straightDistance: straightDistance,
       faiTriangleDistance: faiTriangle['triangleDistance'],
+      faiTrianglePoints: faiTrianglePointsJson,
       notes: _buildNotesFromIgcData(igcData, originalFilename),
       trackLogPath: trackLogPath,
       originalFilename: originalFilename,


### PR DESCRIPTION
## Summary
- Optimizes FAI triangle display by caching pre-calculated triangle points in the database
- Eliminates expensive recalculation every time the map is displayed
- Significantly improves map rendering performance

## Changes
- Added `fai_triangle_points` column to store triangle coordinates as JSON
- Modified IGC import to save triangle points during initial calculation
- Updated map widget to use stored points first, with fallback to calculation
- Added helper method to parse stored triangle points from JSON

## Performance Impact
- **Before**: Triangle recalculated from IGC file every map display (slow)
- **After**: Triangle points loaded from database (fast)
- Fallback ensures backward compatibility for existing flights

## Test Plan
- [x] Delete existing database and reimport IGC files
- [x] Verify FAI triangles display correctly on map
- [x] Confirm statistics show triangle distance
- [x] Check performance improvement in map loading

🤖 Generated with [Claude Code](https://claude.ai/code)