### PR TITLE
feat: Implement triangle closing feature with configurable distance

### DIFF
--- a/free_flight_log_app/lib/data/models/igc_file.dart
+++ b/free_flight_log_app/lib/data/models/igc_file.dart
@@ -692,10 +692,10 @@ class IgcFile {
       };
     }
 
-    // Calculate final triangle perimeter using Pythagorean distance
-    final distance1 = calculateSimpleDistance(bestTriangle[0], bestTriangle[1]);
-    final distance2 = calculateSimpleDistance(bestTriangle[1], bestTriangle[2]);
-    final distance3 = calculateSimpleDistance(bestTriangle[2], bestTriangle[0]);
+    // Calculate final triangle perimeter using Haversine for accuracy
+    final distance1 = _haversineDistance(bestTriangle[0], bestTriangle[1]) * 1000; // Convert km to meters
+    final distance2 = _haversineDistance(bestTriangle[1], bestTriangle[2]) * 1000;
+    final distance3 = _haversineDistance(bestTriangle[2], bestTriangle[0]) * 1000;
     final totalDistance = distance1 + distance2 + distance3;
 
     // Log detailed triangle information

--- a/free_flight_log_app/lib/presentation/screens/preferences_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/preferences_screen.dart
@@ -22,6 +22,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
   double? _detectionClimbRateThreshold;
   bool? _chartTrimmingEnabled;
   double? _triangleClosingDistance;
+  int? _triangleSamplingInterval;
   
   bool _isLoading = true;
   bool _isSaving = false;
@@ -46,6 +47,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
       final climbRateThreshold = await PreferencesHelper.getDetectionClimbRateThreshold();
       final chartTrimmingEnabled = await PreferencesHelper.getChartTrimmingEnabled();
       final triangleClosingDistance = await PreferencesHelper.getTriangleClosingDistance();
+      final triangleSamplingInterval = await PreferencesHelper.getTriangleSamplingInterval();
       
       if (mounted) {
         setState(() {
@@ -59,6 +61,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
           _detectionClimbRateThreshold = climbRateThreshold;
           _chartTrimmingEnabled = chartTrimmingEnabled;
           _triangleClosingDistance = triangleClosingDistance;
+          _triangleSamplingInterval = triangleSamplingInterval;
           
           _isLoading = false;
         });
@@ -380,6 +383,25 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
                     }
                   },
                 ),
+                _buildDropdownRow<int>(
+                  'Triangle Calculation Sampling',
+                  'Time interval between sample points for triangle optimization (shorter = more precise but slower)',
+                  _triangleSamplingInterval,
+                  PreferencesHelper.validTriangleSamplingIntervals.map((interval) => 
+                    DropdownMenuItem(
+                      value: interval,
+                      child: Text(_getTriangleSamplingDescription(interval)),
+                    )
+                  ).toList(),
+                  (value) {
+                    if (value != null) {
+                      setState(() {
+                        _triangleSamplingInterval = value;
+                      });
+                      _savePreference('triangle sampling interval', value, PreferencesHelper.setTriangleSamplingInterval);
+                    }
+                  },
+                ),
               ]),
 
             ],
@@ -394,5 +416,21 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
         ],
       ),
     );
+  }
+  
+  /// Get user-friendly description for triangle sampling intervals
+  String _getTriangleSamplingDescription(int interval) {
+    switch (interval) {
+      case 15:
+        return '15s - Maximum precision (slow for long flights)';
+      case 30:
+        return '30s - High precision (balanced)';
+      case 60:
+        return '60s - Standard precision (recommended)';
+      case 120:
+        return '2m - Fast processing (may miss optimal triangle)';
+      default:
+        return '${interval}s';
+    }
   }
 }

--- a/free_flight_log_app/lib/presentation/widgets/flight_statistics_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/flight_statistics_widget.dart
@@ -64,9 +64,9 @@ class _FlightStatisticsWidgetState extends State<FlightStatisticsWidget> {
                 child: _buildStatItem(
                   'Triangle',
                   widget.flight.isClosed 
-                      ? 'Closed${widget.flight.faiTriangleDistance != null ? ' (${widget.flight.faiTriangleDistance!.toStringAsFixed(1)} km)' : ''}'
+                      ? '${widget.flight.faiTriangleDistance?.toStringAsFixed(1) ?? 'N/A'} km'
                       : 'Open',
-                  widget.flight.isClosed ? Icons.change_history : Icons.open_in_new,
+                  Icons.change_history,
                   context,
                   tooltip: widget.flight.isClosed 
                       ? 'Flight returned within ${widget.flight.closingDistance?.toStringAsFixed(0) ?? 'N/A'}m of launch point${widget.flight.faiTriangleDistance != null ? '. Triangle distance shown.' : ''}'

--- a/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
@@ -683,24 +683,24 @@ class _FlightTrack2DWidgetState extends State<FlightTrack2DWidget> {
     final p2 = LatLng(_faiTrianglePoints[1].latitude, _faiTrianglePoints[1].longitude);
     final p3 = LatLng(_faiTrianglePoints[2].latitude, _faiTrianglePoints[2].longitude);
     
-    // Create triangle as dashed grey lines
+    // Create triangle as dashed purple lines
     return [
       Polyline(
         points: [p1, p2],
         strokeWidth: 2.0,
-        color: Colors.grey,
+        color: Colors.purple,
         pattern: StrokePattern.dashed(segments: [5, 5]),
       ),
       Polyline(
         points: [p2, p3],
         strokeWidth: 2.0,
-        color: Colors.grey,
+        color: Colors.purple,
         pattern: StrokePattern.dashed(segments: [5, 5]),
       ),
       Polyline(
         points: [p3, p1],
         strokeWidth: 2.0,
-        color: Colors.grey,
+        color: Colors.purple,
         pattern: StrokePattern.dashed(segments: [5, 5]),
       ),
     ];

--- a/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
@@ -16,9 +16,9 @@ import '../../services/igc_parser.dart';
 import '../../services/database_service.dart';
 import '../../services/paragliding_earth_api.dart';
 import '../../services/logging_service.dart';
+import '../../utils/preferences_helper.dart';
 import '../../utils/site_marker_utils.dart';
 import '../../utils/ui_utils.dart';
-import '../../utils/preferences_helper.dart';
 import '../screens/flight_track_3d_fullscreen.dart';
 
 enum MapProvider {
@@ -415,7 +415,8 @@ class _FlightTrack2DWidgetState extends State<FlightTrack2DWidget> {
         try {
           final igcParser = IgcParser();
           final igcFile = await igcParser.parseFile(widget.flight.trackLogPath!);
-          final faiTriangle = igcFile.calculateFaiTriangle();
+          final triangleSamplingInterval = await PreferencesHelper.getTriangleSamplingInterval();
+          final faiTriangle = igcFile.calculateFaiTriangle(samplingIntervalSeconds: triangleSamplingInterval);
           final trianglePoints = faiTriangle['trianglePoints'] as List<dynamic>?;
           
           if (trianglePoints != null && trianglePoints.length == 3) {

--- a/free_flight_log_app/lib/services/igc_import_service.dart
+++ b/free_flight_log_app/lib/services/igc_import_service.dart
@@ -324,9 +324,12 @@ class IgcImportService {
       faiTriangle = dataForTriangle.calculateFaiTriangle(samplingIntervalSeconds: triangleSamplingInterval);
       LoggingService.debug('IgcImportService: Triangle calculated${copyFile ? '' : ' (NO COPY)'} on ${dataForTriangle.trackPoints.length} points (launch to closing point)');
     } else {
-      // No closing point, use entire trimmed track
-      faiTriangle = dataForStats.calculateFaiTriangle(samplingIntervalSeconds: triangleSamplingInterval);
-      LoggingService.debug('IgcImportService: Triangle calculated${copyFile ? '' : ' (NO COPY)'} on ${dataForStats.trackPoints.length} points (full trimmed track)');
+      // No closing point, no triangle calculation for open flights
+      faiTriangle = {
+        'trianglePoints': null,
+        'triangleDistance': 0.0,
+      };
+      LoggingService.debug('IgcImportService: No triangle calculated${copyFile ? '' : ' (NO COPY)'} - flight does not close');
     }
     
     // Convert triangle points to JSON for storage

--- a/free_flight_log_app/lib/services/igc_import_service.dart
+++ b/free_flight_log_app/lib/services/igc_import_service.dart
@@ -185,6 +185,7 @@ class IgcImportService {
     // Get detection thresholds from preferences
     final speedThreshold = await PreferencesHelper.getDetectionSpeedThreshold();
     final climbRateThreshold = await PreferencesHelper.getDetectionClimbRateThreshold();
+    final triangleSamplingInterval = await PreferencesHelper.getTriangleSamplingInterval();
     
     // Perform takeoff/landing detection
     final detectionResult = TakeoffLandingDetector.detectTakeoffLanding(
@@ -320,11 +321,11 @@ class IgcImportService {
     if (closingPointIndex != null) {
       // If there's a closing point, calculate triangle on track from launch to closing point
       final dataForTriangle = dataForStats.copyWithTrimmedPoints(0, closingPointIndex);
-      faiTriangle = dataForTriangle.calculateFaiTriangle();
+      faiTriangle = dataForTriangle.calculateFaiTriangle(samplingIntervalSeconds: triangleSamplingInterval);
       LoggingService.debug('IgcImportService: Triangle calculated${copyFile ? '' : ' (NO COPY)'} on ${dataForTriangle.trackPoints.length} points (launch to closing point)');
     } else {
       // No closing point, use entire trimmed track
-      faiTriangle = dataForStats.calculateFaiTriangle();
+      faiTriangle = dataForStats.calculateFaiTriangle(samplingIntervalSeconds: triangleSamplingInterval);
       LoggingService.debug('IgcImportService: Triangle calculated${copyFile ? '' : ' (NO COPY)'} on ${dataForStats.trackPoints.length} points (full trimmed track)');
     }
     
@@ -540,7 +541,6 @@ class IgcImportService {
       recordingInterval: flight.recordingInterval,
     );
   }
-
 
   /// Save IGC file to app storage
   Future<String> _saveIgcFile(String sourcePath) async {

--- a/free_flight_log_app/lib/utils/preferences_helper.dart
+++ b/free_flight_log_app/lib/utils/preferences_helper.dart
@@ -29,15 +29,18 @@ class PreferencesHelper {
   static const String detectionClimbRateThresholdKey = 'detection_climb_rate_threshold';
   static const String chartTrimmingEnabledKey = 'chart_trimming_enabled';
   static const String triangleClosingDistanceKey = 'triangle_closing_distance';
+  static const String triangleSamplingIntervalKey = 'triangle_sampling_interval';
   
   // Default values for detection
   static const double defaultDetectionSpeedThreshold = 9.0; // km/h
   static const double defaultDetectionClimbRateThreshold = 0.2; // m/s
   static const bool defaultChartTrimmingEnabled = true; // Default to trimmed charts
   static const double defaultTriangleClosingDistance = 100.0; // meters
+  static const int defaultTriangleSamplingInterval = 60; // seconds
   static const List<double> validSpeedThresholds = [5.0, 7.0, 9.0, 11.0, 15.0]; // km/h
   static const List<double> validClimbRateThresholds = [0.1, 0.2, 0.3, 0.5]; // m/s
   static const List<double> validTriangleClosingDistances = [50.0, 100.0, 250.0, 500.0, 1000.0]; // meters
+  static const List<int> validTriangleSamplingIntervals = [15, 30, 60, 120]; // seconds
   
   // Cesium 3D Map methods
   static Future<String?> getCesiumSceneMode() async {
@@ -260,6 +263,22 @@ class PreferencesHelper {
   static Future<void> setTriangleClosingDistance(double value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setDouble(triangleClosingDistanceKey, value);
+  }
+  
+  static Future<int> getTriangleSamplingInterval() async {
+    final prefs = await SharedPreferences.getInstance();
+    // Check if the preference has been set before
+    if (!prefs.containsKey(triangleSamplingIntervalKey)) {
+      // First time - set default
+      await prefs.setInt(triangleSamplingIntervalKey, defaultTriangleSamplingInterval);
+      return defaultTriangleSamplingInterval;
+    }
+    return prefs.getInt(triangleSamplingIntervalKey) ?? defaultTriangleSamplingInterval;
+  }
+  
+  static Future<void> setTriangleSamplingInterval(int value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(triangleSamplingIntervalKey, value);
   }
   
   // Generic methods for direct access if needed

--- a/free_flight_log_app/lib/utils/preferences_helper.dart
+++ b/free_flight_log_app/lib/utils/preferences_helper.dart
@@ -261,6 +261,9 @@ class PreferencesHelper {
   }
   
   static Future<void> setTriangleClosingDistance(double value) async {
+    if (value < 50.0 || value > 1000.0) {
+      throw ArgumentError('Triangle closing distance must be between 50-1000m');
+    }
     final prefs = await SharedPreferences.getInstance();
     await prefs.setDouble(triangleClosingDistanceKey, value);
   }


### PR DESCRIPTION
Implement triangle closing feature as specified in issue #130

- Add flight closure detection algorithm using configurable distance
- Only show dotted triangle on 2D track for closed flights
- Show "Open" status in statistics for unclosed flights
- Add preferences dropdown for closing distance [50, 100, 250, 500, 1000]m
- Triangle detection scans backwards to find closing point within distance
- Triangle algorithm only considers track data from start to closing point

Generated with [Claude Code](https://claude.ai/code)