### PR TITLE
Fix map tile loading issue in flight track view

### DIFF
--- a/free_flight_log_app/lib/presentation/widgets/common/base_map_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/common/base_map_widget.dart
@@ -359,6 +359,7 @@ abstract class BaseMapState<T extends BaseMapWidget> extends State<T> {
   /// Build the tile layer for the selected map provider
   Widget buildTileLayer() {
     return TileLayer(
+      key: ValueKey('${mapContext}_tile_layer_${_selectedMapProvider.name}'),
       urlTemplate: _selectedMapProvider.urlTemplate,
       userAgentPackageName: 'com.freeflightlog.free_flight_log_app',
       maxNativeZoom: _selectedMapProvider.maxZoom,
@@ -803,6 +804,7 @@ abstract class BaseMapState<T extends BaseMapWidget> extends State<T> {
     return Stack(
       children: [
         FlutterMap(
+          key: ValueKey('${mapContext}_flutter_map'),
           mapController: _mapController,
           options: MapOptions(
             initialCenter: widget.initialCenter ?? const LatLng(46.9480, 7.4474),

--- a/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
+++ b/free_flight_log_app/lib/presentation/widgets/flight_track_2d_widget.dart
@@ -573,15 +573,18 @@ class _FlightTrack2DWidgetState extends State<FlightTrack2DWidget> {
         // Flight Track Map using the new refactored widget
         SizedBox(
           height: (widget.height ?? 400) - _totalChartsHeight - 20,
-          child: FlightTrackMap(
-            flight: widget.flight,
-            trackPoints: _trackPoints,
-            faiTrianglePoints: _faiTrianglePoints,
-            selectedTrackPointIndex: _selectedTrackPointIndex,
-            closingDistanceThreshold: _closingDistanceThreshold,
-            onTrackPointSelected: (index) {
-              _selectedTrackPointIndex.value = index;
-            },
+          child: RepaintBoundary(
+            child: FlightTrackMap(
+              key: ValueKey('flight_track_map_${widget.flight.id}'),
+              flight: widget.flight,
+              trackPoints: _trackPoints,
+              faiTrianglePoints: _faiTrianglePoints,
+              selectedTrackPointIndex: _selectedTrackPointIndex,
+              closingDistanceThreshold: _closingDistanceThreshold,
+              onTrackPointSelected: (index) {
+                _selectedTrackPointIndex.value = index;
+              },
+            ),
           ),
         ),
         // Three synchronized charts

--- a/free_flight_log_app/lib/presentation/widgets/flight_track_map.dart
+++ b/free_flight_log_app/lib/presentation/widgets/flight_track_map.dart
@@ -56,21 +56,6 @@ class _FlightTrackMapState extends BaseMapState<FlightTrackMap> {
   int get siteLimit => MapConstants.flightMapSiteLimit; // Optimized for performance with charts
 
   @override
-  void initState() {
-    super.initState();
-
-    // Set initial center from track points
-    if (widget.trackPoints.isNotEmpty) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        mapController.move(
-          LatLng(widget.trackPoints.first.latitude, widget.trackPoints.first.longitude),
-          13.0,
-        );
-      });
-    }
-  }
-
-  @override
   void onMapReady() {
     super.onMapReady();
     _fitMapToBounds();


### PR DESCRIPTION
## Summary
- Fixed race condition causing map tiles to not load properly on initial display
- Resolved issue where tiles would disappear when returning to original zoom level
- Prevented tile loading cancellation during map initialization

## Problem
The flight track map was positioning itself twice during initialization:
1. First in `initState()` - moving to first track point at zoom 13
2. Then in `onMapReady()` - fitting to bounds at a different zoom level

This race condition caused tile loading requests to be cancelled mid-flight, leaving blank tiles in the cache. When users returned to the initial zoom level, the map thought tiles were cached but they were actually blank.

## Solution
- Removed redundant map positioning in `initState()`
- Map now positions itself only once via `_fitMapToBounds()` in `onMapReady()`
- Added stable keys to FlutterMap and TileLayer widgets to preserve state during rebuilds
- Wrapped FlightTrackMap in RepaintBoundary to isolate repaints

## Test plan
- [x] Open flight detail view and verify all map tiles load correctly
- [x] Zoom in and out multiple times
- [x] Return to initial zoom level and confirm tiles remain loaded
- [x] Switch between different map providers
- [x] Hot reload/restart maintains map state

🤖 Generated with [Claude Code](https://claude.ai/code)