### PR TITLE
Enhance wind rose visibility and consistency

### DIFF
--- a/free_flight_log_app/lib/presentation/screens/nearby_sites_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/nearby_sites_screen.dart
@@ -1437,9 +1437,20 @@ class _SiteDetailsDialogState extends State<_SiteDetailsDialog> with SingleTicke
       siteType: 'launch',
     );
 
+    // Calculate flyability status using the same logic as site markers
+    FlyabilityStatus? status;
+    if (windDirections.isNotEmpty) {
+      final isFlyable = _windData!.isFlyable(
+        tempSite.windDirections,
+        25.0, // maxWindSpeed
+        30.0, // maxWindGusts
+      );
+      status = isFlyable ? FlyabilityStatus.flyable : FlyabilityStatus.notFlyable;
+    }
+
     return SiteMarkerPresentation.forFlyability(
       site: tempSite,
-      status: null, // Will be calculated from wind data
+      status: status, // Now properly calculated!
       windData: _windData,
       maxWindSpeed: 25.0, // Default max wind speed
       maxWindGusts: 30.0, // Default max gusts
@@ -1999,7 +2010,7 @@ class _SiteDetailsDialogState extends State<_SiteDetailsDialog> with SingleTicke
               const Center(child: CircularProgressIndicator())
             else if (_loadingError != null)
               Center(child: Text(_loadingError!, style: TextStyle(color: Colors.red)))
-            else if (windDirections.isNotEmpty) ...[
+            else ...[
               // Compact single-column layout with inline wind rose
               Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -2056,37 +2067,6 @@ class _SiteDetailsDialogState extends State<_SiteDetailsDialog> with SingleTicke
                     ],
                   ),
                 ],
-              ),
-            ] else ...[
-              // No wind directions - center message
-              Center(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 32.0),
-                  child: Column(
-                    children: [
-                      Icon(
-                        Icons.info_outline,
-                        size: 48,
-                        color: Colors.grey.shade400,
-                      ),
-                      const SizedBox(height: 16),
-                      Text(
-                        'No wind direction restrictions',
-                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      Text(
-                        'This site has no specific wind direction requirements.',
-                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          color: Colors.grey.shade600,
-                        ),
-                        textAlign: TextAlign.center,
-                      ),
-                    ],
-                  ),
-                ),
               ),
             ],
           ],

--- a/free_flight_log_app/lib/presentation/widgets/wind_rose_painter.dart
+++ b/free_flight_log_app/lib/presentation/widgets/wind_rose_painter.dart
@@ -179,18 +179,9 @@ class WindRosePainter extends CustomPainter {
   void _drawCenterPoint(Canvas canvas, Offset center, double radius) {
     final centerDotRadius = 15.0; // Same fixed size as used in _drawWindSectors
 
-    // Use provided color if available, otherwise determine based on wind suitability
-    Color centerColor;
-    if (centerDotColor != null) {
-      centerColor = centerDotColor!;
-    } else if (windDirection != null) {
-      final isLaunchable = _isWindDirectionLaunchable();
-      centerColor = isLaunchable
-          ? Colors.green.withValues(alpha: 0.3)  // Same as green wedges
-          : Colors.grey.withValues(alpha: 0.1);   // Same as grey wedges
-    } else {
-      centerColor = theme.colorScheme.primary; // Default blue if no wind data
-    }
+    // Use provided color from parent (which uses SiteMarkerPresentation logic)
+    // If no color provided, fall back to theme default
+    final centerColor = centerDotColor ?? theme.colorScheme.primary;
 
     final centerPaint = Paint()
       ..color = centerColor
@@ -200,7 +191,7 @@ class WindRosePainter extends CustomPainter {
   }
 
   void _drawWindArrow(Canvas canvas, Offset center, double radius) {
-    final gap = 5.0;
+    final gap = 3.0;
     final centerDotRadius = 15.0;
     final arrowStartRadius = radius - gap; // Start from outer edge
     final arrowEndRadius = centerDotRadius; // End at center
@@ -220,7 +211,7 @@ class WindRosePainter extends CustomPainter {
     final arrowPaint = Paint()
       ..color = theme.colorScheme.outline
       ..style = PaintingStyle.stroke
-      ..strokeWidth = 1.5  // Thinner arrow line
+      ..strokeWidth = 1.75  // Thicker arrow line for better visibility
       ..strokeCap = StrokeCap.round;
 
     // Draw arrow line from outer edge toward center
@@ -231,7 +222,7 @@ class WindRosePainter extends CustomPainter {
     );
 
     // Draw arrowhead pointing inward (toward center)
-    final arrowheadLength = 6.0;  // Smaller arrowhead
+    final arrowheadLength = 7.0;  // Larger arrowhead for better visibility
     final arrowheadAngle = 25 * pi / 180; // Narrower angle
 
     // Arrowhead at the END point (center), pointing inward
@@ -278,37 +269,6 @@ class WindRosePainter extends CustomPainter {
     );
 
     speedTextPainter.paint(canvas, speedOffset);
-  }
-
-  bool _isWindDirectionLaunchable() {
-    if (windDirection == null) return false;
-
-    // Convert wind direction to compass direction
-    final windCompassDirection = _degreesToCompassDirection(windDirection!);
-
-    // Check if wind direction matches any launchable direction
-
-    // Check if it matches any launchable direction
-    return launchableDirections.contains(windCompassDirection);
-  }
-
-  String _degreesToCompassDirection(double degrees) {
-    // Normalize to 0-360 range
-    double normalizedDegrees = degrees % 360;
-    if (normalizedDegrees < 0) normalizedDegrees += 360;
-
-    // 16-point compass for better accuracy
-    const directions = [
-      'N', 'NNE', 'NE', 'ENE',
-      'E', 'ESE', 'SE', 'SSE',
-      'S', 'SSW', 'SW', 'WSW',
-      'W', 'WNW', 'NW', 'NNW'
-    ];
-
-    // Each direction covers 22.5 degrees, offset by 11.25 degrees
-    final index = ((normalizedDegrees + 11.25) / 22.5).floor() % 16;
-
-    return directions[index];
   }
 
   double _degreesToRadians(double degrees) {


### PR DESCRIPTION
## Summary
- Enhanced wind arrow visibility with thicker stroke and larger arrowhead
- Centralized flyability color logic through SiteMarkerPresentation
- Wind rose now always displayed in site weather tab
- Center dot color and tooltip now match site marker flyability status

## Changes
- **Wind Arrow Visibility**: Increased stroke width (1.5→1.75), arrowhead size (6→7), and reduced gap (5→3) for better visibility
- **Flyability Logic**: Centralized color determination through `SiteMarkerPresentation.forFlyability()` with proper status calculation using `windData.isFlyable()`
- **Always Show Wind Rose**: Removed conditional that hid wind rose when no wind orientations defined
- **Code Cleanup**: Removed duplicate flyability logic from WindRosePainter, now properly delegated to parent

## Test plan
- [x] Wind arrow is more visible on wind rose
- [x] Wind rose center dot color matches site marker color (red for not flyable, green for flyable, blue for unknown)
- [x] Wind rose tooltip matches site marker tooltip
- [x] Wind rose displays even when site has no wind orientations defined

🤖 Generated with [Claude Code](https://claude.com/claude-code)