### PR TITLE
fix: Resolve flutter analyzer warnings and deprecations

### DIFF
--- a/free_flight_log_app/lib/presentation/screens/nearby_sites_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/nearby_sites_screen.dart
@@ -1007,9 +1007,6 @@ class _NearbySitesScreenState extends State<NearbySitesScreen> {
       final previousForecastEnabled = _forecastEnabled;
       final previousWeatherStationsEnabled = _weatherStationsEnabled;
 
-      // Get previous clipping state to detect changes
-      final previousClippingEnabled = await _openAipService.isClippingEnabled();
-
       // Update non-airspace states immediately
       setState(() {
         _sitesEnabled = sitesEnabled;

--- a/free_flight_log_app/lib/presentation/widgets/map_filter_dialog.dart
+++ b/free_flight_log_app/lib/presentation/widgets/map_filter_dialog.dart
@@ -225,9 +225,9 @@ class _MapFilterDialogState extends State<MapFilterDialog> {
                       const SizedBox(height: 16),
                       Container(
                         decoration: BoxDecoration(
-                          color: Colors.white.withOpacity(0.05),
+                          color: Colors.white.withValues(alpha: 0.05),
                           borderRadius: BorderRadius.circular(4),
-                          border: Border.all(color: Colors.white.withOpacity(0.1)),
+                          border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
                         ),
                         padding: const EdgeInsets.all(8),
                         child: Row(

--- a/free_flight_log_app/lib/presentation/widgets/weather_station_marker.dart
+++ b/free_flight_log_app/lib/presentation/widgets/weather_station_marker.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'dart:math' as math;
 import '../../data/models/weather_station.dart';
 import '../../data/models/wind_data.dart';
-import 'package:intl/intl.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 /// Weather station marker showing wind direction and speed with barbed arrow

--- a/free_flight_log_app/lib/services/weather_station_service.dart
+++ b/free_flight_log_app/lib/services/weather_station_service.dart
@@ -208,8 +208,7 @@ class WeatherStationService {
       LoggingService.structured('METAR_REQUEST_FAILED', {
         'error_type': e.runtimeType.toString(),
         'error_message': e.toString(),
-        'bbox': bounds.south.toStringAsFixed(2) + ',' + bounds.west.toStringAsFixed(2) + ',' +
-                bounds.north.toStringAsFixed(2) + ',' + bounds.east.toStringAsFixed(2),
+        'bbox': '${bounds.south.toStringAsFixed(2)},${bounds.west.toStringAsFixed(2)},${bounds.north.toStringAsFixed(2)},${bounds.east.toStringAsFixed(2)}',
         'cache_key': cacheKey,
       });
       LoggingService.error('Failed to fetch METAR stations', e, stackTrace);


### PR DESCRIPTION
## Summary
- Removed unused variable `previousClippingEnabled` in nearby_sites_screen
- Replaced deprecated `withOpacity()` with `withValues(alpha:)` in map_filter_dialog  
- Removed unused import `package:intl/intl.dart` in weather_station_marker
- Used string interpolation instead of concatenation in weather_station_service

All 7 analyzer issues resolved. Clean build with no warnings.

## Test plan
- [x] Run `flutter analyze` - no issues found
- [ ] Verify app builds and runs without errors
- [ ] Verify map filter dialog displays correctly with new withValues() method
- [ ] Verify nearby sites screen functions normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)