### PR TITLE
refactor: Simplify database layer by removing migration code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ junk.md
 free_flight_log_app/android/build/reports/problems/problems-report.html
 .kotlin
 free_flight_log_app/coverage/
+free_flight_log_app.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,30 @@ Replace any `print()` statements with the appropriate LoggingService method base
 - **Cesium 3D**: Receives ISO8601 timestamps with timezone offset (e.g., "2025-07-11T11:03:56.000+02:00")
 - **Flutter UI**: Displays times in HH:MM format with optional timezone indicator
 
+## Database Development
+
+### Pre-Release Schema Strategy
+
+- **No Database Migrations**: Since the app is pre-release, we use a simplified approach
+- **Schema Changes**: Any database schema changes require clearing app data during development
+- **Clean v1.0**: The current schema in `database_helper.dart` represents the v1.0 release baseline
+- **Future Migrations**: Post-release migrations will start from v2 with the current schema as the baseline
+
+### Developer Workflow
+
+When pulling code changes that modify the database schema:
+1. Clear app data: Settings → Apps → Free Flight Log → Storage → Clear Data
+2. Or use the emulator wipe: `flutter_controller.sh clean` (if available)
+3. Hot restart the app to recreate the database with the new schema
+4. Re-import any test data as needed
+
+### Benefits
+
+- **Simplified codebase**: No complex migration logic during development
+- **Clean baseline**: Start v1.0 with optimized schema
+- **Fewer bugs**: No migration-related errors during development
+- **Performance**: Faster app startup without migration checks
+
 ## Development Reminders
 
 - Store documentation in the document directory

--- a/free_flight_log_app/lib/data/datasources/database_helper.dart
+++ b/free_flight_log_app/lib/data/datasources/database_helper.dart
@@ -188,9 +188,12 @@ class DatabaseHelper {
       final flightColumns = await db.rawQuery("PRAGMA table_info(flights)");
       final expectedFlightColumns = {
         'id', 'date', 'launch_time', 'landing_time', 'duration',
-        'launch_site_id', 'landing_latitude', 'landing_longitude', 'landing_altitude', 'landing_description',
+        'launch_site_id', 'launch_latitude', 'launch_longitude', 'launch_altitude',
+        'landing_latitude', 'landing_longitude', 'landing_altitude', 'landing_description',
         'max_altitude', 'max_climb_rate', 'max_sink_rate', 'max_climb_rate_5_sec', 'max_sink_rate_5_sec',
-        'distance', 'straight_distance', 'wing_id', 'notes', 'created_at', 'updated_at', 'timezone',
+        'distance', 'straight_distance', 'fai_triangle_distance', 'fai_triangle_points',
+        'wing_id', 'notes', 'track_log_path', 'original_filename', 'source',
+        'timezone', 'created_at', 'updated_at',
         'max_ground_speed', 'avg_ground_speed', 'thermal_count', 'avg_thermal_strength',
         'total_time_in_thermals', 'best_thermal', 'best_ld', 'avg_ld', 'longest_glide',
         'climb_percentage', 'gps_fix_quality', 'recording_interval',
@@ -217,6 +220,34 @@ class DatabaseHelper {
       
       if (missingSiteColumns.isNotEmpty) {
         LoggingService.error('DatabaseHelper: Missing site columns: ${missingSiteColumns.join(', ')}');
+        return false;
+      }
+      
+      // Check wings table has all expected columns
+      final wingColumns = await db.rawQuery("PRAGMA table_info(wings)");
+      final expectedWingColumns = {
+        'id', 'name', 'manufacturer', 'model', 'size', 'color', 'purchase_date', 'active', 'notes', 'created_at'
+      };
+      
+      final actualWingColumns = wingColumns.map((col) => col['name'] as String).toSet();
+      final missingWingColumns = expectedWingColumns.difference(actualWingColumns);
+      
+      if (missingWingColumns.isNotEmpty) {
+        LoggingService.error('DatabaseHelper: Missing wing columns: ${missingWingColumns.join(', ')}');
+        return false;
+      }
+      
+      // Check wing_aliases table has all expected columns
+      final wingAliasColumns = await db.rawQuery("PRAGMA table_info(wing_aliases)");
+      final expectedWingAliasColumns = {
+        'id', 'wing_id', 'alias_name', 'created_at'
+      };
+      
+      final actualWingAliasColumns = wingAliasColumns.map((col) => col['name'] as String).toSet();
+      final missingWingAliasColumns = expectedWingAliasColumns.difference(actualWingAliasColumns);
+      
+      if (missingWingAliasColumns.isNotEmpty) {
+        LoggingService.error('DatabaseHelper: Missing wing_aliases columns: ${missingWingAliasColumns.join(', ')}');
         return false;
       }
       

--- a/free_flight_log_app/lib/data/datasources/database_helper.dart
+++ b/free_flight_log_app/lib/data/datasources/database_helper.dart
@@ -5,7 +5,7 @@ import '../../services/logging_service.dart';
 
 class DatabaseHelper {
   static const _databaseName = "FlightLog.db";
-  static const _databaseVersion = 14; // Added triangle closing point fields
+  static const _databaseVersion = 1; // v1.0 Release Schema - Start migrations from v2
 
   // Singleton pattern
   DatabaseHelper._privateConstructor();
@@ -14,6 +14,13 @@ class DatabaseHelper {
   static Database? _database;
   Future<Database> get database async => _database ??= await _initDatabase();
 
+  /// Initialize database with v1.0 schema
+  /// 
+  /// PRE-RELEASE STRATEGY: No migrations needed since app hasn't been released.
+  /// All schema changes during development require clearing app data.
+  /// 
+  /// POST-RELEASE STRATEGY: Start migrations from v2 when app is released.
+  /// This ensures a clean baseline for production users.
   Future<Database> _initDatabase() async {
     String path = join(await getDatabasesPath(), _databaseName);
     LoggingService.database('INIT', 'Opening database at: $path');
@@ -22,7 +29,6 @@ class DatabaseHelper {
       path,
       version: _databaseVersion,
       onCreate: _onCreate,
-      onUpgrade: _onUpgrade,
     );
     
     return db;
@@ -154,153 +160,6 @@ class DatabaseHelper {
     }
   }
 
-  Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
-    LoggingService.database('UPGRADE', 'Upgrading database from version $oldVersion to $newVersion');
-    
-    // SIMPLIFIED MIGRATION for v9: Just optimize indexes
-    // All previous migrations (v1-8) stay applied, we're just removing unnecessary indexes
-    if (oldVersion < 9) {
-      try {
-        LoggingService.database('MIGRATION', 'Optimizing database - reducing indexes from 18 to 3');
-        
-        // Drop all unnecessary indexes (data remains intact)
-        final indexesToDrop = [
-          'idx_flights_original_filename',
-          'idx_flights_date',
-          'idx_flights_created',
-          'idx_flights_updated',
-          'idx_flights_year',
-          'idx_flights_duration',
-          'idx_flights_altitude',
-          'idx_flights_distance',
-          'idx_sites_country',
-          'idx_sites_name',
-          'idx_wings_active',
-          'idx_wings_manufacturer',
-          'idx_wings_name',
-          'idx_flights_duplicate_check',
-        ];
-        
-        for (final index in indexesToDrop) {
-          try {
-            await db.execute('DROP INDEX IF EXISTS $index');
-          } catch (e) {
-            // Ignore if index doesn't exist
-          }
-        }
-        
-        // Ensure only essential indexes exist
-        await _createIndexes(db);
-        
-        LoggingService.database('MIGRATION', 'Successfully optimized database - reduced to 3 essential indexes');
-      } catch (e) {
-        LoggingService.error('DatabaseHelper: Index optimization failed', e);
-        // Non-critical - app can continue with existing indexes
-      }
-    }
-    
-    // Migration for v10: Add wing aliases support
-    if (oldVersion < 10) {
-      try {
-        LoggingService.database('MIGRATION', 'Adding wing aliases support');
-        
-        // Create wing_aliases table
-        await db.execute('''
-          CREATE TABLE IF NOT EXISTS wing_aliases (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            wing_id INTEGER NOT NULL,
-            alias_name TEXT NOT NULL,
-            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-            FOREIGN KEY (wing_id) REFERENCES wings (id) ON DELETE CASCADE,
-            UNIQUE(alias_name)
-          )
-        ''');
-        
-        // Create indexes for wing aliases
-        await db.execute('CREATE INDEX IF NOT EXISTS idx_wing_aliases_wing_id ON wing_aliases(wing_id)');
-        await db.execute('CREATE INDEX IF NOT EXISTS idx_wing_aliases_alias_name ON wing_aliases(alias_name)');
-        
-        LoggingService.database('MIGRATION', 'Successfully added wing aliases support');
-      } catch (e) {
-        LoggingService.error('DatabaseHelper: Failed to add wing aliases', e);
-        rethrow; // This is important for data integrity
-      }
-    }
-    
-    // Migration for v11: Add comprehensive IGC statistics
-    if (oldVersion < 11) {
-      try {
-        LoggingService.database('MIGRATION', 'Adding comprehensive IGC statistics columns');
-        
-        // Add new statistics columns to flights table
-        await db.execute('ALTER TABLE flights ADD COLUMN max_ground_speed REAL');
-        await db.execute('ALTER TABLE flights ADD COLUMN avg_ground_speed REAL');
-        await db.execute('ALTER TABLE flights ADD COLUMN thermal_count INTEGER');
-        await db.execute('ALTER TABLE flights ADD COLUMN avg_thermal_strength REAL');
-        await db.execute('ALTER TABLE flights ADD COLUMN total_time_in_thermals INTEGER');
-        await db.execute('ALTER TABLE flights ADD COLUMN best_thermal REAL');
-        await db.execute('ALTER TABLE flights ADD COLUMN best_ld REAL');
-        await db.execute('ALTER TABLE flights ADD COLUMN avg_ld REAL');
-        await db.execute('ALTER TABLE flights ADD COLUMN longest_glide REAL');
-        await db.execute('ALTER TABLE flights ADD COLUMN climb_percentage REAL');
-        await db.execute('ALTER TABLE flights ADD COLUMN gps_fix_quality REAL');
-        await db.execute('ALTER TABLE flights ADD COLUMN recording_interval REAL');
-        
-        LoggingService.database('MIGRATION', 'Successfully added comprehensive IGC statistics columns');
-      } catch (e) {
-        LoggingService.error('DatabaseHelper: Failed to add IGC statistics columns', e);
-        rethrow; // This is important for data integrity
-      }
-    }
-    
-    // Migration for v12: Add FAI triangle distance
-    if (oldVersion < 12) {
-      try {
-        LoggingService.database('MIGRATION', 'Adding FAI triangle distance column');
-        
-        await db.execute('ALTER TABLE flights ADD COLUMN fai_triangle_distance REAL');
-        
-        LoggingService.database('MIGRATION', 'Successfully added FAI triangle distance column');
-      } catch (e) {
-        LoggingService.error('DatabaseHelper: Failed to add FAI triangle distance column', e);
-        rethrow;
-      }
-    }
-    
-    // Migration for v13: Add takeoff/landing detection fields
-    if (oldVersion < 13) {
-      try {
-        LoggingService.database('MIGRATION', 'Adding takeoff/landing detection fields');
-        
-        await db.execute('ALTER TABLE flights ADD COLUMN takeoff_index INTEGER');
-        await db.execute('ALTER TABLE flights ADD COLUMN landing_index INTEGER');
-        await db.execute('ALTER TABLE flights ADD COLUMN detected_takeoff_time TEXT');
-        await db.execute('ALTER TABLE flights ADD COLUMN detected_landing_time TEXT');
-        
-        LoggingService.database('MIGRATION', 'Successfully added takeoff/landing detection fields');
-      } catch (e) {
-        LoggingService.error('DatabaseHelper: Failed to add takeoff/landing detection fields', e);
-        rethrow;
-      }
-    }
-    
-    // Migration for v14: Add triangle closing point fields
-    if (oldVersion < 14) {
-      try {
-        LoggingService.database('MIGRATION', 'Adding triangle closing point fields');
-        
-        await db.execute('ALTER TABLE flights ADD COLUMN closing_point_index INTEGER');
-        await db.execute('ALTER TABLE flights ADD COLUMN closing_distance REAL');
-        
-        LoggingService.database('MIGRATION', 'Successfully added triangle closing point fields');
-      } catch (e) {
-        LoggingService.error('DatabaseHelper: Failed to add triangle closing point fields', e);
-        rethrow;
-      }
-    }
-    
-    LoggingService.database('UPGRADE', 'Database upgrade complete');
-  }
 
   /// Force recreation of the database (use when migration fails)
   Future<void> recreateDatabase() async {

--- a/free_flight_log_app/test/database_helper_test.dart
+++ b/free_flight_log_app/test/database_helper_test.dart
@@ -1,0 +1,175 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:free_flight_log_app/data/datasources/database_helper.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'helpers/test_helpers.dart';
+
+void main() {
+  group('DatabaseHelper', () {
+    late DatabaseHelper databaseHelper;
+
+    setUpAll(() {
+      // Initialize database factory for testing
+      TestHelpers.initializeDatabaseForTesting();
+    });
+
+    setUp(() {
+      databaseHelper = DatabaseHelper.instance;
+    });
+
+    test('should create database with correct schema', () async {
+      // Get the database instance
+      final db = await databaseHelper.database;
+      
+      // Verify database version
+      final version = await db.getVersion();
+      expect(version, equals(1));
+      
+      // Verify all tables exist
+      final tables = await db.rawQuery(
+        "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+      );
+      final tableNames = tables.map((table) => table['name'] as String).toList();
+      
+      expect(tableNames, containsAll(['flights', 'sites', 'wings', 'wing_aliases']));
+    });
+
+    test('should validate database schema successfully', () async {
+      // Validate schema
+      final isValid = await databaseHelper.validateDatabaseSchema();
+      
+      expect(isValid, isTrue);
+    });
+
+    test('should have all required flights table columns', () async {
+      final db = await databaseHelper.database;
+      
+      // Get flights table column info
+      final columns = await db.rawQuery("PRAGMA table_info(flights)");
+      final columnNames = columns.map((col) => col['name'] as String).toSet();
+      
+      // Expected columns from schema
+      const expectedColumns = {
+        'id', 'date', 'launch_time', 'landing_time', 'duration',
+        'launch_site_id', 'launch_latitude', 'launch_longitude', 'launch_altitude',
+        'landing_latitude', 'landing_longitude', 'landing_altitude', 'landing_description',
+        'max_altitude', 'max_climb_rate', 'max_sink_rate', 'max_climb_rate_5_sec', 'max_sink_rate_5_sec',
+        'distance', 'straight_distance', 'fai_triangle_distance', 'fai_triangle_points',
+        'wing_id', 'notes', 'track_log_path', 'original_filename', 'source',
+        'timezone', 'created_at', 'updated_at',
+        'max_ground_speed', 'avg_ground_speed', 'thermal_count', 'avg_thermal_strength',
+        'total_time_in_thermals', 'best_thermal', 'best_ld', 'avg_ld', 'longest_glide',
+        'climb_percentage', 'gps_fix_quality', 'recording_interval',
+        'takeoff_index', 'landing_index', 'detected_takeoff_time', 'detected_landing_time',
+        'closing_point_index', 'closing_distance'
+      };
+      
+      expect(columnNames.containsAll(expectedColumns), isTrue,
+        reason: 'Missing columns: ${expectedColumns.difference(columnNames)}');
+    });
+
+    test('should have all required sites table columns', () async {
+      final db = await databaseHelper.database;
+      
+      // Get sites table column info
+      final columns = await db.rawQuery("PRAGMA table_info(sites)");
+      final columnNames = columns.map((col) => col['name'] as String).toSet();
+      
+      const expectedColumns = {
+        'id', 'name', 'latitude', 'longitude', 'altitude', 'country', 'custom_name', 'created_at'
+      };
+      
+      expect(columnNames.containsAll(expectedColumns), isTrue,
+        reason: 'Missing columns: ${expectedColumns.difference(columnNames)}');
+    });
+
+    test('should have all required wings table columns', () async {
+      final db = await databaseHelper.database;
+      
+      // Get wings table column info
+      final columns = await db.rawQuery("PRAGMA table_info(wings)");
+      final columnNames = columns.map((col) => col['name'] as String).toSet();
+      
+      const expectedColumns = {
+        'id', 'name', 'manufacturer', 'model', 'size', 'color', 
+        'purchase_date', 'active', 'notes', 'created_at'
+      };
+      
+      expect(columnNames.containsAll(expectedColumns), isTrue,
+        reason: 'Missing columns: ${expectedColumns.difference(columnNames)}');
+    });
+
+    test('should have all required wing_aliases table columns', () async {
+      final db = await databaseHelper.database;
+      
+      // Get wing_aliases table column info
+      final columns = await db.rawQuery("PRAGMA table_info(wing_aliases)");
+      final columnNames = columns.map((col) => col['name'] as String).toSet();
+      
+      const expectedColumns = {
+        'id', 'wing_id', 'alias_name', 'created_at'
+      };
+      
+      expect(columnNames.containsAll(expectedColumns), isTrue,
+        reason: 'Missing columns: ${expectedColumns.difference(columnNames)}');
+    });
+
+    test('should have all required indexes', () async {
+      final db = await databaseHelper.database;
+      
+      // Get index information
+      final indexes = await db.rawQuery(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%'"
+      );
+      final indexNames = indexes.map((index) => index['name'] as String).toSet();
+      
+      const expectedIndexes = {
+        'idx_flights_launch_site',
+        'idx_flights_wing',
+        'idx_flights_date_time',
+        'idx_wing_aliases_wing_id',
+        'idx_wing_aliases_alias_name'
+      };
+      
+      expect(indexNames.containsAll(expectedIndexes), isTrue,
+        reason: 'Missing indexes: ${expectedIndexes.difference(indexNames)}');
+    });
+
+    test('should have proper foreign key constraints', () async {
+      final db = await databaseHelper.database;
+      
+      // Get foreign key information for flights table
+      final flightsForeignKeys = await db.rawQuery("PRAGMA foreign_key_list(flights)");
+      
+      expect(flightsForeignKeys.length, equals(2));
+      
+      // Check launch_site_id foreign key
+      final siteFk = flightsForeignKeys.firstWhere(
+        (fk) => fk['from'] == 'launch_site_id'
+      );
+      expect(siteFk['table'], equals('sites'));
+      expect(siteFk['to'], equals('id'));
+      
+      // Check wing_id foreign key
+      final wingFk = flightsForeignKeys.firstWhere(
+        (fk) => fk['from'] == 'wing_id'
+      );
+      expect(wingFk['table'], equals('wings'));
+      expect(wingFk['to'], equals('id'));
+      
+      // Get foreign key information for wing_aliases table
+      final aliasesForeignKeys = await db.rawQuery("PRAGMA foreign_key_list(wing_aliases)");
+      
+      expect(aliasesForeignKeys.length, equals(1));
+      
+      final aliasWingFk = aliasesForeignKeys.first;
+      expect(aliasWingFk['from'], equals('wing_id'));
+      expect(aliasWingFk['table'], equals('wings'));
+      expect(aliasWingFk['to'], equals('id'));
+    });
+    
+    tearDown(() async {
+      // Clean up database for next test
+      await databaseHelper.recreateDatabase();
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Remove all database migration logic from DatabaseHelper (~150 lines)
- Set database version to 1 as v1.0 release baseline  
- Add comprehensive documentation for pre-release schema strategy
- Update developer workflow in CLAUDE.md for schema changes

## Benefits
- **Simpler codebase**: No complex migration logic during development
- **Fewer bugs**: Eliminates migration-related errors 
- **Clean v1.0**: Establishes optimized schema baseline for release
- **Better performance**: Faster app startup without migration checks

## Impact
Since the app is pre-release, this change requires developers to clear app data when pulling schema changes. This is documented in the updated CLAUDE.md with clear workflow steps.

Future migrations will start from v2 post-release using the current schema as the baseline.

## Test plan
- [x] Database creates successfully with version 1
- [x] All tables and indexes created properly via _onCreate()
- [x] App startup works without errors
- [x] No migration logs in database initialization
- [x] Documentation updated with developer workflow

🤖 Generated with [Claude Code](https://claude.ai/code)