### PR TITLE
Fix: Map shows exact bounds when jumping to sites

### DIFF
--- a/free_flight_log_app/lib/presentation/widgets/nearby_sites_map_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/nearby_sites_map_widget.dart
@@ -15,6 +15,7 @@ class NearbySitesMapWidget extends StatefulWidget {
   final Map<String, bool> siteFlightStatus;
   final Position? userPosition;
   final LatLng? centerPosition;
+  final LatLngBounds? boundsToFit; // Optional bounds for exact map fitting
   final double initialZoom;
   final MapProvider mapProvider;
   final bool isLegendExpanded;
@@ -36,6 +37,7 @@ class NearbySitesMapWidget extends StatefulWidget {
     required this.siteFlightStatus,
     this.userPosition,
     this.centerPosition,
+    this.boundsToFit,
     this.initialZoom = 10.0,
     required this.mapProvider,
     required this.isLegendExpanded,
@@ -69,9 +71,21 @@ class _NearbySitesMapWidgetState extends State<NearbySitesMapWidget> {
   void didUpdateWidget(NearbySitesMapWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
     
-    // If center position changed, move map to new location
-    if (widget.centerPosition != null && 
-        oldWidget.centerPosition != widget.centerPosition) {
+    // Priority 1: Check if we should fit to exact bounds (for precise area display)
+    if (widget.boundsToFit != null && 
+        oldWidget.boundsToFit != widget.boundsToFit) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _mapController.fitCamera(
+          CameraFit.bounds(
+            bounds: widget.boundsToFit!,
+            padding: const EdgeInsets.all(20), // Small padding for visibility
+          ),
+        );
+      });
+    }
+    // Priority 2: Fallback to center/zoom for normal navigation
+    else if (widget.centerPosition != null && 
+             oldWidget.centerPosition != widget.centerPosition) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _mapController.move(widget.centerPosition!, widget.initialZoom);
       });


### PR DESCRIPTION
## Summary
- Map now fits to the exact bounds used for API search when jumping to sites
- Replaces approximate zoom levels with precise `CameraFit.bounds()` 
- Shows exactly the ±0.05° area searched for nearby sites
- Provides consistent visual representation of loaded area

## Changes Made
- Added `boundsToFit` property to `NearbySitesMapWidget`
- Updated `didUpdateWidget` to prioritize bounds fitting over center/zoom
- Modified `_jumpToLocation` to set exact API search bounds
- Auto-clears bounds after fitting to allow normal navigation

## Benefits
- **Exact area display**: User sees precisely what's being searched
- **Consistent UX**: Map view matches API search bounds  
- **Better spatial awareness**: Clear visual indication of loaded area
- **Maintains navigation**: Normal map interaction after initial fitting

## Test plan
- [ ] Test site jump shows exact ±0.05° bounds
- [ ] Verify bounds auto-clear after 500ms for normal navigation
- [ ] Confirm fallback to center/zoom still works for other cases
- [ ] Check both search and location button jumping behaviors

🤖 Generated with [Claude Code](https://claude.ai/code)