### PR TITLE
Show total IGC file size in data management

### DIFF
--- a/free_flight_log_app/lib/presentation/screens/data_management_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/data_management_screen.dart
@@ -925,7 +925,7 @@ class _DataManagementScreenState extends State<DataManagementScreen> {
                       leading: const Icon(Icons.cleaning_services),
                       title: const Text('IGC File Cleanup'),
                       subtitle: _cleanupStats != null 
-                        ? Text('${_cleanupStats!.totalIgcFiles} total • ${_cleanupStats!.orphanedFiles} orphaned')
+                        ? Text('${_cleanupStats!.totalIgcFiles} (${_cleanupStats!.formattedTotalSize}) • ${_cleanupStats!.orphanedFiles} orphaned')
                         : const Text('Analyzing files...'),
                       initiallyExpanded: _cleanupExpanded,
                       onExpansionChanged: (expanded) {


### PR DESCRIPTION
Add total IGC file size display in brackets after file count in the IGC File Cleanup section.

Changes:
- Updated subtitle to show format like "17 (34MB) • 3 orphaned"
- Uses existing `formattedTotalSize` property from IGCCleanupStats

Fixes #142

Generated with [Claude Code](https://claude.ai/code)