### PR TITLE
feat: Add triangle validation to prevent invalid triangles near launch

### DIFF
--- a/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
@@ -416,7 +416,8 @@ class _FlightTrack2DWidgetState extends State<FlightTrack2DWidget> {
           final igcParser = IgcParser();
           final igcFile = await igcParser.parseFile(widget.flight.trackLogPath!);
           final triangleSamplingInterval = await PreferencesHelper.getTriangleSamplingInterval();
-          final faiTriangle = igcFile.calculateFaiTriangle(samplingIntervalSeconds: triangleSamplingInterval);
+          final closingDistance = await PreferencesHelper.getTriangleClosingDistance();
+          final faiTriangle = igcFile.calculateFaiTriangle(samplingIntervalSeconds: triangleSamplingInterval, closingDistanceMeters: closingDistance);
           final trianglePoints = faiTriangle['trianglePoints'] as List<dynamic>?;
           
           if (trianglePoints != null && trianglePoints.length == 3) {

--- a/free_flight_log_app/lib/services/igc_import_service.dart
+++ b/free_flight_log_app/lib/services/igc_import_service.dart
@@ -321,7 +321,7 @@ class IgcImportService {
     if (closingPointIndex != null) {
       // If there's a closing point, calculate triangle on track from launch to closing point
       final dataForTriangle = dataForStats.copyWithTrimmedPoints(0, closingPointIndex);
-      faiTriangle = dataForTriangle.calculateFaiTriangle(samplingIntervalSeconds: triangleSamplingInterval);
+      faiTriangle = dataForTriangle.calculateFaiTriangle(samplingIntervalSeconds: triangleSamplingInterval, closingDistanceMeters: closingDistance);
       LoggingService.debug('IgcImportService: Triangle calculated${copyFile ? '' : ' (NO COPY)'} on ${dataForTriangle.trackPoints.length} points (launch to closing point)');
     } else {
       // No closing point, no triangle calculation for open flights


### PR DESCRIPTION
## Summary

- Add triangle validation to ensure meaningful triangles by checking vertex distances from launch point
- Validate that at least 2 triangle vertices are outside closing detection threshold (default 100m)
- Mark flights with invalid triangles as "open" with detailed logging explaining why

## Changes Made

- **`igc_file.dart`**: Enhanced `calculateFaiTriangle()` with `closingDistanceMeters` parameter and validation logic
- **`igc_import_service.dart`**: Updated to pass closing distance to triangle calculation
- **`flight_track_2d_widget.dart`**: Updated fallback triangle calculation to use validation

## Validation Logic

1. After finding the best triangle (maximum perimeter), validate each vertex distance from launch
2. Count vertices that are > closing threshold distance from launch point
3. If < 2 vertices are outside threshold → invalid triangle, return empty result
4. Enhanced logging shows vertex distances and validation results

## Test Plan

- [x] Code compiles without errors (dart analyzer)
- [x] App runs successfully with existing flights
- [x] Ready for testing with new IGC imports that would trigger triangle validation
- [ ] Test with ground handling flights (should be marked as open)
- [ ] Test with short flights near launch (should be marked as open) 
- [ ] Test with valid triangular flights (should calculate triangles normally)

## Problem Solved

Previously, the app could calculate meaningless "triangles" where all vertices were clustered near the launch point (e.g., ground handling or very short flights). This enhancement ensures only flights with vertices spread meaningfully across the landscape generate valid triangle distances.

🤖 Generated with [Claude Code](https://claude.ai/code)