### PR TITLE
fix: Refresh 2D chart after reimporting a flight

### DIFF
--- a/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
@@ -92,6 +92,27 @@ class _FlightTrack2DWidgetState extends State<FlightTrack2DWidget> {
     _loadClosingDistanceThreshold();
   }
 
+  @override
+  void didUpdateWidget(FlightTrack2DWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    
+    // Check if flight data that affects the map display has changed
+    if (_shouldReloadTrackData(oldWidget.flight, widget.flight)) {
+      LoggingService.ui('FlightTrack2D', 'Flight data changed, reloading track data');
+      _loadTrackData();
+    }
+  }
+
+  /// Check if track data should be reloaded based on flight changes
+  bool _shouldReloadTrackData(Flight oldFlight, Flight newFlight) {
+    // Compare key fields that affect track/triangle display
+    return oldFlight.id != newFlight.id ||
+           oldFlight.trackLogPath != newFlight.trackLogPath ||
+           oldFlight.faiTrianglePoints != newFlight.faiTrianglePoints ||
+           oldFlight.isClosed != newFlight.isClosed ||
+           oldFlight.closingPointIndex != newFlight.closingPointIndex;
+  }
+
   Future<void> _loadMapProvider() async {
     try {
       final prefs = await SharedPreferences.getInstance();


### PR DESCRIPTION
Add didUpdateWidget() lifecycle method to FlightTrack2DWidget to detect when flight parameter changes and reload track data accordingly.

The widget now compares key flight fields to determine if track data should be reloaded, ensuring the 2D chart displays updated triangle data after flight reimport.

Fixes #139

Generated with [Claude Code](https://claude.ai/code)