### PR TITLE
feat: Add takeoff/landing detection with configurable thresholds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,3 +195,4 @@ Replace any `print()` statements with the appropriate LoggingService method base
 - **GPS/Sensors**: Primary data source. All calculations derive from GPS timestamps and coordinates
 - **File Storage**: IGC files are immutable once imported. Parse once, store results
 - don't cd when using flutter controller
+- when doing a hot reload, check if the bash process is still running. If not start again

--- a/free_flight_log_app/lib/data/models/flight.dart
+++ b/free_flight_log_app/lib/data/models/flight.dart
@@ -106,6 +106,35 @@ class Flight {
     this.detectedLandingTime,
   });
 
+  /// Get the effective launch time - uses detected takeoff time if available, otherwise original launch time
+  String get effectiveLaunchTime {
+    if (detectedTakeoffTime != null) {
+      // Format detected time as HH:mm
+      return '${detectedTakeoffTime!.hour.toString().padLeft(2, '0')}:${detectedTakeoffTime!.minute.toString().padLeft(2, '0')}';
+    }
+    return launchTime;
+  }
+
+  /// Get the effective landing time - uses detected landing time if available, otherwise original landing time  
+  String get effectiveLandingTime {
+    if (detectedLandingTime != null) {
+      // Format detected time as HH:mm
+      return '${detectedLandingTime!.hour.toString().padLeft(2, '0')}:${detectedLandingTime!.minute.toString().padLeft(2, '0')}';
+    }
+    return landingTime;
+  }
+
+  /// Get the effective duration - uses detected times if available, otherwise original duration
+  int get effectiveDuration {
+    if (detectedTakeoffTime != null && detectedLandingTime != null) {
+      return detectedLandingTime!.difference(detectedTakeoffTime!).inMinutes;
+    }
+    return duration;
+  }
+
+  /// Whether this flight has detected takeoff/landing data
+  bool get hasDetectionData => takeoffIndex != null && landingIndex != null;
+
   Map<String, dynamic> toMap() {
     return {
       'id': id,
@@ -428,24 +457,6 @@ class Flight {
     return launchTime;
   }
   
-  /// Get effective landing time (detected time if available, otherwise landing time)  
-  String get effectiveLandingTime {
-    if (detectedLandingTime != null) {
-      return '${detectedLandingTime!.hour.toString().padLeft(2, '0')}:${detectedLandingTime!.minute.toString().padLeft(2, '0')}';
-    }
-    return landingTime;
-  }
-  
-  /// Get effective flight duration in minutes (detected duration if available, otherwise stored duration)
-  int get effectiveDuration {
-    if (detectedTakeoffTime != null && detectedLandingTime != null) {
-      return detectedLandingTime!.difference(detectedTakeoffTime!).inMinutes;
-    }
-    return duration;
-  }
-  
-  /// Check if this flight has takeoff/landing detection data
-  bool get hasDetectionData => takeoffIndex != null && landingIndex != null;
   
   /// Get trimmed track points based on detected takeoff/landing indices
   /// Returns null if no detection data available - caller should use full track points

--- a/free_flight_log_app/lib/data/models/igc_file.dart
+++ b/free_flight_log_app/lib/data/models/igc_file.dart
@@ -20,6 +20,24 @@ class IgcFile {
     this.timezone,
   });
 
+  /// Create a copy of this IgcFile with trimmed track points
+  /// Uses sublist for efficient memory usage (no data duplication)
+  IgcFile copyWithTrimmedPoints(int startIndex, int endIndex) {
+    if (startIndex < 0 || endIndex >= trackPoints.length || startIndex > endIndex) {
+      throw ArgumentError('Invalid indices: startIndex=$startIndex, endIndex=$endIndex, length=${trackPoints.length}');
+    }
+    
+    return IgcFile(
+      date: date,
+      pilot: pilot,
+      gliderType: gliderType,
+      gliderID: gliderID,
+      trackPoints: trackPoints.sublist(startIndex, endIndex + 1),
+      headers: headers,
+      timezone: timezone,
+    );
+  }
+
   /// Get launch time from first track point
   DateTime get launchTime => trackPoints.isNotEmpty 
       ? trackPoints.first.timestamp 

--- a/free_flight_log_app/lib/presentation/screens/flight_detail_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/flight_detail_screen.dart
@@ -1008,7 +1008,7 @@ class _FlightDetailScreenState extends State<FlightDetailScreen> with WidgetsBin
                               ),
                             ),
                             child: Text(
-                              _formatTimeWithTimezone(_flight.launchTime, _flight.timezone),
+                              _formatTimeWithTimezone(_flight.effectiveLaunchTime, _flight.timezone),
                               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                                 color: Theme.of(context).colorScheme.primary,
                               ),
@@ -1030,7 +1030,7 @@ class _FlightDetailScreenState extends State<FlightDetailScreen> with WidgetsBin
                               ),
                             ),
                             child: Text(
-                              _formatTimeWithTimezone(_flight.launchTime, _flight.timezone),
+                              _formatTimeWithTimezone(_flight.effectiveLaunchTime, _flight.timezone),
                               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                                 color: Theme.of(context).colorScheme.primary,
                               ),
@@ -1120,7 +1120,7 @@ class _FlightDetailScreenState extends State<FlightDetailScreen> with WidgetsBin
                               ),
                             ),
                             child: Text(
-                              _formatTimeWithTimezone(_flight.landingTime, _flight.timezone),
+                              _formatTimeWithTimezone(_flight.effectiveLandingTime, _flight.timezone),
                               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                                 color: Theme.of(context).colorScheme.primary,
                               ),
@@ -1142,7 +1142,7 @@ class _FlightDetailScreenState extends State<FlightDetailScreen> with WidgetsBin
                               ),
                             ),
                             child: Text(
-                              _formatTimeWithTimezone(_flight.landingTime, _flight.timezone),
+                              _formatTimeWithTimezone(_flight.effectiveLandingTime, _flight.timezone),
                               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                                 color: Theme.of(context).colorScheme.primary,
                               ),

--- a/free_flight_log_app/lib/presentation/screens/flight_list_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/flight_list_screen.dart
@@ -118,13 +118,13 @@ class _FlightListScreenState extends State<FlightListScreen> {
         _sortedFlights.sort((a, b) {
           final aDateTime = DateTime(
             a.date.year, a.date.month, a.date.day,
-            int.parse(a.launchTime.split(':')[0]),
-            int.parse(a.launchTime.split(':')[1]),
+            int.parse(a.effectiveLaunchTime.split(':')[0]),
+            int.parse(a.effectiveLaunchTime.split(':')[1]),
           );
           final bDateTime = DateTime(
             b.date.year, b.date.month, b.date.day,
-            int.parse(b.launchTime.split(':')[0]),
-            int.parse(b.launchTime.split(':')[1]),
+            int.parse(b.effectiveLaunchTime.split(':')[0]),
+            int.parse(b.effectiveLaunchTime.split(':')[1]),
           );
           return _sortAscending 
               ? aDateTime.compareTo(bDateTime)
@@ -134,8 +134,8 @@ class _FlightListScreenState extends State<FlightListScreen> {
       case 'duration':
         _sortedFlights.sort((a, b) {
           return _sortAscending 
-              ? a.duration.compareTo(b.duration)
-              : b.duration.compareTo(a.duration);
+              ? a.effectiveDuration.compareTo(b.effectiveDuration)
+              : b.effectiveDuration.compareTo(a.effectiveDuration);
         });
         break;
       case 'track_distance':
@@ -691,7 +691,7 @@ class _FlightListScreenState extends State<FlightListScreen> {
       // In selection mode, count only selected flights
       final selectedFlights = flights.where((flight) => _selectedFlightIds.contains(flight.id)).toList();
       totalFlights = selectedFlights.length;
-      totalTime = selectedFlights.fold(0, (sum, flight) => sum + flight.duration);
+      totalTime = selectedFlights.fold(0, (sum, flight) => sum + flight.effectiveDuration);
     } else {
       // Normal mode: use totals from the database
       totalFlights = _totalFlights;
@@ -809,7 +809,7 @@ class _FlightListScreenState extends State<FlightListScreen> {
                   Text(
                     '${flight.date.day.toString().padLeft(2, '0')}/'
                     '${flight.date.month.toString().padLeft(2, '0')}/'
-                    '${flight.date.year} ${flight.launchTime}',
+                    '${flight.date.year} ${flight.effectiveLaunchTime}',
                   ),
                   onTap: _isSelectionMode 
                       ? null 
@@ -825,7 +825,7 @@ class _FlightListScreenState extends State<FlightListScreen> {
                         },
                 ),
                 DataCell(
-                  Text(DateTimeUtils.formatDuration(flight.duration)),
+                  Text(DateTimeUtils.formatDuration(flight.effectiveDuration)),
                   onTap: _isSelectionMode 
                       ? null 
                       : () async {

--- a/free_flight_log_app/lib/presentation/screens/preferences_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/preferences_screen.dart
@@ -20,6 +20,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
   // Takeoff/Landing Detection preferences
   double? _detectionSpeedThreshold;
   double? _detectionClimbRateThreshold;
+  bool? _chartTrimmingEnabled;
   
   bool _isLoading = true;
   bool _isSaving = false;
@@ -42,6 +43,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
       // Load Detection preferences
       final speedThreshold = await PreferencesHelper.getDetectionSpeedThreshold();
       final climbRateThreshold = await PreferencesHelper.getDetectionClimbRateThreshold();
+      final chartTrimmingEnabled = await PreferencesHelper.getChartTrimmingEnabled();
       
       if (mounted) {
         setState(() {
@@ -53,6 +55,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
           
           _detectionSpeedThreshold = speedThreshold;
           _detectionClimbRateThreshold = climbRateThreshold;
+          _chartTrimmingEnabled = chartTrimmingEnabled;
           
           _isLoading = false;
         });
@@ -372,6 +375,17 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
                       });
                       _savePreference('climb rate threshold', value, PreferencesHelper.setDetectionClimbRateThreshold);
                     }
+                  },
+                ),
+                _buildSwitchRow(
+                  'Apply Trimming to Charts',
+                  'Show only detected flight period in charts (launch to landing)',
+                  _chartTrimmingEnabled,
+                  (value) {
+                    setState(() {
+                      _chartTrimmingEnabled = value;
+                    });
+                    _savePreference('chart trimming', value, PreferencesHelper.setChartTrimmingEnabled);
                   },
                 ),
               ]),

--- a/free_flight_log_app/lib/presentation/screens/preferences_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/preferences_screen.dart
@@ -17,7 +17,9 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
   int? _cesiumTrailDuration;
   double? _cesiumQuality;
   
-  
+  // Takeoff/Landing Detection preferences
+  double? _detectionSpeedThreshold;
+  double? _detectionClimbRateThreshold;
   
   bool _isLoading = true;
   bool _isSaving = false;
@@ -37,6 +39,10 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
       final trailDuration = await PreferencesHelper.getCesiumTrailDuration();
       final quality = await PreferencesHelper.getCesiumQuality();
       
+      // Load Detection preferences
+      final speedThreshold = await PreferencesHelper.getDetectionSpeedThreshold();
+      final climbRateThreshold = await PreferencesHelper.getDetectionClimbRateThreshold();
+      
       if (mounted) {
         setState(() {
           _cesiumSceneMode = sceneMode;
@@ -44,6 +50,9 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
           _cesiumTerrainEnabled = terrainEnabled;
           _cesiumTrailDuration = trailDuration;
           _cesiumQuality = quality;
+          
+          _detectionSpeedThreshold = speedThreshold;
+          _detectionClimbRateThreshold = climbRateThreshold;
           
           _isLoading = false;
         });
@@ -324,7 +333,48 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
                   },
                 ),
               ]),
-
+              
+              // Flight Detection Settings
+              _buildSection('Flight Detection', [
+                _buildDropdownRow<double>(
+                  'Speed Threshold',
+                  'Minimum 5-second ground speed for takeoff/landing detection',
+                  _detectionSpeedThreshold,
+                  PreferencesHelper.validSpeedThresholds.map((speed) => 
+                    DropdownMenuItem(
+                      value: speed,
+                      child: Text('${speed.toStringAsFixed(0)} km/h'),
+                    )
+                  ).toList(),
+                  (value) {
+                    if (value != null) {
+                      setState(() {
+                        _detectionSpeedThreshold = value;
+                      });
+                      _savePreference('speed threshold', value, PreferencesHelper.setDetectionSpeedThreshold);
+                    }
+                  },
+                ),
+                _buildDropdownRow<double>(
+                  'Climb Rate Threshold',
+                  'Minimum absolute 5-second climb rate for takeoff/landing detection',
+                  _detectionClimbRateThreshold,
+                  PreferencesHelper.validClimbRateThresholds.map((rate) => 
+                    DropdownMenuItem(
+                      value: rate,
+                      child: Text('${rate.toStringAsFixed(1)} m/s'),
+                    )
+                  ).toList(),
+                  (value) {
+                    if (value != null) {
+                      setState(() {
+                        _detectionClimbRateThreshold = value;
+                      });
+                      _savePreference('climb rate threshold', value, PreferencesHelper.setDetectionClimbRateThreshold);
+                    }
+                  },
+                ),
+              ]),
 
             ],
           ),

--- a/free_flight_log_app/lib/presentation/widgets/duplicate_flight_dialog.dart
+++ b/free_flight_log_app/lib/presentation/widgets/duplicate_flight_dialog.dart
@@ -80,8 +80,8 @@ class DuplicateFlightDialog extends StatelessWidget {
                   ),
                   const SizedBox(height: 8),
                   _buildFlightDetailRow('Date:', _formatDate(existingFlight.date)),
-                  _buildFlightDetailRow('Launch Time:', existingFlight.launchTime),
-                  _buildFlightDetailRow('Duration:', '${existingFlight.duration} minutes'),
+                  _buildFlightDetailRow('Launch Time:', existingFlight.effectiveLaunchTime),
+                  _buildFlightDetailRow('Duration:', '${existingFlight.effectiveDuration} minutes'),
                   if (existingFlight.maxAltitude != null)
                     _buildFlightDetailRow('Max Altitude:', '${existingFlight.maxAltitude!.round()}m'),
                   _buildFlightDetailRow('Source:', existingFlight.source),

--- a/free_flight_log_app/lib/presentation/widgets/flight_statistics_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/flight_statistics_widget.dart
@@ -18,7 +18,7 @@ class _FlightStatisticsWidgetState extends State<FlightStatisticsWidget> {
 
   @override
   Widget build(BuildContext context) {
-    final duration = DateTimeUtils.formatDurationCompact(widget.flight.duration);
+    final duration = DateTimeUtils.formatDurationCompact(widget.flight.effectiveDuration);
 
     return Container(
       padding: const EdgeInsets.all(16),

--- a/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
@@ -311,7 +311,11 @@ class _FlightTrack2DWidgetState extends State<FlightTrack2DWidget> {
     }
 
     try {
-      final trackData = await _igcService.getTrackPointsWithTimezone(widget.flight.trackLogPath!);
+      final trackData = await _igcService.getTrackPointsWithTimezone(
+        widget.flight.trackLogPath!,
+        takeoffIndex: widget.flight.takeoffIndex,
+        landingIndex: widget.flight.landingIndex,
+      );
       
       if (trackData.points.isEmpty) {
         setState(() {

--- a/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
@@ -549,6 +549,13 @@ class _FlightTrack2DWidgetState extends State<FlightTrack2DWidget> {
     return math.sqrt(deltaLat * deltaLat + deltaLng * deltaLng);
   }
 
+  /// Format timestamp as HH:MM:SS for the time overlay
+  String _formatTimeHMS(DateTime timestamp) {
+    return '${timestamp.hour.toString().padLeft(2, '0')}:'
+           '${timestamp.minute.toString().padLeft(2, '0')}:'
+           '${timestamp.second.toString().padLeft(2, '0')}';
+  }
+
   Color _getClimbRateColor(double climbRate) {
     if (climbRate >= 0) return Colors.green;
     if (climbRate > -1.5) return Colors.blue;
@@ -1426,6 +1433,34 @@ class _FlightTrack2DWidgetState extends State<FlightTrack2DWidget> {
                 ),
               ),
             ),
+          // Time display overlay for selected point
+          if (_selectedTrackPointIndex != null && _selectedTrackPointIndex! < _trackPoints.length)
+            Positioned(
+              bottom: 8,
+              left: 8,
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  color: Colors.black.withValues(alpha: 0.8),
+                  borderRadius: BorderRadius.circular(4),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.3),
+                      blurRadius: 4,
+                      offset: const Offset(0, 2),
+                    ),
+                  ],
+                ),
+                child: Text(
+                  'Time: ${_formatTimeHMS(_trackPoints[_selectedTrackPointIndex!].timestamp)}',
+                  style: const TextStyle(
+                    fontSize: 12,
+                    color: Colors.white,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+            ),
             ],
           ),
         ),
@@ -1464,7 +1499,7 @@ class _FlightTrack2DWidgetState extends State<FlightTrack2DWidget> {
             showTimeLabels: false,
             showGridLabels: true,
           ),
-          tooltip: 'GPS ground speed in meters',
+          tooltip: '5-second average GPS ground speed in km/h',
         ),
       ],
     );

--- a/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
@@ -18,6 +18,7 @@ import '../../services/paragliding_earth_api.dart';
 import '../../services/logging_service.dart';
 import '../../utils/site_marker_utils.dart';
 import '../../utils/ui_utils.dart';
+import '../../utils/preferences_helper.dart';
 import '../screens/flight_track_3d_fullscreen.dart';
 
 enum MapProvider {
@@ -311,10 +312,13 @@ class _FlightTrack2DWidgetState extends State<FlightTrack2DWidget> {
     }
 
     try {
+      // Check if chart trimming is enabled in preferences
+      final chartTrimmingEnabled = await PreferencesHelper.getChartTrimmingEnabled();
+      
       final trackData = await _igcService.getTrackPointsWithTimezone(
         widget.flight.trackLogPath!,
-        takeoffIndex: widget.flight.takeoffIndex,
-        landingIndex: widget.flight.landingIndex,
+        takeoffIndex: chartTrimmingEnabled ? widget.flight.takeoffIndex : null,
+        landingIndex: chartTrimmingEnabled ? widget.flight.landingIndex : null,
       );
       
       if (trackData.points.isEmpty) {

--- a/free_flight_log_app/lib/presentation/widgets/flight_track_3d_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/flight_track_3d_widget.dart
@@ -4,6 +4,7 @@ import '../../data/models/flight.dart';
 import '../../data/models/igc_file.dart';
 import '../../services/igc_import_service.dart';
 import '../../services/logging_service.dart';
+import '../../utils/preferences_helper.dart';
 import 'cesium_3d_map_inappwebview.dart';
 
 /// Configuration for the 3D flight track visualization
@@ -79,10 +80,13 @@ class _FlightTrack3DWidgetState extends State<FlightTrack3DWidget> {
     }
 
     try {
+      // Check if chart trimming is enabled in preferences
+      final chartTrimmingEnabled = await PreferencesHelper.getChartTrimmingEnabled();
+      
       final trackData = await _igcService.getTrackPointsWithTimezone(
         widget.flight.trackLogPath!,
-        takeoffIndex: widget.flight.takeoffIndex,
-        landingIndex: widget.flight.landingIndex,
+        takeoffIndex: chartTrimmingEnabled ? widget.flight.takeoffIndex : null,
+        landingIndex: chartTrimmingEnabled ? widget.flight.landingIndex : null,
       );
       
       if (trackData.points.isEmpty) {

--- a/free_flight_log_app/lib/presentation/widgets/flight_track_3d_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/flight_track_3d_widget.dart
@@ -79,7 +79,11 @@ class _FlightTrack3DWidgetState extends State<FlightTrack3DWidget> {
     }
 
     try {
-      final trackData = await _igcService.getTrackPointsWithTimezone(widget.flight.trackLogPath!);
+      final trackData = await _igcService.getTrackPointsWithTimezone(
+        widget.flight.trackLogPath!,
+        takeoffIndex: widget.flight.takeoffIndex,
+        landingIndex: widget.flight.landingIndex,
+      );
       
       if (trackData.points.isEmpty) {
         setState(() {

--- a/free_flight_log_app/lib/services/takeoff_landing_detector.dart
+++ b/free_flight_log_app/lib/services/takeoff_landing_detector.dart
@@ -1,0 +1,163 @@
+import '../data/models/igc_file.dart';
+import 'logging_service.dart';
+
+/// Service for detecting takeoff and landing points in flight tracks
+/// Based on configurable ground speed and climb rate thresholds
+class TakeoffLandingDetector {
+  /// Default detection thresholds
+  static const double defaultSpeedThresholdKmh = 9.0;
+  static const double defaultClimbRateThresholdMs = 0.2;
+  
+  /// Detect takeoff and landing points in an IGC file
+  /// 
+  /// Takeoff: First point (scanning forward) where 5s ground speed > threshold AND 
+  ///          absolute 5s climb rate > threshold
+  /// Landing: Last point (scanning backward) meeting the same criteria
+  static DetectionResult detectTakeoffLanding(
+    IgcFile igcData, {
+    double speedThresholdKmh = defaultSpeedThresholdKmh,
+    double climbRateThresholdMs = defaultClimbRateThresholdMs,
+  }) {
+    final trackPoints = igcData.trackPoints;
+    
+    if (trackPoints.length < 10) {
+      LoggingService.warning('TakeoffLandingDetector: Insufficient track points (${trackPoints.length}) for detection');
+      return DetectionResult(
+        takeoffIndex: null,
+        landingIndex: null,
+        takeoffTime: null,
+        landingTime: null,
+        message: 'Insufficient track points for detection',
+      );
+    }
+    
+    LoggingService.info('TakeoffLandingDetector: Starting detection with speed=${speedThresholdKmh}km/h, climb=${climbRateThresholdMs}m/s');
+    
+    // Detect takeoff (scan forward from start)
+    int? takeoffIndex;
+    for (int i = 1; i < trackPoints.length; i++) {
+      final point = trackPoints[i];
+      
+      if (_meetsCriteria(point, speedThresholdKmh, climbRateThresholdMs)) {
+        takeoffIndex = i;
+        LoggingService.debug('TakeoffLandingDetector: Takeoff detected at index $i (${point.timestamp})');
+        break;
+      }
+    }
+    
+    // Detect landing (scan backward from end)
+    int? landingIndex;
+    for (int i = trackPoints.length - 2; i >= 0; i--) {
+      final point = trackPoints[i];
+      
+      if (_meetsCriteria(point, speedThresholdKmh, climbRateThresholdMs)) {
+        landingIndex = i;
+        LoggingService.debug('TakeoffLandingDetector: Landing detected at index $i (${point.timestamp})');
+        break;
+      }
+    }
+    
+    // Validation: takeoff must come before landing
+    if (takeoffIndex != null && landingIndex != null && takeoffIndex >= landingIndex) {
+      LoggingService.warning('TakeoffLandingDetector: Invalid detection - takeoff ($takeoffIndex) >= landing ($landingIndex)');
+      return DetectionResult(
+        takeoffIndex: null,
+        landingIndex: null,
+        takeoffTime: null,
+        landingTime: null,
+        message: 'Invalid detection: takeoff point after landing point',
+      );
+    }
+    
+    final takeoffTime = takeoffIndex != null ? trackPoints[takeoffIndex].timestamp : null;
+    final landingTime = landingIndex != null ? trackPoints[landingIndex].timestamp : null;
+    
+    // Log results
+    if (takeoffIndex != null && landingIndex != null) {
+      final originalDuration = trackPoints.last.timestamp.difference(trackPoints.first.timestamp).inMinutes;
+      final detectedDuration = landingTime!.difference(takeoffTime!).inMinutes;
+      LoggingService.info('TakeoffLandingDetector: Detection successful - trimmed ${originalDuration - detectedDuration} minutes');
+    } else if (takeoffIndex == null && landingIndex == null) {
+      LoggingService.warning('TakeoffLandingDetector: No takeoff or landing detected');
+    } else {
+      LoggingService.warning('TakeoffLandingDetector: Partial detection - takeoff=${takeoffIndex != null}, landing=${landingIndex != null}');
+    }
+    
+    return DetectionResult(
+      takeoffIndex: takeoffIndex,
+      landingIndex: landingIndex,
+      takeoffTime: takeoffTime,
+      landingTime: landingTime,
+      message: _buildResultMessage(takeoffIndex, landingIndex),
+    );
+  }
+  
+  /// Check if a track point meets the takeoff/landing criteria
+  static bool _meetsCriteria(IgcPoint point, double speedThresholdKmh, double climbRateThresholdMs) {
+    // Get 5-second average values
+    final groundSpeed = point.groundSpeed; // Already calculated as 5s average in IgcPoint
+    final climbRate5s = point.climbRate5s; // 5-second average climb rate
+    
+    // Check thresholds
+    final speedOk = groundSpeed > speedThresholdKmh;
+    final climbRateOk = climbRate5s.abs() > climbRateThresholdMs;
+    
+    return speedOk && climbRateOk;
+  }
+  
+  /// Build a human-readable result message
+  static String _buildResultMessage(int? takeoffIndex, int? landingIndex) {
+    if (takeoffIndex != null && landingIndex != null) {
+      return 'Takeoff and landing detected successfully';
+    } else if (takeoffIndex != null) {
+      return 'Takeoff detected, landing not found';
+    } else if (landingIndex != null) {
+      return 'Landing detected, takeoff not found';
+    } else {
+      return 'No takeoff or landing detected';
+    }
+  }
+}
+
+/// Result of takeoff/landing detection
+class DetectionResult {
+  /// Index of takeoff point in track points array (null if not detected)
+  final int? takeoffIndex;
+  
+  /// Index of landing point in track points array (null if not detected)
+  final int? landingIndex;
+  
+  /// Timestamp of detected takeoff (null if not detected)
+  final DateTime? takeoffTime;
+  
+  /// Timestamp of detected landing (null if not detected)
+  final DateTime? landingTime;
+  
+  /// Human-readable message about the detection result
+  final String message;
+  
+  DetectionResult({
+    required this.takeoffIndex,
+    required this.landingIndex,
+    required this.takeoffTime,
+    required this.landingTime,
+    required this.message,
+  });
+  
+  /// Whether both takeoff and landing were successfully detected
+  bool get isComplete => takeoffIndex != null && landingIndex != null;
+  
+  /// Whether any detection was made
+  bool get hasDetection => takeoffIndex != null || landingIndex != null;
+  
+  /// Get the detected flight duration in minutes (null if incomplete detection)
+  int? get detectedDurationMinutes {
+    if (!isComplete) return null;
+    return landingTime!.difference(takeoffTime!).inMinutes;
+  }
+  
+  @override
+  String toString() {
+    return 'DetectionResult(takeoff: $takeoffIndex, landing: $landingIndex, message: $message)';
+  }
+}

--- a/free_flight_log_app/lib/utils/preferences_helper.dart
+++ b/free_flight_log_app/lib/utils/preferences_helper.dart
@@ -27,10 +27,12 @@ class PreferencesHelper {
   // Takeoff/Landing Detection preferences
   static const String detectionSpeedThresholdKey = 'detection_speed_threshold';
   static const String detectionClimbRateThresholdKey = 'detection_climb_rate_threshold';
+  static const String chartTrimmingEnabledKey = 'chart_trimming_enabled';
   
   // Default values for detection
   static const double defaultDetectionSpeedThreshold = 9.0; // km/h
   static const double defaultDetectionClimbRateThreshold = 0.2; // m/s
+  static const bool defaultChartTrimmingEnabled = true; // Default to trimmed charts
   static const List<double> validSpeedThresholds = [5.0, 7.0, 9.0, 11.0, 15.0]; // km/h
   static const List<double> validClimbRateThresholds = [0.1, 0.2, 0.3, 0.5]; // m/s
   
@@ -223,6 +225,22 @@ class PreferencesHelper {
   static Future<void> setDetectionClimbRateThreshold(double value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setDouble(detectionClimbRateThresholdKey, value);
+  }
+
+  static Future<bool> getChartTrimmingEnabled() async {
+    final prefs = await SharedPreferences.getInstance();
+    // Check if the preference has been set before
+    if (!prefs.containsKey(chartTrimmingEnabledKey)) {
+      // First time - set default
+      await prefs.setBool(chartTrimmingEnabledKey, defaultChartTrimmingEnabled);
+      return defaultChartTrimmingEnabled;
+    }
+    return prefs.getBool(chartTrimmingEnabledKey) ?? defaultChartTrimmingEnabled;
+  }
+
+  static Future<void> setChartTrimmingEnabled(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(chartTrimmingEnabledKey, value);
   }
   
   // Generic methods for direct access if needed

--- a/free_flight_log_app/lib/utils/preferences_helper.dart
+++ b/free_flight_log_app/lib/utils/preferences_helper.dart
@@ -24,6 +24,16 @@ class PreferencesHelper {
   // IGC Import preferences
   static const String igcLastFolderKey = 'igc_last_folder';
   
+  // Takeoff/Landing Detection preferences
+  static const String detectionSpeedThresholdKey = 'detection_speed_threshold';
+  static const String detectionClimbRateThresholdKey = 'detection_climb_rate_threshold';
+  
+  // Default values for detection
+  static const double defaultDetectionSpeedThreshold = 9.0; // km/h
+  static const double defaultDetectionClimbRateThreshold = 0.2; // m/s
+  static const List<double> validSpeedThresholds = [5.0, 7.0, 9.0, 11.0, 15.0]; // km/h
+  static const List<double> validClimbRateThresholds = [0.1, 0.2, 0.3, 0.5]; // m/s
+  
   // Cesium 3D Map methods
   static Future<String?> getCesiumSceneMode() async {
     final prefs = await SharedPreferences.getInstance();
@@ -180,6 +190,39 @@ class PreferencesHelper {
   static Future<void> removeIgcLastFolder() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(igcLastFolderKey);
+  }
+  
+  // Takeoff/Landing Detection methods
+  static Future<double> getDetectionSpeedThreshold() async {
+    final prefs = await SharedPreferences.getInstance();
+    // Check if the preference has been set before
+    if (!prefs.containsKey(detectionSpeedThresholdKey)) {
+      // First time - set default
+      await prefs.setDouble(detectionSpeedThresholdKey, defaultDetectionSpeedThreshold);
+      return defaultDetectionSpeedThreshold;
+    }
+    return prefs.getDouble(detectionSpeedThresholdKey) ?? defaultDetectionSpeedThreshold;
+  }
+  
+  static Future<void> setDetectionSpeedThreshold(double value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(detectionSpeedThresholdKey, value);
+  }
+  
+  static Future<double> getDetectionClimbRateThreshold() async {
+    final prefs = await SharedPreferences.getInstance();
+    // Check if the preference has been set before
+    if (!prefs.containsKey(detectionClimbRateThresholdKey)) {
+      // First time - set default
+      await prefs.setDouble(detectionClimbRateThresholdKey, defaultDetectionClimbRateThreshold);
+      return defaultDetectionClimbRateThreshold;
+    }
+    return prefs.getDouble(detectionClimbRateThresholdKey) ?? defaultDetectionClimbRateThreshold;
+  }
+  
+  static Future<void> setDetectionClimbRateThreshold(double value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(detectionClimbRateThresholdKey, value);
   }
   
   // Generic methods for direct access if needed


### PR DESCRIPTION
## Summary
- Implement automatic takeoff/landing detection using 5-second average ground speed and climb rate criteria
- Add configurable detection thresholds in preferences (speed: 5-15 km/h, climb: 0.1-0.5 m/s)
- Trim flight charts and statistics to show only actual flight period (no ground preparation/packing time)
- Update launch/landing times to display detected values instead of raw IGC file timestamps
- Centralized trimming architecture ensures all widgets and statistics use consistent data

## Key Features
### Detection Algorithm
- Uses 5-second moving averages for ground speed and climb rate
- Forward scan from start to find takeoff (first point meeting both criteria)
- Backward scan from end to find landing (last point meeting both criteria)
- Configurable thresholds with sensible defaults (9 km/h speed, 0.2 m/s climb rate)

### User Interface
- Preferences screen with dropdown controls for detection thresholds
- Flight times automatically show detected values when available
- Duration reflects actual flight time without ground periods
- Charts start/end at actual takeoff/landing points

### Technical Implementation
- Database migration to v13 adds detection fields (takeoff_index, landing_index, detected times)
- Centralized trimming in `getTrackPointsWithTimezone` ensures consistency
- Efficient memory usage with sublist views (no data duplication)
- Backward compatible with existing flights (falls back to original data if no detection)

## Test Plan
- [x] Import IGC files and verify detection works correctly
- [x] Check that charts no longer show zero ground speed/climb at start
- [x] Verify launch/landing times display detected values
- [x] Confirm duration shows trimmed flight time
- [x] Test preferences screen threshold configuration
- [x] Validate statistics are calculated on trimmed data
- [x] Ensure backward compatibility with existing flights

🤖 Generated with [Claude Code](https://claude.ai/code)