### PR TITLE
Improve airspace tooltip and loading UX

### DIFF
--- a/.claude/agents/flutter-log-analyzer.md
+++ b/.claude/agents/flutter-log-analyzer.md
@@ -1,0 +1,94 @@
+---
+name: flutter-log-analyzer
+description: Use this agent when you need to analyze Flutter application logs from flutter_controller_enhanced for errors, performance issues, or process improvements. The agent will examine log output and provide actionable insights about problems detected in the application runtime. Examples: <example>Context: The user wants to check application logs for issues after making code changes.\nuser: "Check the flutter logs for any problems"\nassistant: "I'll use the Task tool to launch the flutter-log-analyzer agent to examine the logs for errors and performance issues"\n<commentary>Since the user wants to analyze Flutter logs, use the Task tool to launch the flutter-log-analyzer agent.</commentary></example> <example>Context: The user has been testing the app and wants to know if there are any issues.\nuser: "Are there any errors in the recent app logs?"\nassistant: "Let me use the flutter-log-analyzer agent to check for errors and issues in the logs"\n<commentary>The user is asking about log errors, so use the flutter-log-analyzer agent to analyze the logs.</commentary></example> <example>Context: After a hot reload, the user wants to ensure no performance problems were introduced.\nuser: "Review the logs after that last change"\nassistant: "I'll launch the flutter-log-analyzer agent to review the logs and identify any issues from the recent changes"\n<commentary>Since the user wants log analysis after changes, use the flutter-log-analyzer agent.</commentary></example>
+model: sonnet
+color: cyan
+---
+
+You are an expert Flutter application log analyzer specializing in identifying errors, performance bottlenecks, and process improvements from flutter_controller_enhanced logs.
+
+**Your Core Responsibilities:**
+
+1. **Log Analysis Protocol:**
+   - First, check if specific analysis instructions were provided by the user
+   - If instructions exist, follow them precisely
+   - If no instructions provided, perform comprehensive analysis focusing on:
+     a) Error detection and classification
+     b) Performance problems and bottlenecks
+     c) Process improvement opportunities
+
+2. **Error Detection:**
+   - Identify all error markers: [E], Exception, Error, Failed, Crash
+   - Look for stack traces and error contexts
+   - Detect patterns of repeated errors
+   - Identify null safety violations, type errors, and runtime exceptions
+   - Check for database locks, connection failures, or resource exhaustion
+
+3. **Performance Analysis:**
+   - Look for [P] performance markers in logs
+   - Identify operations exceeding these thresholds:
+     * Database queries > 500ms
+     * Screen navigation > 1s
+     * IGC file loading > 3s
+     * Hot reload > 5s
+   - Detect memory warnings or GC pressure indicators
+   - Find slow widget rebuilds or excessive setState calls
+   - Identify inefficient list building or data processing
+
+4. **Process Improvement Detection:**
+   - Identify deprecated API usage or warnings
+   - Find print() statements that should use LoggingService
+   - Detect direct IGC parsing instead of FlightTrackLoader usage
+   - Look for state management anti-patterns
+   - Identify missing error handling or try-catch blocks
+   - Find opportunities for const constructor usage
+   - Detect potential race conditions or async issues
+
+5. **Log Pattern Recognition:**
+   - Standard format: [Level][Time] Message | at=file:line
+   - Structured logs: [TAG] key=value pairs
+   - Performance logs: [P][Time] Operation | duration | details
+   - Error logs: [E][Time] Error message | error details | stack trace
+
+6. **Output Format:**
+   Your analysis must be structured as follows:
+   
+   **ERRORS FOUND:** (if any)
+   - Error Type: [Description]
+     Location: [file:line if available]
+     Impact: [High/Medium/Low]
+     Fix: [Specific action to resolve]
+   
+   **PERFORMANCE ISSUES:** (if any)
+   - Issue: [Description with measured time]
+     Threshold Exceeded: [Expected vs Actual]
+     Location: [Where it occurred]
+     Optimization: [Specific improvement suggestion]
+   
+   **PROCESS IMPROVEMENTS:** (if any)
+   - Pattern: [Anti-pattern or improvement opportunity]
+     Current: [What's being done]
+     Recommended: [Better approach]
+     Benefit: [Why this matters]
+   
+   **SUMMARY:**
+   - Total Issues: [Count by category]
+   - Priority Actions: [Top 3 most important fixes]
+   - Health Status: [Good/Warning/Critical]
+
+7. **Analysis Guidelines:**
+   - Be specific with file locations and line numbers when available
+   - Provide actionable fixes, not generic advice
+   - Prioritize issues by impact on user experience
+   - Consider the project's coding standards from CLAUDE.md
+   - Reference specific Flutter/Dart best practices
+   - If logs appear healthy, explicitly state "No significant issues detected"
+
+8. **Special Considerations:**
+   - Flutter readiness indicators: Check for "Flutter is ready" messages
+   - Hot reload success/failure patterns
+   - Database migration or schema issues
+   - WebView constraints and JavaScript errors
+   - State corruption indicators requiring hot restart
+
+When analyzing logs, you must be thorough but concise, focusing on actionable insights that will improve application stability and performance. Always provide specific remediation steps rather than general observations.

--- a/free_flight_log_app/documentation/OPENAIP_API_STRUCTURE.md
+++ b/free_flight_log_app/documentation/OPENAIP_API_STRUCTURE.md
@@ -1,6 +1,7 @@
 # OpenAIP Airspace API JSON Structure
 
-This document describes the JSON structure returned by the OpenAIP Core API v1 airspaces endpoint.
+This document describes the JSON structure returned by the OpenAIP 
+Core API v1 airspaces endpoint.
 
 ## API Response Structure
 
@@ -26,7 +27,7 @@ Each airspace in the `items` array contains 22 properties:
   - Examples: "PERTH CTA C1", "JANDAKOT CONTROL ZONE (D)", "PERTH CENTRE"
 - `country`: ISO country code (string)
   - Example: "AU" (Australia)
-- `type`: Numeric airspace type code (integer)
+- `type`: Numeric airspace type code (integer 0 - 36)
   - `0`: Unknown
   - `1`: Restricted
   - `2`: Danger
@@ -37,38 +38,52 @@ Each airspace in the `items` array contains 22 properties:
   - `26`: CTA
 
 ### ICAO Classification System
-- `icaoClass`: Numeric ICAO airspace class code (integer)
-  - `0`: A 
+- `icaoClass`: Numeric ICAO airspace class code (integer 0-6, 8)
+  - `0`: A
   - `1`: B
   - `2`: C
   - `3`: D
   - `4`: E
   - `5`: F
-  - `6`: G 
+  - `6`: G
   - `8`: None
 
 **Note**: `icaoClass: 8` indicates the airspace has no ICAO class assigned in the OpenAIP system, not missing data.
 
-### ICAP Airspace Classifications Explainations
+### ICAO Airspace Classifications Explanations
 
-ICAO classifies airspace into seven classes (A through G) to provide different levels of air traffic s:w!ervices and separation. The classes range from highly controlled Class A to uncontrolled Class G:
+OpenAIP uses International Civil Aviation Organization (ICAO) classifications. THese classify airspace into seven classes (A through G) to provide different levels of air traffic services and separation. The classes range from highly controlled Class A to uncontrolled Class G:
 
-- **Class A**: IFR only. All flights receive air traffic control service and are separated from all other traffic.
+#### Controlled Airspace (Classes A-E)
 
-- **Class B**: IFR and VFR permitted. All flights receive air traffic control service and are separated from all other traffic.
+- **Class A**: High-level, restrictive airspace primarily for commercial and passenger jets, requiring advanced IFR clearance. IFR only. All flights receive air traffic control service and are separated from all other traffic.
 
-- **Class C**: IFR and VFR permitted. All flights receive air traffic control service. IFR flights are separated from other IFR and VFR flights. VFR flights are separated from IFR flights and receive traffic information on other VFR flights.
+- **Class B**: Airspace surrounding major airports, with specific requirements for IFR and VFR flight, including clearance and ATC services. IFR and VFR permitted. All flights receive air traffic control service and are separated from all other traffic.
 
-- **Class D**: IFR and VFR permitted. All flights receive air traffic control service. IFR flights are separated from other IFR flights and receive traffic information on VFR flights. VFR flights receive traffic information on all other traffic.
+- **Class C**: Airspace surrounding major airports, with specific requirements for IFR and VFR flight, including clearance and ATC services. IFR and VFR permitted. All flights receive air traffic control service. IFR flights are separated from other IFR and VFR flights. VFR flights are separated from IFR flights and receive traffic information on other VFR flights.
 
-- **Class E**: IFR and VFR permitted. IFR flights receive air traffic control service and are separated from other IFR flights. All flights receive traffic information as far as practical. VFR flights do not receive separation service.
+- **Class D**: Airspace surrounding major airports, with specific requirements for IFR and VFR flight, including clearance and ATC services. IFR and VFR permitted. All flights receive air traffic control service. IFR flights are separated from other IFR flights and receive traffic information on VFR flights. VFR flights receive traffic information on all other traffic.
+
+- **Class E**: Mid-level, en route controlled airspace open to both IFR and VFR aircraft, with less stringent rules than lower classes. IFR and VFR permitted. IFR flights receive air traffic control service and are separated from other IFR flights. All flights receive traffic information as far as practical. VFR flights do not receive separation service.
+
+#### Uncontrolled Airspace (Classes F-G)
 
 - **Class F**: IFR and VFR permitted. IFR flights receive air traffic advisory service and all flights receive flight information service if requested. Class F is not implemented in many countries.
 
-- **Class G**: Uncontrolled airspace. Only flight information service provided if requested. No separation service provided.
+- **Class G**: Uncontrolled airspace where pilots are responsible for "see and avoid" and maintaining separation, as ATC services and separation are not provided. Only flight information service provided if requested. No separation service provided.
 
+#### Special Use Airspace (SUA)
 
+SUA areas have specific limitations or rules for safety, found on flight charts and including:
 
+- **Prohibited Areas**: Flight is forbidden.
+- **Restricted Areas**: Flight is restricted and requires permission to enter.
+- **Warning Areas**: Areas with a high volume of military activity but do not pose the same danger as restricted areas.
+- **Military Operations Areas (MOAs)**: Used to separate military flight training from civilian air traffic.
+- **Alert Areas**: Areas with a high volume of pilot activity, though not necessarily dangerous.
+- **Controlled Firing Areas (CFAs)**: Areas where activities, like firing, pose a potential hazard and can be temporarily suspended to permit VFR flight.
+
+OpenAIP data includes details on the specific characteristics of each airspace, including its boundaries, altitudes, and operational times to ensure safe and efficient flight.
 
 ### Altitude Limits Structure
 Both `lowerLimit` and `upperLimit` are objects with identical structure:
@@ -90,18 +105,6 @@ Both `lowerLimit` and `upperLimit` are objects with identical structure:
 - `1`: Above Mean Sea Level (AMSL)
 - `2`: Standard/Flight Level (STD)
 
-#### Common Altitude Combinations (Perth Area)
-- GND (0/0) to 1500 ft AMSL (1500/1/1)
-- GND (0/0) to FL999 (999/6/2)
-- 1500 ft AMSL to 2000 ft AMSL
-- 2000 ft AMSL to 3500 ft AMSL
-- 3500 ft AMSL to 4500 ft AMSL
-- 4500 ft AMSL to 8500 ft AMSL
-- 8500 ft AMSL to FL125
-- FL125 to FL180
-- FL125 to FL245
-- FL180 to FL245
-- FL245 to FL600
 
 ### Operational Status Flags
 All boolean flags in the Perth dataset are `false`:
@@ -123,37 +126,16 @@ All boolean flags in the Perth dataset are `false`:
 - `hoursOfOperation`: Operating hours if applicable (array/null)
 - `geometry`: GeoJSON geometry defining airspace boundaries (object)
 
-## Perth Area Airspace Examples
-
-Based on the sample data from coordinates (-32.1067, 115.8913):
-
-### Control Areas (CTA)
-- **PERTH CTA A**: Type 26, ICAO Class 0 (G), FL245-FL600
-- **PERTH CTA C1**: Type 26, ICAO Class 2 (E), FL125-FL245
-- **PERTH CTA C2**: Type 26, ICAO Class 2 (E), FL125-FL180
-- **PERTH CTA C4-C7**: Type 26, ICAO Class 2 (E), various FL ranges
-
-### Control Zones (CTR)
-- **JANDAKOT CONTROL ZONE (D)**: Type 4, ICAO Class 3 (D), GND-1500ft AMSL
-
-### Terminal Areas
-- **PERTH/JANDAKOT**: Type 6, ICAO Class 8 (No class), 1500-2000ft AMSL
-
-### Centers
-- **PERTH CENTRE**: Type 0, ICAO Class 4 (C), 8500ft-FL125
-- **CONTINENTAL AUSTRALIA CTA E1**: Type 0, ICAO Class 4 (C), FL180-FL245
-
 ## Implementation Notes
 
-1. **Type Mapping**: The numeric type codes need to be mapped to aviation standard abbreviations (CTR, CTA, TMA, etc.)
+1. **Type Mapping**: The numeric type codes need to be mapped to aviation standard abbreviations (CTR, CTA, TMA, etc.) If there isn't a mapping, show the numerical value.
 
-2. **ICAO Class Display**: Use the numeric `icaoClass` code to determine the class letter (A-G), with code 8 meaning no class assigned.
 
-3. **Altitude Conversion**: Flight levels (unit=6) represent hundreds of feet (FL125 = 12,500ft), while feet (unit=1) are direct values.
+2. **Altitude Conversion**: Flight levels (unit=6) represent hundreds of feet (FL125 = 12,500ft), while feet (unit=1) are direct values.
 
-4. **Reference Datum**: Ground reference (referenceDatum=0) with value=0 should display as "GND".
+3. **Reference Datum**: Ground reference (referenceDatum=0) with value=0 should display as "GND".
 
-5. **Sorting**: For altitude-based sorting, convert all altitudes to a common unit (feet) using the conversion rules.
+4. **Sorting**: For altitude-based sorting, convert all altitudes to a common unit (feet) using the conversion rules.
 
 ## API Access
 
@@ -167,6 +149,7 @@ Based on the sample data from coordinates (-32.1067, 115.8913):
 The OpenAIP `/airspaces` endpoint uses both numeric type codes and standard aviation abbreviations. Below are the complete airspace classifications:
 
 ### ATS Airspace Types
+
 - **CTR** - Control Zone/Controlled Tower Region (airport control zone)
 - **TMA** - Terminal Maneuvering Area (terminal control area)
 - **FIR** - Flight Information Region
@@ -176,6 +159,7 @@ The OpenAIP `/airspaces` endpoint uses both numeric type codes and standard avia
 - **MATZ** - Military Aerodrome Traffic Zone
 
 ### Special Use Airspace
+
 - **DANGER** or **D** - Danger Area (hazardous activities)
 - **RESTRICTED** or **R** - Restricted Area (entry restricted)
 - **PROHIBITED** or **P** - Prohibited Area (flight forbidden)

--- a/free_flight_log_app/documentation/OPENAIP_API_STRUCTURE.md
+++ b/free_flight_log_app/documentation/OPENAIP_API_STRUCTURE.md
@@ -28,14 +28,43 @@ Each airspace in the `items` array contains 22 properties:
 - `country`: ISO country code (string)
   - Example: "AU" (Australia)
 - `type`: Numeric airspace type code (integer 0 - 36)
-  - `0`: Unknown
+  - `0`: Other
   - `1`: Restricted
   - `2`: Danger
-  - `4`: CTR
-  - `6`: TMA
-  - `7`: TMA
-  - `10`: FIR
-  - `26`: CTA
+  - `3`: Prohibited
+  - `4`: Controlled Tower Region (CTR)
+  - `5`: Transponder Mandatory Zone (TMZ)
+  - `6`: Radio Mandatory Zone (RMZ)
+  - `7`: Terminal Maneuvering Area (TMA)
+  - `8`: Temporary Reserved Area (TRA)
+  - `9`: Temporary Segregated Area (TSA)
+  - `10`: Flight Information Region (FIR)
+  - `11`: Upper Flight Information Region (UIR)
+  - `12`: Air Defense Identification Zone (ADIZ)
+  - `13`: Airport Traffic Zone (ATZ)
+  - `14`: Military Airport Traffic Zone (MATZ)
+  - `15`: Airway
+  - `16`: Military Training Route (MTR)
+  - `17`: Alert Area
+  - `18`: Warning Area
+  - `19`: Protected Area
+  - `20`: Helicopter Traffic Zone (HTZ)
+  - `21`: Gliding Sector
+  - `22`: Transponder Setting (TRP)
+  - `23`: Traffic Information Zone (TIZ)
+  - `24`: Traffic Information Area (TIA)
+  - `25`: Military Training Area (MTA)
+  - `26`: Control Area (CTA)
+  - `27`: ACC Sector (ACC)
+  - `28`: Aerial Sporting Or Recreational Activity
+  - `29`: Low Altitude Overflight Restriction
+  - `30`: Military Route (MRT)
+  - `31`: TSA/TRA Feeding Route (TFR)
+  - `32`: VFR Sector
+  - `33`: FIS Sector
+  - `34`: Lower Traffic Area (LTA)
+  - `35`: Upper Traffic Area (UTA)
+  - `36`: Military Controlled Tower Region (MCTR)
 
 ### ICAO Classification System
 - `icaoClass`: Numeric ICAO airspace class code (integer 0-6, 8)

--- a/free_flight_log_app/lib/data/models/airspace_enums.dart
+++ b/free_flight_log_app/lib/data/models/airspace_enums.dart
@@ -1,0 +1,144 @@
+/// Enum definitions for OpenAIP airspace types and ICAO classes
+/// Provides type safety and centralized mapping for airspace data
+
+/// OpenAIP airspace type classifications
+/// Based on OpenAIP Core API documentation
+enum AirspaceType {
+  other(0, 'Other', 'Unknown/Other', 'Other airspace type'),
+  restricted(1, 'R', 'Restricted', 'Restricted Area - entry restricted'),
+  danger(2, 'D', 'Danger', 'Danger Area - hazardous activities'),
+  prohibited(3, 'P', 'Prohibited', 'Prohibited Area - flight forbidden'),
+  ctr(4, 'CTR', 'Control Zone', 'Controlled Tower Region (airport control zone)'),
+  tmz(5, 'TMZ', 'TMZ', 'Transponder Mandatory Zone'),
+  rmz(6, 'RMZ', 'RMZ', 'Radio Mandatory Zone'),
+  tma(7, 'TMA', 'Terminal Area', 'Terminal Maneuvering Area (terminal control area)'),
+  tra(8, 'TRA', 'TRA', 'Temporary Reserved Area'),
+  tsa(9, 'TSA', 'TSA', 'Temporary Segregated Area'),
+  fir(10, 'FIR', 'Flight Info Region', 'Flight Information Region'),
+  uir(11, 'UIR', 'UIR', 'Upper Flight Information Region'),
+  adiz(12, 'ADIZ', 'ADIZ', 'Air Defense Identification Zone'),
+  atz(13, 'ATZ', 'ATZ', 'Airport Traffic Zone'),
+  matz(14, 'MATZ', 'MATZ', 'Military Airport Traffic Zone'),
+  airway(15, 'AWY', 'Airway', 'Airway'),
+  mtr(16, 'MTR', 'MTR', 'Military Training Route'),
+  alert(17, 'A', 'Alert', 'Alert Area'),
+  warning(18, 'W', 'Warning', 'Warning Area'),
+  protected(19, 'PROT', 'Protected', 'Protected Area'),
+  htz(20, 'HTZ', 'HTZ', 'Helicopter Traffic Zone'),
+  gliding(21, 'GLIDING', 'Gliding', 'Gliding Sector'),
+  trp(22, 'TRP', 'TRP', 'Transponder Setting'),
+  tiz(23, 'TIZ', 'TIZ', 'Traffic Information Zone'),
+  tia(24, 'TIA', 'TIA', 'Traffic Information Area'),
+  mta(25, 'MTA', 'MTA', 'Military Training Area'),
+  cta(26, 'CTA', 'Control Area', 'Control Area'),
+  acc(27, 'ACC', 'ACC', 'ACC Sector'),
+  sport(28, 'SPORT', 'Sport/Recreation', 'Aerial Sporting Or Recreational Activity'),
+  lowAltRestriction(29, 'LAR', 'Low Alt Restriction', 'Low Altitude Overflight Restriction'),
+  militaryRoute(30, 'MRT', 'Military Route', 'Military Route'),
+  tfr(31, 'TFR', 'TFR', 'TSA/TRA Feeding Route'),
+  vfrSector(32, 'VFR', 'VFR Sector', 'VFR Sector'),
+  fisSector(33, 'FIS', 'FIS Sector', 'FIS Sector'),
+  lta(34, 'LTA', 'LTA', 'Lower Traffic Area'),
+  uta(35, 'UTA', 'UTA', 'Upper Traffic Area'),
+  mctr(36, 'MCTR', 'MCTR', 'Military Controlled Tower Region');
+
+  const AirspaceType(this.code, this.abbreviation, this.displayName, this.description);
+
+  final int code;
+  final String abbreviation;
+  final String displayName;
+  final String description;
+
+  /// Convert from OpenAIP numeric code to enum
+  static AirspaceType fromCode(int code) {
+    for (final type in AirspaceType.values) {
+      if (type.code == code) return type;
+    }
+    return AirspaceType.other; // Default to other for unknown codes
+  }
+
+  /// Get all types that should be hidden by default (large coverage areas)
+  static Set<AirspaceType> get defaultHiddenTypes => {
+    AirspaceType.fir,
+    AirspaceType.uir,
+    AirspaceType.other,
+  };
+
+  /// Check if this type should be hidden by default
+  bool get isHiddenByDefault => defaultHiddenTypes.contains(this);
+}
+
+/// ICAO airspace class classifications
+/// Based on International Civil Aviation Organization standards
+enum IcaoClass {
+  classA(0, 'A', 'Class A', 'IFR only. All flights receive ATC service and separation'),
+  classB(1, 'B', 'Class B', 'IFR/VFR. All flights receive ATC service and separation'),
+  classC(2, 'C', 'Class C', 'IFR/VFR. All receive ATC, IFR separated from all'),
+  classD(3, 'D', 'Class D', 'IFR/VFR. All receive ATC, IFR separated from IFR only'),
+  classE(4, 'E', 'Class E', 'IFR/VFR. IFR receives ATC service and separation'),
+  classF(5, 'F', 'Class F', 'IFR/VFR. Advisory service, not widely implemented'),
+  classG(6, 'G', 'Class G', 'Uncontrolled airspace, flight information only'),
+  none(8, 'None', 'No Class', 'No ICAO class assigned in the OpenAIP system');
+
+  const IcaoClass(this.code, this.abbreviation, this.displayName, this.description);
+
+  final int code;
+  final String abbreviation;
+  final String displayName;
+  final String description;
+
+  /// Convert from OpenAIP numeric code to enum
+  static IcaoClass? fromCode(int? code) {
+    if (code == null) return null;
+    for (final icaoClass in IcaoClass.values) {
+      if (icaoClass.code == code) return icaoClass;
+    }
+    return IcaoClass.none; // Default to none for unknown codes
+  }
+
+  /// Get all classes that should be hidden by default
+  static Set<IcaoClass> get defaultHiddenClasses => {
+    IcaoClass.classA, // High altitude, primarily commercial
+    IcaoClass.classE, // Less critical for VFR
+    IcaoClass.classF, // Not widely implemented
+  };
+
+  /// Check if this class should be hidden by default
+  bool get isHiddenByDefault => defaultHiddenClasses.contains(this);
+}
+
+/// Extension methods for easier use in UI components
+extension AirspaceTypeExtension on AirspaceType {
+  /// Get tooltip message for UI display
+  String get tooltip => '$displayName - $description';
+
+  /// Get color-coded priority for rendering order (lower = render on top)
+  int get renderPriority {
+    switch (this) {
+      case AirspaceType.prohibited:
+      case AirspaceType.danger:
+        return 1; // Highest priority (most critical)
+      case AirspaceType.restricted:
+        return 2;
+      case AirspaceType.ctr:
+      case AirspaceType.atz:
+        return 3;
+      case AirspaceType.tma:
+      case AirspaceType.cta:
+        return 4;
+      case AirspaceType.tmz:
+      case AirspaceType.rmz:
+        return 5;
+      case AirspaceType.fir:
+      case AirspaceType.uir:
+        return 99; // Lowest priority (background)
+      default:
+        return 10;
+    }
+  }
+}
+
+extension IcaoClassExtension on IcaoClass {
+  /// Get tooltip message for UI display
+  String get tooltip => '$displayName - $description';
+}

--- a/free_flight_log_app/lib/presentation/screens/nearby_sites_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/nearby_sites_screen.dart
@@ -660,7 +660,8 @@ class _NearbySitesScreenState extends State<NearbySitesScreen> {
 
       // Refresh map to apply airspace filter changes
       setState(() {
-        _mapWidgetKey = UniqueKey();
+        // Just update state - don't reset the map widget key
+        // This preserves the map position and zoom level
       });
 
       LoggingService.structured('MAP_FILTER_APPLIED_SUCCESS', {
@@ -757,6 +758,7 @@ class _NearbySitesScreenState extends State<NearbySitesScreen> {
                               onShowMapFilter: _showMapFilterDialog,
                               hasActiveFilters: hasActiveFilters,
                               sitesEnabled: _sitesEnabled,
+                              maxAltitudeFt: _maxAltitudeFt,
                             );
                           },
                         ),

--- a/free_flight_log_app/lib/presentation/screens/nearby_sites_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/nearby_sites_screen.dart
@@ -79,6 +79,7 @@ class _NearbySitesScreenState extends State<NearbySitesScreen> {
   bool _sitesEnabled = true; // Controls site loading and display
   bool _airspaceEnabled = true; // Controls airspace loading and display
   double _maxAltitudeFt = 15000.0; // Default altitude filter
+  int _filterUpdateCounter = 0; // Increments when any filter changes to trigger map refresh
   final OpenAipService _openAipService = OpenAipService.instance;
   
 
@@ -660,7 +661,8 @@ class _NearbySitesScreenState extends State<NearbySitesScreen> {
 
       // Refresh map to apply airspace filter changes
       setState(() {
-        // Just update state - don't reset the map widget key
+        // Increment counter to trigger map overlay refresh
+        _filterUpdateCounter++;
         // This preserves the map position and zoom level
       });
 
@@ -759,6 +761,7 @@ class _NearbySitesScreenState extends State<NearbySitesScreen> {
                               hasActiveFilters: hasActiveFilters,
                               sitesEnabled: _sitesEnabled,
                               maxAltitudeFt: _maxAltitudeFt,
+                              filterUpdateCounter: _filterUpdateCounter,
                             );
                           },
                         ),

--- a/free_flight_log_app/lib/presentation/screens/nearby_sites_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/nearby_sites_screen.dart
@@ -17,8 +17,10 @@ import '../../utils/map_provider.dart';
 import '../../utils/site_utils.dart';
 import '../widgets/nearby_sites_map_widget.dart';
 import '../widgets/airspace_controls_widget.dart';
+import '../widgets/map_filter_dialog.dart';
 import '../widgets/common/app_error_state.dart';
 import '../widgets/common/app_empty_state.dart';
+import '../../services/openaip_service.dart';
 
 
 class NearbySitesScreen extends StatefulWidget {
@@ -72,6 +74,12 @@ class _NearbySitesScreenState extends State<NearbySitesScreen> {
   bool _showLocationNotification = false;
   Timer? _locationNotificationTimer;
   late final NearbySitesSearchManager _searchManager;
+
+  // Filter state for sites and airspace
+  bool _sitesEnabled = true; // Controls site loading and display
+  bool _airspaceEnabled = true; // Controls airspace loading and display
+  double _maxAltitudeFt = 15000.0; // Default altitude filter
+  final OpenAipService _openAipService = OpenAipService.instance;
   
 
   @override
@@ -427,6 +435,12 @@ class _NearbySitesScreenState extends State<NearbySitesScreen> {
 
   Future<void> _loadSitesForBounds(LatLngBounds bounds) async {
     if (_isLoadingSites) return;
+
+    // Skip loading sites if they're disabled
+    if (!_sitesEnabled) {
+      LoggingService.info('Sites loading skipped - sites disabled');
+      return;
+    }
     
     // Create a unique key for these bounds to prevent duplicate requests
     final boundsKey = '${bounds.north.toStringAsFixed(6)}_${bounds.south.toStringAsFixed(6)}_${bounds.east.toStringAsFixed(6)}_${bounds.west.toStringAsFixed(6)}';
@@ -440,14 +454,23 @@ class _NearbySitesScreenState extends State<NearbySitesScreen> {
     
     try {
       // 1. Load local sites from DB to check flight status
+      final dbStopwatch = Stopwatch()..start();
       final localSites = await _databaseService.getSitesInBounds(
         north: bounds.north,
         south: bounds.south,
         east: bounds.east,
         west: bounds.west,
       );
-      
+      dbStopwatch.stop();
+
+      LoggingService.performance(
+        'Sites DB Query',
+        Duration(milliseconds: dbStopwatch.elapsedMilliseconds),
+        'sites=${localSites.length}'
+      );
+
       // 2. Load API sites within bounds
+      final apiStopwatch = Stopwatch()..start();
       final apiSites = await _paraglidingEarthApi.getSitesInBounds(
         bounds.north,
         bounds.south,
@@ -455,6 +478,13 @@ class _NearbySitesScreenState extends State<NearbySitesScreen> {
         bounds.west,
         limit: 50,
         detailed: false,
+      );
+      apiStopwatch.stop();
+
+      LoggingService.performance(
+        'Sites API Fetch',
+        Duration(milliseconds: apiStopwatch.elapsedMilliseconds),
+        'sites=${apiSites.length}, bounds=${bounds.west},${bounds.south},${bounds.east},${bounds.north}'
       );
       
       // 3. For each local site, try to find its corresponding API data
@@ -546,72 +576,135 @@ class _NearbySitesScreenState extends State<NearbySitesScreen> {
     );
   }
 
-  /// Show airspace controls in a bottom sheet to avoid map gesture conflicts
-  void _showAirspaceControls() {
-    showModalBottomSheet(
-      context: context,
-      isScrollControlled: true,
-      backgroundColor: Colors.transparent,
-      builder: (context) => Container(
-        decoration: const BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+  /// Show map filter dialog
+  void _showMapFilterDialog() async {
+    try {
+      // Get current filter states
+      final airspaceTypes = await _openAipService.getEnabledAirspaceTypes();
+      final icaoClasses = await _openAipService.getEnabledIcaoClasses();
+
+      if (!mounted) return;
+
+      showDialog(
+        context: context,
+        barrierColor: Colors.black54,
+        builder: (context) => _DraggableFilterDialog(
+          sitesEnabled: _sitesEnabled,
+          airspaceEnabled: _airspaceEnabled,
+          airspaceTypes: airspaceTypes,
+          icaoClasses: icaoClasses,
+          maxAltitudeFt: _maxAltitudeFt,
+          mapProvider: _selectedMapProvider,
+          onApply: _handleFilterApply,
         ),
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Header
-            Row(
-              children: [
-                const Icon(Icons.airplanemode_active, color: Colors.blue),
-                const SizedBox(width: 8),
-                const Text(
-                  'Airspace Overlays',
-                  style: TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                const Spacer(),
-                IconButton(
-                  icon: const Icon(Icons.close),
-                  onPressed: () => Navigator.of(context).pop(),
-                ),
-              ],
-            ),
-            const SizedBox(height: 16),
-            
-            // Airspace controls widget in a container with dark background
-            Container(
-              decoration: BoxDecoration(
-                color: Colors.grey[900],
-                borderRadius: BorderRadius.circular(8),
-              ),
-              padding: const EdgeInsets.all(16),
-              child: AirspaceControlsWidget(
-                isExpanded: true, // Always expanded in bottom sheet
-                onToggleExpanded: () {}, // No-op since always expanded
-                onLayersChanged: () {
-                  // Refresh map layers when airspace settings change
-                  setState(() {
-                    // Generate new key to force map widget rebuild and reload airspace layers
-                    _mapWidgetKey = UniqueKey();
-                  });
-                  LoggingService.action('NearbySites', 'airspace_settings_changed', {
-                    'triggered_map_refresh': true,
-                  });
-                },
-              ),
-            ),
-            
-            // Bottom padding for safe area
-            SizedBox(height: MediaQuery.of(context).padding.bottom),
-          ],
-        ),
-      ),
-    );
+      );
+    } catch (error, stackTrace) {
+      LoggingService.error('Failed to show map filter dialog', error, stackTrace);
+    }
+  }
+
+  /// Handle filter apply from dialog
+  void _handleFilterApply(bool sitesEnabled, bool airspaceEnabled, Map<String, bool> types, Map<String, bool> classes, double maxAltitudeFt, MapProvider mapProvider) async {
+    try {
+      // Update filter states
+      final previousSitesEnabled = _sitesEnabled;
+      final previousAirspaceEnabled = _airspaceEnabled;
+      final previousMapProvider = _selectedMapProvider;
+
+      setState(() {
+        _sitesEnabled = sitesEnabled;
+        _airspaceEnabled = airspaceEnabled;
+        _maxAltitudeFt = maxAltitudeFt;
+        _selectedMapProvider = mapProvider;
+      });
+
+      // Handle sites visibility changes
+      if (!sitesEnabled && previousSitesEnabled) {
+        // Sites were disabled - clear displayed sites
+        setState(() {
+          _displayedSites.clear();
+          _allSites.clear();
+        });
+        LoggingService.action('MapFilter', 'sites_disabled', {'cleared_sites_count': _displayedSites.length});
+      } else if (sitesEnabled && !previousSitesEnabled) {
+        // Sites were enabled - reload sites for current bounds or trigger map refresh
+        if (_currentBounds != null) {
+          _loadSitesForBounds(_currentBounds!);
+        }
+        LoggingService.action('MapFilter', 'sites_enabled', {'reloading_sites': true, 'has_bounds': _currentBounds != null});
+      }
+
+      // Handle airspace visibility changes
+      if (airspaceEnabled) {
+        // Enable airspace and update filters
+        await _openAipService.setAirspaceEnabled(true);
+        await _openAipService.setEnabledAirspaceTypes(types);
+        await _openAipService.setEnabledIcaoClasses(classes);
+
+        if (!previousAirspaceEnabled) {
+          LoggingService.action('MapFilter', 'airspace_enabled');
+        }
+      } else if (!airspaceEnabled) {
+        // Disable airspace completely
+        await _openAipService.setAirspaceEnabled(false);
+        if (previousAirspaceEnabled) {
+          LoggingService.action('MapFilter', 'airspace_disabled');
+        }
+      }
+
+      // Handle map provider changes
+      if (mapProvider != previousMapProvider) {
+        await _saveMapProviderPreference(mapProvider);
+        LoggingService.action('MapFilter', 'map_provider_changed', {'provider': mapProvider.displayName});
+      }
+
+      // Refresh map to apply airspace filter changes
+      setState(() {
+        _mapWidgetKey = UniqueKey();
+      });
+
+      LoggingService.structured('MAP_FILTER_APPLIED_SUCCESS', {
+        'sites_enabled': sitesEnabled,
+        'airspace_enabled': airspaceEnabled,
+        'sites_changed': sitesEnabled != previousSitesEnabled,
+        'airspace_changed': airspaceEnabled != previousAirspaceEnabled,
+        'map_provider_changed': mapProvider != previousMapProvider,
+        'selected_types': types.values.where((v) => v).length,
+        'selected_classes': classes.values.where((v) => v).length,
+        'max_altitude_ft': maxAltitudeFt,
+        'map_provider': mapProvider.displayName,
+      });
+    } catch (error, stackTrace) {
+      LoggingService.error('Failed to apply map filters', error, stackTrace);
+    }
+  }
+
+  /// Save map provider preference
+  Future<void> _saveMapProviderPreference(MapProvider provider) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setInt(_mapProviderKey, provider.index);
+    } catch (e) {
+      LoggingService.error('Failed to save map provider preference', e);
+    }
+  }
+
+  /// Check if filters are currently active (for FAB indicator)
+  Future<bool> _hasActiveFilters() async {
+    try {
+      // Check if any airspace types or classes are disabled from defaults
+      final types = await _openAipService.getEnabledAirspaceTypes();
+      final classes = await _openAipService.getEnabledIcaoClasses();
+
+      // Consider filters active if any type/class is disabled or sites are disabled
+      final hasDisabledTypes = types.values.contains(false);
+      final hasDisabledClasses = classes.values.contains(false);
+
+      return !_sitesEnabled || hasDisabledTypes || hasDisabledClasses;
+    } catch (error) {
+      LoggingService.error('Failed to check active filters', error);
+      return false; // Assume no active filters on error
+    }
   }
 
   @override
@@ -619,14 +712,6 @@ class _NearbySitesScreenState extends State<NearbySitesScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Nearby Sites'),
-        actions: [
-          // Airspace controls - moved to app bar to avoid map gesture conflicts
-          IconButton(
-            icon: const Icon(Icons.airplanemode_active),
-            onPressed: _showAirspaceControls,
-            tooltip: 'Airspace overlays',
-          ),
-        ],
       ),
       body: Stack(
         children: [
@@ -641,30 +726,38 @@ class _NearbySitesScreenState extends State<NearbySitesScreen> {
                 : Stack(
                       children: [
                         // Map
-                        NearbySitesMapWidget(
-                          key: _mapWidgetKey, // Force rebuild when airspace settings change
-                          sites: _displayedSites,
-                          siteFlightStatus: _siteFlightStatus,
-                          userPosition: _userPosition,
-                          centerPosition: _mapCenterPosition,
-                          boundsToFit: _boundsToFit,
-                          initialZoom: _mapZoom,
-                          mapProvider: _selectedMapProvider,
-                          isLegendExpanded: _isLegendExpanded,
-                          onToggleLegend: _toggleLegend,
-                          onMapProviderChanged: _selectMapProvider,
-                          onSiteSelected: _onSiteSelected,
-                          onBoundsChanged: _onBoundsChanged,
-                          searchQuery: _searchManager.state.query,
-                          onSearchChanged: _searchManager.onSearchQueryChanged,
-                          onRefreshLocation: _onRefreshLocation,
-                          isLocationLoading: _isLocationLoading,
-                          searchResults: _searchManager.state.results,
-                          isSearching: _searchManager.state.isSearching,
-                          onSearchResultSelected: (site) {
-                            _searchManager.selectSearchResult(site);
-                            // Also jump to location for smooth UX
-                            _jumpToLocation(site);
+                        FutureBuilder<bool>(
+                          future: _hasActiveFilters(),
+                          builder: (context, snapshot) {
+                            final hasActiveFilters = snapshot.data ?? false;
+                            return NearbySitesMapWidget(
+                              key: _mapWidgetKey, // Force rebuild when airspace settings change
+                              sites: _displayedSites,
+                              siteFlightStatus: _siteFlightStatus,
+                              userPosition: _userPosition,
+                              centerPosition: _mapCenterPosition,
+                              boundsToFit: _boundsToFit,
+                              initialZoom: _mapZoom,
+                              mapProvider: _selectedMapProvider,
+                              isLegendExpanded: _isLegendExpanded,
+                              onToggleLegend: _toggleLegend,
+                                              onSiteSelected: _onSiteSelected,
+                              onBoundsChanged: _onBoundsChanged,
+                              searchQuery: _searchManager.state.query,
+                              onSearchChanged: _searchManager.onSearchQueryChanged,
+                              onRefreshLocation: _onRefreshLocation,
+                              isLocationLoading: _isLocationLoading,
+                              searchResults: _searchManager.state.results,
+                              isSearching: _searchManager.state.isSearching,
+                              onSearchResultSelected: (site) {
+                                _searchManager.selectSearchResult(site);
+                                // Also jump to location for smooth UX
+                                _jumpToLocation(site);
+                              },
+                              onShowMapFilter: _showMapFilterDialog,
+                              hasActiveFilters: hasActiveFilters,
+                              sitesEnabled: _sitesEnabled,
+                            );
                           },
                         ),
                         
@@ -830,6 +923,7 @@ class _NearbySitesScreenState extends State<NearbySitesScreen> {
                 ),
               ),
             ),
+
         ],
       ),
     );
@@ -1554,8 +1648,74 @@ class _SiteDetailsDialogState extends State<_SiteDetailsDialog> with SingleTicke
       }
     });
     
-    return characteristics.isNotEmpty 
+    return characteristics.isNotEmpty
         ? characteristics.join(', ')
         : 'Site information';
+  }
+}
+
+/// Draggable dialog widget for the map filter
+class _DraggableFilterDialog extends StatefulWidget {
+  final bool sitesEnabled;
+  final bool airspaceEnabled;
+  final Map<String, bool> airspaceTypes;
+  final Map<String, bool> icaoClasses;
+  final double maxAltitudeFt;
+  final MapProvider mapProvider;
+  final Function(bool sitesEnabled, bool airspaceEnabled, Map<String, bool> types, Map<String, bool> classes, double maxAltitudeFt, MapProvider mapProvider) onApply;
+
+  const _DraggableFilterDialog({
+    required this.sitesEnabled,
+    required this.airspaceEnabled,
+    required this.airspaceTypes,
+    required this.icaoClasses,
+    required this.maxAltitudeFt,
+    required this.mapProvider,
+    required this.onApply,
+  });
+
+  @override
+  State<_DraggableFilterDialog> createState() => _DraggableFilterDialogState();
+}
+
+class _DraggableFilterDialogState extends State<_DraggableFilterDialog> {
+  late Offset _position = const Offset(16, 80); // Start in top-left
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        // Positioned dialog
+        Positioned(
+          left: _position.dx,
+          top: _position.dy,
+          child: GestureDetector(
+            onPanUpdate: (details) {
+              setState(() {
+                _position += details.delta;
+                // Keep dialog within screen bounds
+                final screenSize = MediaQuery.of(context).size;
+                _position = Offset(
+                  _position.dx.clamp(0, screenSize.width - 300), // Assume dialog width ~300
+                  _position.dy.clamp(0, screenSize.height - 400), // Assume dialog height ~400
+                );
+              });
+            },
+            child: Material(
+              color: Colors.transparent,
+              child: MapFilterDialog(
+                sitesEnabled: widget.sitesEnabled,
+                airspaceEnabled: widget.airspaceEnabled,
+                airspaceTypes: widget.airspaceTypes,
+                icaoClasses: widget.icaoClasses,
+                maxAltitudeFt: widget.maxAltitudeFt,
+                mapProvider: widget.mapProvider,
+                onApply: widget.onApply,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
   }
 }

--- a/free_flight_log_app/lib/presentation/widgets/airspace_controls_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/airspace_controls_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../services/openaip_service.dart';
 import '../../services/logging_service.dart';
+import '../../data/models/airspace_enums.dart';
 
 /// Widget for controlling OpenAIP airspace overlay layers
 class AirspaceControlsWidget extends StatefulWidget {
@@ -31,7 +32,7 @@ class _AirspaceControlsWidgetState extends State<AirspaceControlsWidget> {
   bool _hasApiKey = false;
 
   // Individual airspace type states
-  Map<String, bool> _airspaceTypes = {};
+  Map<AirspaceType, bool> _airspaceTypes = {};
   bool _airspaceTypesExpanded = false;
 
   bool _loading = true;
@@ -152,12 +153,18 @@ class _AirspaceControlsWidgetState extends State<AirspaceControlsWidget> {
 
   Future<void> _updateAirspaceTypeEnabled(String type, bool enabled) async {
     try {
-      await _openAipService.setAirspaceTypeEnabled(type, enabled);
+      // Convert string abbreviation to AirspaceType enum
+      final airspaceType = AirspaceType.values.firstWhere(
+        (t) => t.abbreviation == type,
+        orElse: () => AirspaceType.other,
+      );
+
+      await _openAipService.setAirspaceTypeEnabled(airspaceType, enabled);
 
       // Update local state
       if (mounted) {
         setState(() {
-          _airspaceTypes[type] = enabled;
+          _airspaceTypes[airspaceType] = enabled;
         });
 
         // Defer parent callback to avoid re-entrancy during gesture handling
@@ -677,7 +684,12 @@ class _AirspaceControlsWidgetState extends State<AirspaceControlsWidget> {
 
   /// Build individual airspace type toggle
   Widget _buildAirspaceTypeToggle(String type, String description, Color color) {
-    final isEnabled = _airspaceTypes[type] ?? false;
+    // Convert string abbreviation to AirspaceType enum
+    final airspaceType = AirspaceType.values.firstWhere(
+      (t) => t.abbreviation == type,
+      orElse: () => AirspaceType.other,
+    );
+    final isEnabled = _airspaceTypes[airspaceType] ?? false;
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 1),

--- a/free_flight_log_app/lib/presentation/widgets/airspace_tooltip_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/airspace_tooltip_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../services/airspace_geojson_service.dart';
+import '../../data/models/airspace_enums.dart';
 
 /// Widget that displays airspace information in a floating tooltip
 /// Positioned near the cursor/touch location on the map
@@ -210,7 +211,7 @@ class AirspaceTooltipWidget extends StatelessWidget {
   /// Build individual airspace information item (compact 2-line format)
   Widget _buildAirspaceItem(AirspaceData airspace) {
     // Get type-specific styling
-    final style = AirspaceGeoJsonService.instance.getStyleForType(_getTypeAbbreviation(airspace.type));
+    final style = AirspaceGeoJsonService.instance.getStyleForType(airspace.type);
 
     // Format compact details line (type, altitude, country)
     final String compactDetails = _formatCompactDetails(airspace);
@@ -303,9 +304,9 @@ class AirspaceTooltipWidget extends StatelessWidget {
                     fontSize: 12,
                     fontWeight: FontWeight.w400,
                   ),
-                  message: _getTypeTooltip(airspace.type),
+                  message: airspace.type.tooltip,
                   child: Text(
-                    '${_getTypeMappedString(airspace.type)},',
+                    '${airspace.type.abbreviation},',
                     style: TextStyle(
                       color: Colors.white.withValues(alpha: 0.85),
                       fontSize: 10,
@@ -315,7 +316,7 @@ class AirspaceTooltipWidget extends StatelessWidget {
                 ),
 
                 // ICAO class with mapping and tooltip (if available)
-                if (airspace.icaoClass != null && _getIcaoClassMappedString(airspace.icaoClass).isNotEmpty) ...[
+                if (airspace.icaoClass != null && airspace.icaoClass != IcaoClass.none) ...[
                   const SizedBox(width: 6),
                   Tooltip(
                     preferBelow: false,
@@ -330,9 +331,9 @@ class AirspaceTooltipWidget extends StatelessWidget {
                       fontSize: 12,
                       fontWeight: FontWeight.w400,
                     ),
-                    message: _getIcaoClassTooltip(airspace.icaoClass),
+                    message: airspace.icaoClass!.tooltip,
                     child: Text(
-                      '${_getIcaoClassMappedString(airspace.icaoClass)},',
+                      '${airspace.icaoClass!.abbreviation},',
                       style: TextStyle(
                         color: Colors.white.withValues(alpha: 0.85),
                         fontSize: 10,
@@ -456,13 +457,11 @@ class AirspaceTooltipWidget extends StatelessWidget {
     final parts = <String>[];
 
     // Add type abbreviation
-    final typeAbbrev = _getTypeAbbreviation(airspace.type);
-    parts.add(typeAbbrev);
+    parts.add(airspace.type.abbreviation);
 
     // Add ICAO class abbreviation if available
-    final icaoClassAbbrev = _getIcaoClassAbbreviation(airspace.icaoClass);
-    if (icaoClassAbbrev.isNotEmpty) {
-      parts.add(icaoClassAbbrev);
+    if (airspace.icaoClass != null && airspace.icaoClass != IcaoClass.none) {
+      parts.add(airspace.icaoClass!.abbreviation);
     }
 
     // Add altitude range with units

--- a/free_flight_log_app/lib/presentation/widgets/airspace_tooltip_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/airspace_tooltip_widget.dart
@@ -210,8 +210,8 @@ class AirspaceTooltipWidget extends StatelessWidget {
 
   /// Build individual airspace information item (compact 2-line format)
   Widget _buildAirspaceItem(AirspaceData airspace) {
-    // Get type-specific styling
-    final style = AirspaceGeoJsonService.instance.getStyleForType(airspace.type);
+    // Get ICAO class-based styling (prioritizes ICAO class over type)
+    final style = AirspaceGeoJsonService.instance.getStyleForAirspace(airspace);
 
     // Format compact details line (type, altitude, country)
     final String compactDetails = _formatCompactDetails(airspace);
@@ -221,70 +221,51 @@ class AirspaceTooltipWidget extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // Line 1: Airspace name with type indicator
+          // Line 1: Airspace name with visibility indicator
           Row(
             children: [
-              // Type color indicator
-              Container(
-                width: 10,
-                height: 6,
+              // Visibility status indicator (moved from right to left)
+              Tooltip(
+                preferBelow: false,
+                message: airspace.isCurrentlyFiltered
+                  ? 'This airspace is currently hidden on map'
+                  : 'This airspace is visible on map',
                 decoration: BoxDecoration(
-                  color: style.fillColor,
-                  border: Border.all(
-                    color: style.borderColor,
-                    width: 1,
+                  color: const Color(0xE6000000),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: Colors.white.withValues(alpha: 0.2)),
+                ),
+                textStyle: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w400,
+                ),
+                child: Container(
+                  padding: const EdgeInsets.all(2),
+                  child: Icon(
+                    airspace.isCurrentlyFiltered
+                      ? Icons.visibility_off
+                      : Icons.visibility,
+                    size: 12,
+                    color: airspace.isCurrentlyFiltered
+                      ? Colors.orange.withValues(alpha: 0.8)
+                      : Colors.green.withValues(alpha: 0.8),
                   ),
-                  borderRadius: BorderRadius.circular(2),
                 ),
               ),
               const SizedBox(width: 6),
 
-              // Airspace name with filter indicator
+              // Airspace name
               Expanded(
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: Text(
-                        airspace.name,
-                        style: TextStyle(
-                          color: airspace.isCurrentlyFiltered ? Colors.grey : Colors.white,
-                          fontSize: 12,
-                          fontWeight: FontWeight.w600,
-                        ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                    // Filter status indicator (always shown)
-                    Tooltip(
-                      preferBelow: false,
-                      message: airspace.isCurrentlyFiltered
-                        ? 'This airspace is currently hidden on map'
-                        : 'This airspace is visible on map',
-                      decoration: BoxDecoration(
-                        color: const Color(0xE6000000),
-                        borderRadius: BorderRadius.circular(8),
-                        border: Border.all(color: Colors.white.withValues(alpha: 0.2)),
-                      ),
-                      textStyle: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 12,
-                        fontWeight: FontWeight.w400,
-                      ),
-                      child: Container(
-                        padding: const EdgeInsets.all(2),
-                        child: Icon(
-                          airspace.isCurrentlyFiltered
-                            ? Icons.visibility_off
-                            : Icons.visibility,
-                          size: 12,
-                          color: airspace.isCurrentlyFiltered
-                            ? Colors.orange.withValues(alpha: 0.8)
-                            : Colors.green.withValues(alpha: 0.8),
-                        ),
-                      ),
-                    ),
-                  ],
+                child: Text(
+                  airspace.name,
+                  style: TextStyle(
+                    color: airspace.isCurrentlyFiltered ? Colors.grey : Colors.white,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                 ),
               ),
             ],
@@ -313,7 +294,9 @@ class AirspaceTooltipWidget extends StatelessWidget {
                   child: Text(
                     '${airspace.type.abbreviation},',
                     style: TextStyle(
-                      color: Colors.white.withValues(alpha: 0.85),
+                      color: airspace.isCurrentlyFiltered
+                        ? Colors.grey.withValues(alpha: 0.8)
+                        : Colors.white.withValues(alpha: 0.85),
                       fontSize: 10,
                       fontWeight: FontWeight.w600,
                     ),
@@ -340,9 +323,11 @@ class AirspaceTooltipWidget extends StatelessWidget {
                     child: Text(
                       '${airspace.icaoClass!.abbreviation},',
                       style: TextStyle(
-                        color: Colors.white.withValues(alpha: 0.85),
+                        color: airspace.isCurrentlyFiltered
+                          ? Colors.grey.withValues(alpha: 0.8)
+                          : style.borderColor, // Use ICAO class color for highlighting when visible
                         fontSize: 10,
-                        fontWeight: FontWeight.w600,
+                        fontWeight: FontWeight.bold, // Make it bold to emphasize
                       ),
                     ),
                   ),
@@ -355,7 +340,9 @@ class AirspaceTooltipWidget extends StatelessWidget {
                   child: Text(
                     '${_formatAltitudeRangeWithUnits(airspace)} ${_getCountryName(airspace.country)}',
                     style: TextStyle(
-                      color: Colors.white.withValues(alpha: 0.85),
+                      color: airspace.isCurrentlyFiltered
+                        ? Colors.grey.withValues(alpha: 0.8)
+                        : Colors.white.withValues(alpha: 0.85),
                       fontSize: 10,
                     ),
                     maxLines: 1,

--- a/free_flight_log_app/lib/presentation/widgets/airspace_tooltip_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/airspace_tooltip_widget.dart
@@ -246,8 +246,8 @@ class AirspaceTooltipWidget extends StatelessWidget {
                     Expanded(
                       child: Text(
                         airspace.name,
-                        style: const TextStyle(
-                          color: Colors.white,
+                        style: TextStyle(
+                          color: airspace.isCurrentlyFiltered ? Colors.grey : Colors.white,
                           fontSize: 12,
                           fontWeight: FontWeight.w600,
                         ),
@@ -255,30 +255,35 @@ class AirspaceTooltipWidget extends StatelessWidget {
                         overflow: TextOverflow.ellipsis,
                       ),
                     ),
-                    // Filter status indicator
-                    if (airspace.isCurrentlyFiltered)
-                      Tooltip(
-                        preferBelow: false,
-                        message: 'This airspace is currently filtered (hidden on map)',
-                        decoration: BoxDecoration(
-                          color: const Color(0xE6000000),
-                          borderRadius: BorderRadius.circular(8),
-                          border: Border.all(color: Colors.white.withValues(alpha: 0.2)),
-                        ),
-                        textStyle: const TextStyle(
-                          color: Colors.white,
-                          fontSize: 12,
-                          fontWeight: FontWeight.w400,
-                        ),
-                        child: Container(
-                          padding: const EdgeInsets.all(2),
-                          child: Icon(
-                            Icons.visibility_off,
-                            size: 12,
-                            color: Colors.orange.withValues(alpha: 0.8),
-                          ),
+                    // Filter status indicator (always shown)
+                    Tooltip(
+                      preferBelow: false,
+                      message: airspace.isCurrentlyFiltered
+                        ? 'This airspace is currently hidden on map'
+                        : 'This airspace is visible on map',
+                      decoration: BoxDecoration(
+                        color: const Color(0xE6000000),
+                        borderRadius: BorderRadius.circular(8),
+                        border: Border.all(color: Colors.white.withValues(alpha: 0.2)),
+                      ),
+                      textStyle: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w400,
+                      ),
+                      child: Container(
+                        padding: const EdgeInsets.all(2),
+                        child: Icon(
+                          airspace.isCurrentlyFiltered
+                            ? Icons.visibility_off
+                            : Icons.visibility,
+                          size: 12,
+                          color: airspace.isCurrentlyFiltered
+                            ? Colors.orange.withValues(alpha: 0.8)
+                            : Colors.green.withValues(alpha: 0.8),
                         ),
                       ),
+                    ),
                   ],
                 ),
               ),

--- a/free_flight_log_app/lib/presentation/widgets/airspace_tooltip_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/airspace_tooltip_widget.dart
@@ -238,17 +238,47 @@ class AirspaceTooltipWidget extends StatelessWidget {
               ),
               const SizedBox(width: 6),
 
-              // Airspace name
+              // Airspace name with filter indicator
               Expanded(
-                child: Text(
-                  airspace.name,
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontSize: 12,
-                    fontWeight: FontWeight.w600,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        airspace.name,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    // Filter status indicator
+                    if (airspace.isCurrentlyFiltered)
+                      Tooltip(
+                        preferBelow: false,
+                        message: 'This airspace is currently filtered (hidden on map)',
+                        decoration: BoxDecoration(
+                          color: const Color(0xE6000000),
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(color: Colors.white.withValues(alpha: 0.2)),
+                        ),
+                        textStyle: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w400,
+                        ),
+                        child: Container(
+                          padding: const EdgeInsets.all(2),
+                          child: Icon(
+                            Icons.visibility_off,
+                            size: 12,
+                            color: Colors.orange.withValues(alpha: 0.8),
+                          ),
+                        ),
+                      ),
+                  ],
                 ),
               ),
             ],

--- a/free_flight_log_app/lib/presentation/widgets/map_filter_dialog.dart
+++ b/free_flight_log_app/lib/presentation/widgets/map_filter_dialog.dart
@@ -48,7 +48,7 @@ class _MapFilterDialogState extends State<MapFilterDialog> {
     'R': 'Restricted Area - Areas where flight entry is restricted',
     'P': 'Prohibited Area - Areas where flight is forbidden',
     'FIR': 'Flight Information Region - Airspace for flight information services',
-    'None': 'Unknown Type - Airspace with unidentified or missing classification',
+    'Other': 'Unknown Type - Airspace with unidentified or missing classification',
   };
 
   // Available ICAO classes with detailed descriptions

--- a/free_flight_log_app/lib/presentation/widgets/map_filter_dialog.dart
+++ b/free_flight_log_app/lib/presentation/widgets/map_filter_dialog.dart
@@ -1,0 +1,589 @@
+import 'package:flutter/material.dart';
+import '../../services/logging_service.dart';
+import '../../utils/map_provider.dart';
+
+/// Filter dialog for controlling map layer visibility
+/// Supports sites toggle, airspace type filtering, ICAO class filtering, and altitude filtering
+class MapFilterDialog extends StatefulWidget {
+  final bool sitesEnabled;
+  final bool airspaceEnabled;
+  final Map<String, bool> airspaceTypes;
+  final Map<String, bool> icaoClasses;
+  final double maxAltitudeFt;
+  final MapProvider mapProvider;
+  final Function(bool sitesEnabled, bool airspaceEnabled, Map<String, bool> types, Map<String, bool> classes, double maxAltitudeFt, MapProvider mapProvider) onApply;
+
+  const MapFilterDialog({
+    super.key,
+    required this.sitesEnabled,
+    required this.airspaceEnabled,
+    required this.airspaceTypes,
+    required this.icaoClasses,
+    required this.maxAltitudeFt,
+    required this.mapProvider,
+    required this.onApply,
+  });
+
+  @override
+  State<MapFilterDialog> createState() => _MapFilterDialogState();
+}
+
+class _MapFilterDialogState extends State<MapFilterDialog> {
+  late bool _sitesEnabled;
+  late bool _airspaceEnabled;
+  late Map<String, bool> _airspaceTypes;
+  late Map<String, bool> _icaoClasses;
+  late double _maxAltitudeFt;
+  late MapProvider _selectedMapProvider;
+
+  // Available airspace types with full descriptions for tooltips
+  static const Map<String, String> _typeDescriptions = {
+    'CTR': 'Control Zone - Airport control zone with mandatory ATC contact',
+    'TMA': 'Terminal Area - Terminal maneuvering area around major airports',
+    'CTA': 'Control Area - Controlled airspace providing separation services',
+    'D': 'Danger Area - Areas with hazardous activities for aircraft',
+    'R': 'Restricted Area - Areas where flight entry is restricted',
+    'P': 'Prohibited Area - Areas where flight is forbidden',
+    'FIR': 'Flight Information Region - Airspace for flight information services',
+    'None': 'Unknown Type - Airspace with unidentified or missing classification',
+  };
+
+  // Available ICAO classes with detailed descriptions
+  static const Map<String, String> _classDescriptions = {
+    'A': 'Class A - IFR only. All flights receive ATC service and separation',
+    'B': 'Class B - IFR/VFR. All flights receive ATC service and separation',
+    'C': 'Class C - IFR/VFR. All receive ATC, IFR separated from all',
+    'D': 'Class D - IFR/VFR. All receive ATC, IFR separated from IFR only',
+    'E': 'Class E - IFR/VFR. IFR receives ATC service and separation',
+    'F': 'Class F - IFR/VFR. Advisory service, not widely implemented',
+    'G': 'Class G - Uncontrolled airspace, flight information only',
+    'None': 'No ICAO class assigned in the OpenAIP system',
+  };
+
+  @override
+  void initState() {
+    super.initState();
+    _sitesEnabled = widget.sitesEnabled;
+    _airspaceEnabled = widget.airspaceEnabled;
+    _airspaceTypes = Map<String, bool>.from(widget.airspaceTypes);
+    _icaoClasses = Map<String, bool>.from(widget.icaoClasses);
+    _maxAltitudeFt = widget.maxAltitudeFt;
+    _selectedMapProvider = widget.mapProvider;
+
+    // Initialize any missing types/classes with false
+    for (final type in _typeDescriptions.keys) {
+      _airspaceTypes[type] ??= false;
+    }
+    for (final icaoClass in _classDescriptions.keys) {
+      _icaoClasses[icaoClass] ??= false;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: Colors.transparent,
+      child: Container(
+        width: MediaQuery.of(context).size.width > 320 ? 280 : MediaQuery.of(context).size.width * 0.9,
+        constraints: const BoxConstraints(maxHeight: 500),
+        decoration: BoxDecoration(
+          color: const Color(0xFF1E1E1E),
+          borderRadius: BorderRadius.circular(12),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.3),
+              blurRadius: 16,
+              offset: const Offset(0, 8),
+            ),
+          ],
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Header
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              decoration: const BoxDecoration(
+                color: Color(0xFF2A2A2A),
+                borderRadius: BorderRadius.vertical(top: Radius.circular(12)),
+              ),
+              child: Row(
+                children: [
+                  const Icon(Icons.tune, color: Colors.blue, size: 20),
+                  const SizedBox(width: 8),
+                  const Text(
+                    'Filter Map',
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                      color: Colors.white,
+                    ),
+                  ),
+                  const Spacer(),
+                  IconButton(
+                    icon: const Icon(Icons.close, color: Colors.white70, size: 20),
+                    onPressed: () => Navigator.of(context).pop(),
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(),
+                  ),
+                ],
+              ),
+            ),
+
+            // Content
+            Flexible(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // Two-column layout: Maps and Sites/Airspace
+                    _buildTopTwoColumnSection(),
+                    const SizedBox(height: 16),
+
+                    // Three-column layout: Types | Classes | Altitude
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        // Types column
+                        Expanded(
+                          flex: 1,
+                          child: Opacity(
+                            opacity: _airspaceEnabled ? 1.0 : 0.3,
+                            child: IgnorePointer(
+                              ignoring: !_airspaceEnabled,
+                              child: _buildTypesColumn(),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 6),
+
+                        // Classes column
+                        Expanded(
+                          flex: 1,
+                          child: Opacity(
+                            opacity: _airspaceEnabled ? 1.0 : 0.3,
+                            child: IgnorePointer(
+                              ignoring: !_airspaceEnabled,
+                              child: _buildClassesColumn(),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 6),
+
+                        // Altitude column
+                        Expanded(
+                          flex: 1,
+                          child: Opacity(
+                            opacity: _airspaceEnabled ? 1.0 : 0.3,
+                            child: IgnorePointer(
+                              ignoring: !_airspaceEnabled,
+                              child: _buildAltitudeColumn(),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTopTwoColumnSection() {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Left column: Map provider section
+        Expanded(
+          child: _buildMapProviderColumn(),
+        ),
+        const SizedBox(width: 16),
+        // Right column: Sites and airspace toggles
+        Expanded(
+          child: _buildToggleColumn(),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMapProviderColumn() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Maps',
+          style: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: Colors.white,
+          ),
+        ),
+        const SizedBox(height: 8),
+        ...MapProvider.values.map((provider) =>
+          InkWell(
+            onTap: () => setState(() {
+              _selectedMapProvider = provider;
+              _applyFiltersImmediately();
+            }),
+            borderRadius: BorderRadius.circular(4),
+            child: Container(
+              height: 24,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Transform.scale(
+                    scale: 0.7,
+                    child: Radio<MapProvider>(
+                      value: provider,
+                      groupValue: _selectedMapProvider,
+                      onChanged: (value) => setState(() {
+                        _selectedMapProvider = value!;
+                        _applyFiltersImmediately();
+                      }),
+                      activeColor: Colors.blue,
+                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                  ),
+                  const SizedBox(width: 4),
+                  Flexible(
+                    child: Text(
+                      provider.shortName,
+                      style: const TextStyle(color: Colors.white, fontSize: 12),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ).toList(),
+      ],
+    );
+  }
+
+  Widget _buildToggleColumn() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Layers',
+          style: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: Colors.white,
+          ),
+        ),
+        const SizedBox(height: 8),
+        // Sites checkbox
+        InkWell(
+          onTap: () => setState(() {
+            _sitesEnabled = !_sitesEnabled;
+            _applyFiltersImmediately();
+          }),
+          borderRadius: BorderRadius.circular(4),
+          child: Container(
+            height: 24,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Transform.scale(
+                  scale: 0.7,
+                  child: Checkbox(
+                    value: _sitesEnabled,
+                    onChanged: (value) => setState(() {
+                      _sitesEnabled = value ?? true;
+                      _applyFiltersImmediately();
+                    }),
+                    activeColor: Colors.blue,
+                    checkColor: Colors.white,
+                    side: const BorderSide(color: Colors.white54),
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                ),
+                const SizedBox(width: 4),
+                const Text(
+                  'Sites',
+                  style: TextStyle(color: Colors.white, fontSize: 12),
+                ),
+              ],
+            ),
+          ),
+        ),
+        // Airspace checkbox
+        InkWell(
+          onTap: () => setState(() {
+            _airspaceEnabled = !_airspaceEnabled;
+            _applyFiltersImmediately();
+          }),
+          borderRadius: BorderRadius.circular(4),
+          child: Container(
+            height: 24,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Transform.scale(
+                  scale: 0.7,
+                  child: Checkbox(
+                    value: _airspaceEnabled,
+                    onChanged: (value) => setState(() {
+                      _airspaceEnabled = value ?? true;
+                      _applyFiltersImmediately();
+                    }),
+                    activeColor: Colors.blue,
+                    checkColor: Colors.white,
+                    side: const BorderSide(color: Colors.white54),
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                ),
+                const SizedBox(width: 4),
+                const Text(
+                  'Airspace',
+                  style: TextStyle(color: Colors.white, fontSize: 12),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTypesColumn() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Types',
+          style: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: Colors.white,
+          ),
+        ),
+        const SizedBox(height: 8),
+        ..._typeDescriptions.entries.map((entry) {
+          return Tooltip(
+            message: entry.value,
+            textStyle: const TextStyle(color: Colors.white, fontSize: 12),
+            decoration: BoxDecoration(
+              color: const Color(0xFF1E1E1E),
+              borderRadius: BorderRadius.circular(6),
+              border: Border.all(color: Colors.white24),
+            ),
+            child: InkWell(
+              onTap: () {
+                setState(() {
+                  _airspaceTypes[entry.key] = !(_airspaceTypes[entry.key] ?? false);
+                  // Apply changes immediately
+                  _applyFiltersImmediately();
+                });
+              },
+              borderRadius: BorderRadius.circular(4),
+              child: Container(
+                height: 18,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Transform.scale(
+                      scale: 0.6,
+                      child: Checkbox(
+                        value: _airspaceTypes[entry.key] ?? false,
+                        onChanged: (value) {
+                          setState(() {
+                            _airspaceTypes[entry.key] = value ?? false;
+                            // Apply changes immediately
+                            _applyFiltersImmediately();
+                          });
+                        },
+                        activeColor: Colors.blue,
+                        checkColor: Colors.white,
+                        side: const BorderSide(color: Colors.white54),
+                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      ),
+                    ),
+                    Text(
+                      entry.key,
+                      style: const TextStyle(color: Colors.white, fontSize: 10),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        }).toList(),
+      ],
+    );
+  }
+
+  Widget _buildClassesColumn() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Classes',
+          style: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: Colors.white,
+          ),
+        ),
+        const SizedBox(height: 8),
+        ..._classDescriptions.entries.map((entry) {
+          return Tooltip(
+            message: entry.value,
+            textStyle: const TextStyle(color: Colors.white, fontSize: 12),
+            decoration: BoxDecoration(
+              color: const Color(0xFF1E1E1E),
+              borderRadius: BorderRadius.circular(6),
+              border: Border.all(color: Colors.white24),
+            ),
+            child: InkWell(
+              onTap: () {
+                setState(() {
+                  _icaoClasses[entry.key] = !(_icaoClasses[entry.key] ?? false);
+                  // Apply changes immediately
+                  _applyFiltersImmediately();
+                });
+              },
+              borderRadius: BorderRadius.circular(4),
+              child: Container(
+                height: 18,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Transform.scale(
+                      scale: 0.6,
+                      child: Checkbox(
+                        value: _icaoClasses[entry.key] ?? false,
+                        onChanged: (value) {
+                          setState(() {
+                            _icaoClasses[entry.key] = value ?? false;
+                            // Apply changes immediately
+                            _applyFiltersImmediately();
+                          });
+                        },
+                        activeColor: Colors.blue,
+                        checkColor: Colors.white,
+                        side: const BorderSide(color: Colors.white54),
+                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      ),
+                    ),
+                    Text(
+                      entry.key,
+                      style: const TextStyle(color: Colors.white, fontSize: 10),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        }).toList(),
+      ],
+    );
+  }
+
+  Widget _buildAltitudeColumn() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Elevation',
+          style: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: Colors.white,
+          ),
+        ),
+        const SizedBox(height: 8),
+        SizedBox(
+          height: 144,
+          child: Row(
+            children: [
+              // Labels on the left
+              Column(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: const [
+                  Text('30k', style: TextStyle(color: Colors.white54, fontSize: 8)),
+                  Text('20k', style: TextStyle(color: Colors.white54, fontSize: 8)),
+                  Text('10k', style: TextStyle(color: Colors.white54, fontSize: 8)),
+                  Text('0', style: TextStyle(color: Colors.white54, fontSize: 8)),
+                ],
+              ),
+              const SizedBox(width: 4),
+              // Vertical slider
+              RotatedBox(
+                quarterTurns: 3,
+                child: SizedBox(
+                  width: 144,
+                  child: SliderTheme(
+                    data: SliderThemeData(
+                      trackHeight: 2,
+                      thumbColor: Colors.blue,
+                      activeTrackColor: Colors.blue,
+                      inactiveTrackColor: Colors.white24,
+                      thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 6),
+                      overlayShape: const RoundSliderOverlayShape(overlayRadius: 12),
+                      tickMarkShape: const RoundSliderTickMarkShape(tickMarkRadius: 1),
+                      activeTickMarkColor: Colors.blue,
+                      inactiveTickMarkColor: Colors.white54,
+                    ),
+                    child: Slider(
+                      value: _maxAltitudeFt,
+                      min: 0,
+                      max: 30000,
+                      divisions: 3, // For tick marks at 10k intervals
+                      onChanged: (value) {
+                        setState(() {
+                          _maxAltitudeFt = value;
+                          _applyFiltersImmediately();
+                        });
+                      },
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 4),
+              // Current value display
+              Text(
+                '${(_maxAltitudeFt / 1000).toStringAsFixed(0)} k',
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 10,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _applyFiltersImmediately() {
+    final selectedTypes = _airspaceTypes.entries
+        .where((entry) => entry.value)
+        .length;
+    final selectedClasses = _icaoClasses.entries
+        .where((entry) => entry.value)
+        .length;
+
+    LoggingService.structured('MAP_FILTER_APPLIED', {
+      'sites_enabled': _sitesEnabled,
+      'airspace_enabled': _airspaceEnabled,
+      'selected_types': selectedTypes,
+      'selected_classes': selectedClasses,
+      'total_types': _airspaceTypes.length,
+      'total_classes': _icaoClasses.length,
+      'max_altitude_ft': _maxAltitudeFt,
+      'map_provider': _selectedMapProvider.displayName,
+    });
+
+    widget.onApply(_sitesEnabled, _airspaceEnabled, _airspaceTypes, _icaoClasses, _maxAltitudeFt, _selectedMapProvider);
+  }
+}
+

--- a/free_flight_log_app/lib/presentation/widgets/map_filter_dialog_mockup.dart
+++ b/free_flight_log_app/lib/presentation/widgets/map_filter_dialog_mockup.dart
@@ -1,0 +1,469 @@
+import 'package:flutter/material.dart';
+
+/// Mockup version of the filter dialog showing the new 3-column layout
+class MapFilterDialogMockup extends StatefulWidget {
+  const MapFilterDialogMockup({super.key});
+
+  @override
+  State<MapFilterDialogMockup> createState() => _MapFilterDialogMockupState();
+}
+
+class _MapFilterDialogMockupState extends State<MapFilterDialogMockup> {
+  bool _sitesEnabled = true;
+  double _maxAltitudeFt = 15000.0;
+
+  // Sample data for mockup
+  final Map<String, bool> _airspaceTypes = {
+    'CTR': true,
+    'TMA': true,
+    'CTA': false,
+    'D': true,
+    'R': false,
+    'P': true,
+    'FIR': false,
+    '?': false, // Changed from 'Unknown' to '?' to fix overflow
+  };
+
+  final Map<String, bool> _icaoClasses = {
+    'A': true,
+    'B': true,
+    'C': false,
+    'D': true,
+    'E': false,
+    'F': false,
+    'G': false,
+    'None': false,
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        // Transparent overlay to capture taps
+        GestureDetector(
+          onTap: () => Navigator.of(context).pop(),
+          child: Container(
+            color: Colors.transparent,
+            width: double.infinity,
+            height: double.infinity,
+          ),
+        ),
+        // Positioned dropdown
+        Positioned(
+          top: 130, // Position under the filter button (approximate)
+          right: 20,
+          child: Material(
+            elevation: 8,
+            borderRadius: BorderRadius.circular(8),
+            child: Container(
+              width: 280,
+              constraints: const BoxConstraints(maxHeight: 400),
+              decoration: BoxDecoration(
+                color: const Color(0xFF1E1E1E),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: Colors.white12),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.4),
+                    blurRadius: 12,
+                    offset: const Offset(0, 4),
+                  ),
+                ],
+              ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Header
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              decoration: const BoxDecoration(
+                color: Color(0xFF2A2A2A),
+                borderRadius: BorderRadius.vertical(top: Radius.circular(8)),
+              ),
+              child: Row(
+                children: [
+                  const Icon(Icons.tune, color: Colors.blue, size: 18),
+                  const SizedBox(width: 8),
+                  const Text(
+                    'Filter Map',
+                    style: TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                      color: Colors.white,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+            // Content
+            Flexible(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // Sites toggle section
+                    _buildSitesSection(),
+                    const SizedBox(height: 16),
+
+                    // Three-column layout: Types | Classes | Altitude
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        // Types column
+                        Expanded(
+                          flex: 1,
+                          child: _buildTypesColumn(),
+                        ),
+                        const SizedBox(width: 6),
+
+                        // Classes column
+                        Expanded(
+                          flex: 1,
+                          child: _buildClassesColumn(),
+                        ),
+                        const SizedBox(width: 6),
+
+                        // Altitude column
+                        Expanded(
+                          flex: 1,
+                          child: _buildAltitudeColumn(),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSitesSection() {
+    return InkWell(
+      onTap: () => setState(() => _sitesEnabled = !_sitesEnabled),
+      borderRadius: BorderRadius.circular(4),
+      child: Row(
+        children: [
+          Transform.scale(
+            scale: 0.8,
+            child: Checkbox(
+              value: _sitesEnabled,
+              onChanged: (value) => setState(() => _sitesEnabled = value ?? true),
+              activeColor: Colors.blue,
+              checkColor: Colors.white,
+              side: const BorderSide(color: Colors.white54),
+              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+          ),
+          const SizedBox(width: 4),
+          const Text(
+            'Show Sites',
+            style: TextStyle(color: Colors.white, fontSize: 14, fontWeight: FontWeight.w500),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTypesColumn() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Types',
+          style: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: Colors.white,
+          ),
+        ),
+        const SizedBox(height: 8),
+        ..._airspaceTypes.entries.map((entry) {
+          return InkWell(
+            onTap: () {
+              setState(() {
+                _airspaceTypes[entry.key] = !entry.value;
+              });
+            },
+            borderRadius: BorderRadius.circular(4),
+            child: Container(
+              height: 18,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Transform.scale(
+                    scale: 0.6,
+                    child: Checkbox(
+                      value: entry.value,
+                      onChanged: (value) {
+                        setState(() {
+                          _airspaceTypes[entry.key] = value ?? false;
+                        });
+                      },
+                      activeColor: Colors.blue,
+                      checkColor: Colors.white,
+                      side: const BorderSide(color: Colors.white54),
+                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                  ),
+                  Text(
+                    entry.key,
+                    style: const TextStyle(color: Colors.white, fontSize: 10),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }).toList(),
+      ],
+    );
+  }
+
+  Widget _buildClassesColumn() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Classes',
+          style: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: Colors.white,
+          ),
+        ),
+        const SizedBox(height: 8),
+        ..._icaoClasses.entries.map((entry) {
+          return InkWell(
+            onTap: () {
+              setState(() {
+                _icaoClasses[entry.key] = !entry.value;
+              });
+            },
+            borderRadius: BorderRadius.circular(4),
+            child: Container(
+              height: 18,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Transform.scale(
+                    scale: 0.6,
+                    child: Checkbox(
+                      value: entry.value,
+                      onChanged: (value) {
+                        setState(() {
+                          _icaoClasses[entry.key] = value ?? false;
+                        });
+                      },
+                      activeColor: Colors.blue,
+                      checkColor: Colors.white,
+                      side: const BorderSide(color: Colors.white54),
+                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                  ),
+                  Text(
+                    entry.key,
+                    style: const TextStyle(color: Colors.white, fontSize: 10),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }).toList(),
+      ],
+    );
+  }
+
+  Widget _buildAltitudeColumn() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Elevation',
+          style: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: Colors.white,
+          ),
+        ),
+        const SizedBox(height: 8),
+
+        // Custom vertical slider with tick marks and value display
+        SizedBox(
+          height: 144, // Match height of other columns (~8 items × 18px)
+          child: _buildCustomVerticalSlider(),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCustomVerticalSlider() {
+    return Stack(
+      children: [
+        // Track and tick marks
+        Positioned(
+          left: 16,
+          top: 0,
+          bottom: 0,
+          child: CustomPaint(
+            size: const Size(20, 144),
+            painter: _VerticalSliderTrackPainter(_maxAltitudeFt, 30000.0),
+          ),
+        ),
+
+        // Slider thumb and value
+        Positioned(
+          left: 0,
+          top: 0,
+          bottom: 0,
+          child: GestureDetector(
+            onPanUpdate: (details) {
+              final RenderBox box = context.findRenderObject() as RenderBox;
+              final localPosition = box.globalToLocal(details.globalPosition);
+              final sliderHeight = 144.0;
+              final thumbY = localPosition.dy.clamp(0.0, sliderHeight);
+              final normalizedValue = 1.0 - (thumbY / sliderHeight);
+              final newValue = (normalizedValue * 30000).clamp(0.0, 30000.0);
+
+              setState(() {
+                _maxAltitudeFt = newValue;
+              });
+            },
+            child: Stack(
+              children: [
+                // Thumb position calculation
+                Positioned(
+                  left: 12,
+                  top: (1.0 - (_maxAltitudeFt / 30000)) * 144 - 6,
+                  child: Container(
+                    width: 12,
+                    height: 12,
+                    decoration: const BoxDecoration(
+                      color: Colors.blue,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                ),
+
+                // Value display next to thumb
+                Positioned(
+                  left: 26,
+                  top: (1.0 - (_maxAltitudeFt / 30000)) * 144 - 8,
+                  child: Text(
+                    '${(_maxAltitudeFt / 1000).toStringAsFixed(0)}k',
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 10,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _VerticalSliderTrackPainter extends CustomPainter {
+  final double currentValue;
+  final double maxValue;
+
+  _VerticalSliderTrackPainter(this.currentValue, this.maxValue);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..strokeWidth = 2.0
+      ..color = Colors.white24;
+
+    final activePaint = Paint()
+      ..strokeWidth = 2.0
+      ..color = Colors.blue;
+
+    final tickPaint = Paint()
+      ..strokeWidth = 1.0
+      ..color = Colors.white54;
+
+    final textPainter = TextPainter(
+      textDirection: TextDirection.ltr,
+    );
+
+    final trackRect = Rect.fromLTWH(8, 0, 2, size.height);
+
+    // Draw inactive track
+    canvas.drawRect(trackRect, paint);
+
+    // Draw active track (from bottom to current value)
+    final activeHeight = (currentValue / maxValue) * size.height;
+    final activeTrackRect = Rect.fromLTWH(8, size.height - activeHeight, 2, activeHeight);
+    canvas.drawRect(activeTrackRect, activePaint);
+
+    // Draw tick marks and labels
+    final tickMarks = [
+      {'value': 10000, 'label': '10k'},
+      {'value': 20000, 'label': '20k'},
+    ];
+
+    for (final tick in tickMarks) {
+      final value = tick['value'] as double;
+      final label = tick['label'] as String;
+      final y = size.height - (value / maxValue) * size.height;
+
+      // Draw tick mark
+      canvas.drawLine(
+        Offset(6, y),
+        Offset(12, y),
+        tickPaint,
+      );
+
+      // Draw label
+      textPainter.text = TextSpan(
+        text: label,
+        style: const TextStyle(
+          color: Colors.white54,
+          fontSize: 8,
+          fontWeight: FontWeight.w400,
+        ),
+      );
+      textPainter.layout();
+      textPainter.paint(canvas, Offset(-2, y - textPainter.height / 2));
+    }
+
+    // Draw 0 and 30k labels
+    textPainter.text = const TextSpan(
+      text: '0',
+      style: TextStyle(
+        color: Colors.white54,
+        fontSize: 8,
+        fontWeight: FontWeight.w400,
+      ),
+    );
+    textPainter.layout();
+    textPainter.paint(canvas, Offset(-2, size.height - textPainter.height / 2));
+
+    textPainter.text = const TextSpan(
+      text: '30k',
+      style: TextStyle(
+        color: Colors.white54,
+        fontSize: 8,
+        fontWeight: FontWeight.w400,
+      ),
+    );
+    textPainter.layout();
+    textPainter.paint(canvas, Offset(-2, -textPainter.height / 2));
+  }
+
+  @override
+  bool shouldRepaint(_VerticalSliderTrackPainter oldDelegate) {
+    return currentValue != oldDelegate.currentValue || maxValue != oldDelegate.maxValue;
+  }
+}

--- a/free_flight_log_app/lib/presentation/widgets/map_filter_fab.dart
+++ b/free_flight_log_app/lib/presentation/widgets/map_filter_fab.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+/// Inline filter button for map controls
+/// Matches map control styling with indicator when filters are active
+class MapFilterButton extends StatelessWidget {
+  final bool hasActiveFilters;
+  final bool sitesEnabled;
+  final VoidCallback onPressed;
+
+  const MapFilterButton({
+    super.key,
+    required this.hasActiveFilters,
+    required this.sitesEnabled,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // Show indicator if filters are active or sites are disabled
+    final showIndicator = hasActiveFilters || !sitesEnabled;
+
+    return GestureDetector(
+      onTap: onPressed,
+      child: Container(
+        height: 40,
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        decoration: const BoxDecoration(
+          color: Color(0x80000000),
+          borderRadius: BorderRadius.all(Radius.circular(4)),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black26,
+              blurRadius: 4,
+              offset: Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Center(
+          child: Stack(
+            children: [
+              const Icon(
+                Icons.tune,
+                size: 20,
+                color: Colors.white,
+              ),
+              if (showIndicator)
+                Positioned(
+                  top: 0,
+                  right: 0,
+                  child: Container(
+                    width: 6,
+                    height: 6,
+                    decoration: const BoxDecoration(
+                      color: Colors.blue,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/free_flight_log_app/lib/presentation/widgets/nearby_sites_map_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/nearby_sites_map_widget.dart
@@ -102,9 +102,16 @@ class _NearbySitesMapWidgetState extends State<NearbySitesMapWidget> {
   @override
   void didUpdateWidget(NearbySitesMapWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
-    
+
+    // Check if filter properties changed and reload overlays if needed
+    if (oldWidget.sitesEnabled != widget.sitesEnabled ||
+        oldWidget.maxAltitudeFt != widget.maxAltitudeFt) {
+      // Reload overlays with new filter settings
+      _loadAirspaceOverlays();
+    }
+
     // Priority 1: Check if we should fit to exact bounds (for precise area display)
-    if (widget.boundsToFit != null && 
+    if (widget.boundsToFit != null &&
         oldWidget.boundsToFit != widget.boundsToFit) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _mapController.fitCamera(

--- a/free_flight_log_app/lib/presentation/widgets/nearby_sites_map_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/nearby_sites_map_widget.dart
@@ -13,6 +13,7 @@ import '../../utils/map_tile_provider.dart';
 import '../../utils/airspace_overlay_manager.dart';
 import '../../services/openaip_service.dart';
 import '../../services/airspace_geojson_service.dart';
+import '../../data/models/airspace_enums.dart';
 import '../../services/airspace_identification_service.dart';
 import '../widgets/airspace_tooltip_widget.dart';
 import '../widgets/map_filter_fab.dart';
@@ -302,10 +303,9 @@ class _NearbySitesMapWidgetState extends State<NearbySitesMapWidget> {
 
     // Mark each airspace with its filter status for visual distinction
     for (final airspace in allAirspaces) {
-      final typeString = _getTypeStringFromCode(airspace.type);
       // OpenAipService uses inverted logic: true = filtered out, false = shown
-      final isTypeFiltered = enabledTypes[typeString] ?? false;  // true = filtered out
-      final isClassFiltered = enabledClasses[airspace.icaoClass ?? 8] ?? false;  // true = filtered out
+      final isTypeFiltered = enabledTypes[airspace.type] ?? false;  // true = filtered out
+      final isClassFiltered = enabledClasses[airspace.icaoClass ?? IcaoClass.none] ?? false;  // true = filtered out
       final isElevationFiltered = airspace.getLowerAltitudeInFeet() > widget.maxAltitudeFt;
 
       // Mark if this airspace is currently filtered out

--- a/free_flight_log_app/lib/presentation/widgets/nearby_sites_map_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/nearby_sites_map_widget.dart
@@ -39,6 +39,7 @@ class NearbySitesMapWidget extends StatefulWidget {
   final VoidCallback? onShowMapFilter;
   final bool hasActiveFilters;
   final bool sitesEnabled;
+  final double maxAltitudeFt;
 
   const NearbySitesMapWidget({
     super.key,
@@ -63,6 +64,7 @@ class NearbySitesMapWidget extends StatefulWidget {
     this.onShowMapFilter,
     this.hasActiveFilters = false,
     this.sitesEnabled = true,
+    this.maxAltitudeFt = 15000.0,
   });
 
   @override
@@ -183,6 +185,7 @@ class _NearbySitesMapWidgetState extends State<NearbySitesMapWidget> {
       final layers = await _airspaceManager.buildEnabledOverlayLayers(
         center: center,
         zoom: zoom,
+        maxAltitudeFt: widget.maxAltitudeFt,
       );
 
       if (mounted) {

--- a/free_flight_log_app/lib/presentation/widgets/nearby_sites_map_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/nearby_sites_map_widget.dart
@@ -110,7 +110,7 @@ class _NearbySitesMapWidgetState extends State<NearbySitesMapWidget> {
         oldWidget.maxAltitudeFt != widget.maxAltitudeFt ||
         oldWidget.filterUpdateCounter != widget.filterUpdateCounter) {
       // Reload overlays with new filter settings
-      _loadAirspaceOverlays();
+      _loadAirspaceLayers();
     }
 
     // Priority 1: Check if we should fit to exact bounds (for precise area display)

--- a/free_flight_log_app/lib/presentation/widgets/nearby_sites_map_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/nearby_sites_map_widget.dart
@@ -105,6 +105,15 @@ class _NearbySitesMapWidgetState extends State<NearbySitesMapWidget> {
   void didUpdateWidget(NearbySitesMapWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
 
+    // Check if sites were just enabled - reload site data
+    if (oldWidget.sitesEnabled != widget.sitesEnabled) {
+      if (widget.sitesEnabled && widget.onBoundsChanged != null && _mapController.camera != null) {
+        // Sites were just enabled - reload site data for current bounds
+        final bounds = _mapController.camera.visibleBounds;
+        widget.onBoundsChanged!(bounds);
+      }
+    }
+
     // Check if filter properties changed and reload overlays if needed
     if (oldWidget.sitesEnabled != widget.sitesEnabled ||
         oldWidget.maxAltitudeFt != widget.maxAltitudeFt ||

--- a/free_flight_log_app/lib/presentation/widgets/nearby_sites_map_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/nearby_sites_map_widget.dart
@@ -17,6 +17,7 @@ import '../../data/models/airspace_enums.dart';
 import '../../services/airspace_identification_service.dart';
 import '../widgets/airspace_tooltip_widget.dart';
 import '../widgets/map_filter_fab.dart';
+import '../widgets/map_legend_widget.dart';
 
 class NearbySitesMapWidget extends StatefulWidget {
   final List<ParaglidingSite> sites;
@@ -42,6 +43,7 @@ class NearbySitesMapWidget extends StatefulWidget {
   final bool sitesEnabled;
   final double maxAltitudeFt;
   final int filterUpdateCounter;
+  final Map<IcaoClass, bool> enabledIcaoClasses;
 
   const NearbySitesMapWidget({
     super.key,
@@ -68,6 +70,7 @@ class NearbySitesMapWidget extends StatefulWidget {
     this.sitesEnabled = true,
     this.maxAltitudeFt = 15000.0,
     this.filterUpdateCounter = 0,
+    this.enabledIcaoClasses = const {},
   });
 
   @override
@@ -458,37 +461,11 @@ class _NearbySitesMapWidgetState extends State<NearbySitesMapWidget> {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // Legend (existing) - aligned to top
-          Align(
-            alignment: Alignment.topCenter,
-            child: SiteMarkerUtils.buildCollapsibleMapLegend(
-              context: context,
-              isExpanded: widget.isLegendExpanded,
-              onToggle: widget.onToggleLegend,
-              legendItems: [
-                // Site legend items
-                SiteMarkerUtils.buildLegendItem(context, Icons.location_on, SiteMarkerUtils.flownSiteColor, 'Local Sites (DB)'),
-                const SizedBox(height: 4),
-                SiteMarkerUtils.buildLegendItem(context, Icons.location_on, SiteMarkerUtils.newSiteColor, 'API Sites'),
-
-                // Airspace legend items (only when airspace is enabled)
-                if (_airspaceEnabled) ...[
-                  const SizedBox(height: 8),
-                  // Airspace section title
-                  const Text(
-                    'Airspace Types',
-                    style: TextStyle(
-                      fontSize: 9,
-                      fontWeight: FontWeight.w600,
-                      color: Colors.white,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  // Airspace type legend items with tooltips (filtered by visible types)
-                  ...SiteMarkerUtils.buildAirspaceLegendItems(visibleTypes: _visibleAirspaceTypes.map((type) => type.abbreviation).toSet()),
-                ],
-              ],
-            ),
+          // Legend with ICAO classes
+          MapLegendWidget(
+            isMergeMode: false, // Merge mode not relevant for this widget
+            sitesEnabled: widget.sitesEnabled,
+            enabledIcaoClasses: widget.enabledIcaoClasses,
           ),
           
           const SizedBox(width: 8),

--- a/free_flight_log_app/lib/presentation/widgets/nearby_sites_map_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/nearby_sites_map_widget.dart
@@ -83,7 +83,7 @@ class _NearbySitesMapWidgetState extends State<NearbySitesMapWidget> {
   List<Widget> _airspaceLayers = [];
   bool _airspaceLoading = false;
   bool _airspaceEnabled = false;
-  Set<int> _visibleAirspaceTypes = {};
+  Set<AirspaceType> _visibleAirspaceTypes = {};
 
   // Airspace tooltip state
   List<AirspaceData> _tooltipAirspaces = [];
@@ -303,9 +303,9 @@ class _NearbySitesMapWidgetState extends State<NearbySitesMapWidget> {
 
     // Mark each airspace with its filter status for visual distinction
     for (final airspace in allAirspaces) {
-      // OpenAipService uses inverted logic: true = filtered out, false = shown
-      final isTypeFiltered = enabledTypes[airspace.type] ?? false;  // true = filtered out
-      final isClassFiltered = enabledClasses[airspace.icaoClass ?? IcaoClass.none] ?? false;  // true = filtered out
+      // Check if airspace is filtered: false = filtered out, true/null = shown
+      final isTypeFiltered = enabledTypes[airspace.type] == false;  // false = filtered out
+      final isClassFiltered = enabledClasses[airspace.icaoClass ?? IcaoClass.none] == false;  // false = filtered out
       final isElevationFiltered = airspace.getLowerAltitudeInFeet() > widget.maxAltitudeFt;
 
       // Mark if this airspace is currently filtered out
@@ -485,7 +485,7 @@ class _NearbySitesMapWidgetState extends State<NearbySitesMapWidget> {
                   ),
                   const SizedBox(height: 4),
                   // Airspace type legend items with tooltips (filtered by visible types)
-                  ...SiteMarkerUtils.buildAirspaceLegendItems(visibleTypes: _convertNumericTypesToStrings(_visibleAirspaceTypes)),
+                  ...SiteMarkerUtils.buildAirspaceLegendItems(visibleTypes: _visibleAirspaceTypes.map((type) => type.abbreviation).toSet()),
                 ],
               ],
             ),

--- a/free_flight_log_app/lib/presentation/widgets/nearby_sites_map_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/nearby_sites_map_widget.dart
@@ -15,6 +15,7 @@ import '../../services/openaip_service.dart';
 import '../../services/airspace_geojson_service.dart';
 import '../../services/airspace_identification_service.dart';
 import '../widgets/airspace_tooltip_widget.dart';
+import '../widgets/map_filter_fab.dart';
 
 class NearbySitesMapWidget extends StatefulWidget {
   final List<ParaglidingSite> sites;
@@ -26,7 +27,6 @@ class NearbySitesMapWidget extends StatefulWidget {
   final MapProvider mapProvider;
   final bool isLegendExpanded;
   final VoidCallback onToggleLegend;
-  final Function(MapProvider) onMapProviderChanged;
   final Function(ParaglidingSite)? onSiteSelected;
   final Function(LatLngBounds)? onBoundsChanged;
   final String searchQuery;
@@ -36,7 +36,10 @@ class NearbySitesMapWidget extends StatefulWidget {
   final List<ParaglidingSite> searchResults;
   final bool isSearching;
   final Function(ParaglidingSite) onSearchResultSelected;
-  
+  final VoidCallback? onShowMapFilter;
+  final bool hasActiveFilters;
+  final bool sitesEnabled;
+
   const NearbySitesMapWidget({
     super.key,
     required this.sites,
@@ -48,7 +51,6 @@ class NearbySitesMapWidget extends StatefulWidget {
     required this.mapProvider,
     required this.isLegendExpanded,
     required this.onToggleLegend,
-    required this.onMapProviderChanged,
     this.onSiteSelected,
     this.onBoundsChanged,
     required this.searchQuery,
@@ -58,6 +60,9 @@ class NearbySitesMapWidget extends StatefulWidget {
     required this.searchResults,
     required this.isSearching,
     required this.onSearchResultSelected,
+    this.onShowMapFilter,
+    this.hasActiveFilters = false,
+    this.sitesEnabled = true,
   });
 
   @override
@@ -347,6 +352,11 @@ class _NearbySitesMapWidgetState extends State<NearbySitesMapWidget> {
 
 
   List<Marker> _buildSiteMarkers() {
+    // Don't show site markers if sites are disabled
+    if (!widget.sitesEnabled) {
+      return [];
+    }
+
     return widget.sites.map((site) {
       final siteKey = SiteUtils.createSiteKey(site.latitude, site.longitude);
       final hasFlights = widget.siteFlightStatus[siteKey] ?? false;
@@ -409,14 +419,6 @@ class _NearbySitesMapWidgetState extends State<NearbySitesMapWidget> {
 
 
   // Add methods for map controls, legend, and attribution
-  Widget _buildMapControls() {
-    return MapControls.buildMapControls(
-      currentProvider: widget.mapProvider,
-      onProviderChanged: widget.onMapProviderChanged,
-    );
-  }
-
-
 
   Widget _buildTopControlBar() {
     return Positioned(
@@ -832,9 +834,18 @@ class _NearbySitesMapWidgetState extends State<NearbySitesMapWidget> {
           ),
           
           const SizedBox(width: 12),
-          
-          // Map controls (existing)
-          _buildMapControls(),
+
+          // Filter button
+          if (widget.onShowMapFilter != null)
+            MapFilterButton(
+              hasActiveFilters: widget.hasActiveFilters,
+              sitesEnabled: widget.sitesEnabled,
+              onPressed: widget.onShowMapFilter!,
+            ),
+
+          if (widget.onShowMapFilter != null)
+            const SizedBox(width: 12),
+
         ],
       ),
     );

--- a/free_flight_log_app/lib/presentation/widgets/nearby_sites_map_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/nearby_sites_map_widget.dart
@@ -40,6 +40,7 @@ class NearbySitesMapWidget extends StatefulWidget {
   final bool hasActiveFilters;
   final bool sitesEnabled;
   final double maxAltitudeFt;
+  final int filterUpdateCounter;
 
   const NearbySitesMapWidget({
     super.key,
@@ -65,6 +66,7 @@ class NearbySitesMapWidget extends StatefulWidget {
     this.hasActiveFilters = false,
     this.sitesEnabled = true,
     this.maxAltitudeFt = 15000.0,
+    this.filterUpdateCounter = 0,
   });
 
   @override
@@ -105,7 +107,8 @@ class _NearbySitesMapWidgetState extends State<NearbySitesMapWidget> {
 
     // Check if filter properties changed and reload overlays if needed
     if (oldWidget.sitesEnabled != widget.sitesEnabled ||
-        oldWidget.maxAltitudeFt != widget.maxAltitudeFt) {
+        oldWidget.maxAltitudeFt != widget.maxAltitudeFt ||
+        oldWidget.filterUpdateCounter != widget.filterUpdateCounter) {
       // Reload overlays with new filter settings
       _loadAirspaceOverlays();
     }

--- a/free_flight_log_app/lib/services/airspace_geojson_service.dart
+++ b/free_flight_log_app/lib/services/airspace_geojson_service.dart
@@ -217,10 +217,10 @@ class AirspaceGeoJsonService {
   static const Duration _requestTimeout = Duration(seconds: 30);
 
   // Track currently visible airspace types
-  Set<int> _currentVisibleTypes = <int>{};
+  Set<AirspaceType> _currentVisibleTypes = <AirspaceType>{};
 
   /// Get the currently visible airspace types in the loaded data
-  Set<int> get visibleAirspaceTypes => Set.from(_currentVisibleTypes);
+  Set<AirspaceType> get visibleAirspaceTypes => Set.from(_currentVisibleTypes);
 
   // Airspace type to style mapping - All with 10% opacity (0x1A) for better map visibility
   static const Map<String, AirspaceStyle> _airspaceStyles = {
@@ -664,7 +664,7 @@ class AirspaceGeoJsonService {
 
       List<fm.Polygon> polygons = <fm.Polygon>[];
       List<AirspacePolygonData> identificationPolygons = <AirspacePolygonData>[];
-      final Set<int> visibleEnabledTypes = <int>{}; // Track visible enabled types
+      final Set<AirspaceType> visibleEnabledTypes = <AirspaceType>{}; // Track visible enabled types
 
       for (final feature in featureCollection.features) {
         final geometry = feature.geometry;
@@ -875,8 +875,8 @@ class AirspaceGeoJsonService {
       }
     }
 
-    // Update the visible types for legend filtering
-    _currentVisibleTypes = visibleTypes;
+    // Update the visible types for legend filtering (convert int to AirspaceType)
+    _currentVisibleTypes = visibleTypes.map((type) => AirspaceType.fromCode(type)).toSet();
 
     LoggingService.structured('AIRSPACE_STATISTICS', {
       'mapped_types': typeStats,

--- a/free_flight_log_app/lib/services/airspace_geojson_service.dart
+++ b/free_flight_log_app/lib/services/airspace_geojson_service.dart
@@ -19,6 +19,10 @@ class AirspaceData {
   final Map<String, dynamic>? lowerLimit;
   final String? country;
 
+  /// Indicates if this airspace is currently filtered out by user settings
+  /// Used to show visual distinction in tooltips
+  bool isCurrentlyFiltered = false;
+
   AirspaceData({
     required this.name,
     required this.type,

--- a/free_flight_log_app/lib/services/airspace_identification_service.dart
+++ b/free_flight_log_app/lib/services/airspace_identification_service.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 import 'package:latlong2/latlong.dart';
 import '../services/logging_service.dart';
 import '../services/airspace_geojson_service.dart';
+import '../data/models/airspace_enums.dart';
 
 /// Container for airspace polygon with associated data
 class AirspacePolygonData {
@@ -184,7 +185,7 @@ class AirspaceIdentificationService {
 
   /// Get cache statistics for debugging
   Map<String, dynamic> getCacheStats() {
-    final typeStats = <int, int>{};
+    final typeStats = <AirspaceType, int>{};
     for (final polygon in _airspacePolygons) {
       final type = polygon.airspaceData.type;
       typeStats[type] = (typeStats[type] ?? 0) + 1;

--- a/free_flight_log_app/lib/services/openaip_service.dart
+++ b/free_flight_log_app/lib/services/openaip_service.dart
@@ -56,28 +56,30 @@ class OpenAipService {
   static const bool _defaultNavaidsEnabled = false;
   static const bool _defaultReportingPointsEnabled = false;
 
-  // Default enabled airspace types (VFR-focused: critical for safety)
+  // Default disabled airspace types (inverted logic - show all except these)
+  // This ensures unmapped types are shown by default
   static const Map<String, bool> _defaultAirspaceTypes = {
-    'CTR': true,  // Control Zone - critical
-    'TMA': true,  // Terminal Area - critical
-    'CTA': true,  // Control Area - important
-    'D': true,    // Danger Area - critical for safety
-    'R': true,    // Restricted - critical for safety
-    'P': true,    // Prohibited - critical for safety
-    'FIR': false, // Flight Information Region - less critical
-    'None': false, // Unknown type - less critical
+    'CTR': false,  // Control Zone - show by default
+    'TMA': false,  // Terminal Area - show by default
+    'CTA': false,  // Control Area - show by default
+    'D': false,    // Danger Area - show by default
+    'R': false,    // Restricted - show by default
+    'P': false,    // Prohibited - show by default
+    'FIR': true,   // Flight Information Region - hide by default (very large)
+    'Unknown': true, // Unknown type - hide by default
   };
 
-  // Default enabled ICAO classes (VFR-focused)
+  // Default disabled ICAO classes (inverted logic - show all except these)
+  // This ensures unmapped classes are shown by default
   static const Map<String, bool> _defaultIcaoClasses = {
-    'A': false,   // Class A - IFR only, less relevant for VFR
-    'B': true,    // Class B - important for VFR
-    'C': true,    // Class C - important for VFR
-    'D': true,    // Class D - important for VFR
-    'E': false,   // Class E - less critical
-    'F': false,   // Class F - less critical
-    'G': true,    // Class G - uncontrolled, relevant for VFR
-    'None': false, // No class assigned - less critical
+    'A': true,    // Class A - IFR only, hide by default
+    'B': false,   // Class B - show by default
+    'C': false,   // Class C - show by default
+    'D': false,   // Class D - show by default
+    'E': true,    // Class E - hide by default (less critical)
+    'F': true,    // Class F - hide by default (less critical)
+    'G': false,   // Class G - show by default (uncontrolled)
+    'None': false, // No ICAO class - show by default
   };
   
   /// Get the tile URL template for a specific layer

--- a/free_flight_log_app/lib/services/openaip_service.dart
+++ b/free_flight_log_app/lib/services/openaip_service.dart
@@ -347,15 +347,16 @@ class OpenAipService {
   }
 
   /// Set enabled state for a specific airspace type
-  Future<void> setAirspaceTypeEnabled(String type, bool enabled) async {
+  Future<void> setAirspaceTypeEnabled(AirspaceType type, bool enabled) async {
     final currentTypes = await getEnabledAirspaceTypes();
     currentTypes[type] = enabled;
     await setEnabledAirspaceTypes(currentTypes);
   }
 
   /// Check if a specific airspace type is enabled
-  Future<bool> isAirspaceTypeEnabled(String type) async {
+  Future<bool> isAirspaceTypeEnabled(AirspaceType type) async {
     final enabledTypes = await getEnabledAirspaceTypes();
+    // _defaultAirspaceTypes is already enum-based, no conversion needed
     return enabledTypes[type] ?? _defaultAirspaceTypes[type] ?? false;
   }
 
@@ -410,12 +411,12 @@ class OpenAipService {
         };
         break;
       default:
-        typePreset = _defaultAirspaceTypes;
-        classPreset = _defaultIcaoClasses;
+        typePreset = _convertEnumMapToStringMap(_defaultAirspaceTypes);
+        classPreset = _convertIcaoEnumMapToStringMap(_defaultIcaoClasses);
     }
 
-    await setEnabledAirspaceTypes(typePreset);
-    await setEnabledIcaoClasses(classPreset);
+    await setEnabledAirspaceTypes(_convertStringMapToEnumMap(typePreset));
+    await setEnabledIcaoClasses(_convertIcaoStringMapToEnumMap(classPreset));
 
     LoggingService.structured('AIRSPACE_PRESET_APPLIED', {
       'preset': presetName,
@@ -459,15 +460,16 @@ class OpenAipService {
   }
 
   /// Set enabled state for a specific ICAO class
-  Future<void> setIcaoClassEnabled(String icaoClass, bool enabled) async {
+  Future<void> setIcaoClassEnabled(IcaoClass icaoClass, bool enabled) async {
     final currentClasses = await getEnabledIcaoClasses();
     currentClasses[icaoClass] = enabled;
     await setEnabledIcaoClasses(currentClasses);
   }
 
   /// Check if a specific ICAO class is enabled
-  Future<bool> isIcaoClassEnabled(String icaoClass) async {
+  Future<bool> isIcaoClassEnabled(IcaoClass icaoClass) async {
     final enabledClasses = await getEnabledIcaoClasses();
+    // _defaultIcaoClasses is already enum-based, no conversion needed
     return enabledClasses[icaoClass] ?? _defaultIcaoClasses[icaoClass] ?? false;
   }
 

--- a/free_flight_log_app/lib/utils/airspace_overlay_manager.dart
+++ b/free_flight_log_app/lib/utils/airspace_overlay_manager.dart
@@ -656,7 +656,7 @@ class AirspaceOverlayManager {
       'E': 4,       // Class E
       'F': 5,       // Class F
       'G': 6,       // Class G
-      'None': -1,   // No class assigned (null in data)
+      'None': 8,    // No ICAO class assigned
     };
 
     final numericClasses = <int, bool>{};
@@ -676,18 +676,15 @@ class AirspaceOverlayManager {
     // Mapping from string abbreviations to numeric codes
     const stringToNumeric = {
       'Unknown': 0,
-      'A': 1,       // Class A (could be 1, 6, or others depending on context)
-      'B': 2,       // Class B
-      'C': 3,       // Class C
+      'R': 1,       // Restricted (per OpenAIP doc)
+      'D': 2,       // Danger (per OpenAIP doc)
       'CTR': 4,     // Control Zone
-      'E': 5,       // Class E (could be 2 or 5 depending on context)
-      'TMA': 6,     // Terminal Control Area
-      'G': 7,       // Class G
-      'CTA': 10,    // Control Area (primary mapping to 10/26)
-      'R': 11,      // Restricted
-      'P': 12,      // Prohibited
-      'ATZ': 13,    // Aerodrome Traffic Zone
-      'D': 14,      // Danger Area
+      'TMA': 6,     // Terminal Control Area (also maps to 7)
+      'FIR': 10,    // Flight Information Region
+      'CTA': 26,    // Control Area
+      // Additional mappings for alternate codes
+      'P': 12,      // Prohibited (keeping existing)
+      'ATZ': 13,    // Aerodrome Traffic Zone (keeping existing)
     };
 
     final numericTypes = <int, bool>{};
@@ -698,34 +695,29 @@ class AirspaceOverlayManager {
         numericTypes[numericCode] = enabled;
 
         // Handle special mappings for types that have multiple numeric codes
-        if (stringType == 'CTA') {
-          // CTA maps to both 10 and 26
-          numericTypes[26] = enabled;
-        } else if (stringType == 'CTR') {
-          // CTR maps to 4, 8, and 17
+        if (stringType == 'CTR') {
+          // CTR maps to 4, 8, 13, and 17 (various control zone types)
           numericTypes[8] = enabled;
+          numericTypes[13] = enabled;  // ATZ
           numericTypes[17] = enabled;
         } else if (stringType == 'TMA') {
-          // TMA maps to 6, 9, 16, and 21
+          // TMA maps to 6, 7, 9, 16, and 21
+          numericTypes[7] = enabled;   // Alternate TMA code
           numericTypes[9] = enabled;
           numericTypes[16] = enabled;
           numericTypes[21] = enabled;
-        } else if (stringType == 'A') {
-          // Class A can be code 6 as well
-          numericTypes[6] = enabled;
-        } else if (stringType == 'E') {
-          // Class E can be code 2 as well
-          numericTypes[2] = enabled;
         } else if (stringType == 'R') {
-          // Restricted maps to 11, 15, and 18
-          numericTypes[15] = enabled;
-          numericTypes[18] = enabled;
-        } else if (stringType == 'P') {
-          // Prohibited maps to 12 and 19
-          numericTypes[19] = enabled;
+          // Restricted can be 1, 11, 15, 18
+          numericTypes[11] = enabled;
+          numericTypes[15] = enabled;  // Military Restricted
+          numericTypes[18] = enabled;  // Temporary Restricted
         } else if (stringType == 'D') {
-          // Danger maps to 14 and 20
-          numericTypes[20] = enabled;
+          // Danger can be 2, 14, 20
+          numericTypes[14] = enabled;
+          numericTypes[20] = enabled;  // Temporary Danger
+        } else if (stringType == 'P') {
+          // Prohibited can be 12, 19
+          numericTypes[19] = enabled;  // Temporary Prohibited
         }
       }
     });

--- a/free_flight_log_app/lib/utils/airspace_overlay_manager.dart
+++ b/free_flight_log_app/lib/utils/airspace_overlay_manager.dart
@@ -7,6 +7,7 @@ import '../services/openaip_service.dart';
 import '../services/airspace_geojson_service.dart';
 import '../services/aviation_data_service.dart';
 import '../services/logging_service.dart';
+import '../data/models/airspace_enums.dart';
 import '../data/models/airport.dart';
 import '../data/models/navaid.dart';
 import '../data/models/reporting_point.dart';
@@ -231,13 +232,9 @@ class AirspaceOverlayManager {
       // Fetch GeoJSON data from OpenAIP
       final geoJsonString = await _geoJsonService.fetchAirspaceGeoJson(bounds);
 
-      // Get enabled airspace types and ICAO classes for filtering
-      final enabledStringTypes = await _openAipService.getEnabledAirspaceTypes();
-      final enabledStringClasses = await _openAipService.getEnabledIcaoClasses();
-
-      // Convert string keys to numeric keys
-      final enabledTypes = _convertStringTypesToNumeric(enabledStringTypes);
-      final enabledClasses = _convertStringClassesToNumeric(enabledStringClasses);
+      // Get enabled airspace types and ICAO classes for filtering (now enum-based)
+      final enabledTypes = await _openAipService.getEnabledAirspaceTypes();
+      final enabledClasses = await _openAipService.getEnabledIcaoClasses();
 
       // Time the airspace processing/clipping step
       final processingStopwatch = Stopwatch()..start();
@@ -257,7 +254,7 @@ class AirspaceOverlayManager {
       LoggingService.structured('AIRSPACE_FETCH_SUCCESS', {
         'polygon_count': polygons.length,
         'geojson_size': geoJsonString.length,
-        'enabled_types_count': enabledStringTypes.values.where((enabled) => enabled).length,
+        'enabled_types_count': enabledTypes.values.where((enabled) => enabled).length,
         'total_types_count': enabledTypes.length,
         'total_time_ms': stopwatch.elapsedMilliseconds,
         'processing_time_ms': processingStopwatch.elapsedMilliseconds,
@@ -432,7 +429,7 @@ class AirspaceOverlayManager {
         final Set<String> visibleTypeNames = {};
         for (final typeCode in visibleAirspaceTypes) {
           // Map the numeric code to the string type name
-          final typeName = _mapNumericTypeToString(typeCode);
+          final typeName = _mapNumericTypeToString(typeCode.code);
           if (typeName != null) {
             visibleTypeNames.add(typeName);
           }

--- a/free_flight_log_app/lib/utils/map_provider.dart
+++ b/free_flight_log_app/lib/utils/map_provider.dart
@@ -1,8 +1,8 @@
 /// Map provider configuration for consistent map tiles across the application
 enum MapProvider {
   openStreetMap('Street Map', 'OSM', 'https://tile.openstreetmap.org/{z}/{x}/{y}.png', 18, '© OpenStreetMap contributors'),
-  googleSatellite('Google Satellite', 'Google', 'https://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}', 18, '© Google'),
-  esriWorldImagery('Esri Satellite', 'Esri', 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', 18, '© Esri');
+  googleSatellite('Google Satellite', 'Google Satellite', 'https://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}', 18, '© Google'),
+  esriWorldImagery('Esri Satellite', 'ESRI Satellite', 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', 18, '© Esri');
   
   const MapProvider(this.displayName, this.shortName, this.urlTemplate, this.maxZoom, this.attribution);
   

--- a/free_flight_log_app/lib/utils/site_marker_utils.dart
+++ b/free_flight_log_app/lib/utils/site_marker_utils.dart
@@ -257,7 +257,7 @@ class SiteMarkerUtils {
     final styles = airspaceService.allAirspaceStyles;
 
     // If visibleTypes is not provided, get from service (for backwards compatibility)
-    final typesToShow = visibleTypes ?? _convertNumericTypesToStrings(airspaceService.visibleAirspaceTypes);
+    final typesToShow = visibleTypes ?? airspaceService.visibleAirspaceTypes.map((type) => type.abbreviation).toSet();
 
     // Define airspace type descriptions with detailed tooltips
     final typeDescriptions = {


### PR DESCRIPTION
## Summary
- Show ALL airspaces in tooltip when clicking map, not just filtered ones
- Add visual filter indicators for currently filtered airspaces in tooltips
- Fix filter status logic that incorrectly marked all airspaces as filtered
- Replace blocking full-screen loading overlay with non-blocking corner indicator
- Add 500ms debouncing to filter changes to prevent rapid API calls

## Test plan
- [x] Test airspace tooltip shows all airspaces at clicked location
- [x] Verify filtered airspaces display orange eye-off icon with tooltip
- [x] Confirm loading indicator doesn't block map interactions during zoom
- [x] Test filter changes are debounced properly
- [x] Verify filter logic correctly identifies filtered vs visible airspaces

🤖 Generated with [Claude Code](https://claude.ai/code)