### PR TITLE
feat: Multi-provider weather station architecture with METAR and NWS support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -535,3 +535,4 @@ Use format `file_path:line_number` in logs:
 - always run flutter_controller_enhanced in background
 - DOnt try to contol the app
 - don't try to controll app with adb
+- Filters in Map FIlter, e.g, checkboxes, should have immediate effect in the map

--- a/docs/ADDING_WEATHER_PROVIDERS.md
+++ b/docs/ADDING_WEATHER_PROVIDERS.md
@@ -1,0 +1,303 @@
+# Adding Weather Station Providers
+
+This guide explains how to add a new weather station data provider to Free Flight Log.
+
+## Architecture Overview
+
+The weather station system uses a **provider-based architecture** that allows multiple weather data sources to work together:
+
+```
+WeatherStationService
+    ↓ (coordinates all providers)
+WeatherStationProviderRegistry
+    ↓ (manages available providers)
+WeatherStationProvider (interface)
+    ↓ (implemented by each source)
+├─ MetarWeatherProvider
+├─ NwsWeatherProvider
+└─ YourNewProvider
+```
+
+## Core Components
+
+### 1. WeatherStationSource Enum
+**File:** `lib/data/models/weather_station_source.dart`
+
+Add your provider identifier:
+```dart
+enum WeatherStationSource {
+  metar,
+  nws,
+  yourProvider,  // Add here
+}
+```
+
+### 2. WeatherStationProvider Interface
+**File:** `lib/services/weather_providers/weather_station_provider.dart`
+
+All providers must implement this interface:
+
+```dart
+abstract class WeatherStationProvider {
+  // Identification
+  WeatherStationSource get source;
+  String get displayName;        // "Your Provider Name"
+  String get description;        // Short description for UI
+  String get attributionName;    // For About screen
+  String get attributionUrl;     // Provider website
+
+  // Configuration
+  bool get requiresApiKey;
+  Duration get cacheTTL;
+  Future<bool> isConfigured();
+
+  // Data fetching
+  Future<List<WeatherStation>> fetchStations(LatLngBounds bounds);
+  Future<Map<String, WindData>> fetchWeatherData(List<WeatherStation> stations);
+
+  // Cache management
+  void clearCache();
+  Map<String, dynamic> getCacheStats();
+}
+```
+
+### 3. Create Provider Implementation
+**File:** `lib/services/weather_providers/your_provider_weather_provider.dart`
+
+```dart
+class YourProviderWeatherProvider implements WeatherStationProvider {
+  static final YourProviderWeatherProvider instance = YourProviderWeatherProvider._();
+  YourProviderWeatherProvider._();
+
+  static const String _baseUrl = 'https://api.yourprovider.com';
+
+  @override
+  WeatherStationSource get source => WeatherStationSource.yourProvider;
+
+  @override
+  String get displayName => 'Your Provider';
+
+  @override
+  String get description => 'Description shown in UI';
+
+  @override
+  String get attributionName => 'Your Provider Inc.';
+
+  @override
+  String get attributionUrl => 'https://yourprovider.com/';
+
+  @override
+  Duration get cacheTTL => MapConstants.weatherStationCacheTTL;
+
+  @override
+  bool get requiresApiKey => true; // or false
+
+  @override
+  Future<bool> isConfigured() async {
+    // Check if API key is configured (if required)
+    return true;
+  }
+
+  @override
+  Future<List<WeatherStation>> fetchStations(LatLngBounds bounds) async {
+    // Fetch station list from API
+    // Parse response
+    // Return List<WeatherStation>
+  }
+
+  @override
+  Future<Map<String, WindData>> fetchWeatherData(
+    List<WeatherStation> stations,
+  ) async {
+    // Fetch weather observations for stations
+    // Return Map<stationKey, WindData>
+  }
+
+  @override
+  void clearCache() {
+    // Clear any cached data
+  }
+
+  @override
+  Map<String, dynamic> getCacheStats() {
+    return {
+      'total_cache_entries': 0,
+      'valid_cache_entries': 0,
+    };
+  }
+}
+```
+
+### 4. Register Provider
+**File:** `lib/services/weather_providers/weather_station_provider.dart`
+
+Add to the registry:
+
+```dart
+class WeatherStationProviderRegistry {
+  static final Map<WeatherStationSource, WeatherStationProvider> _providers = {
+    WeatherStationSource.metar: MetarWeatherProvider.instance,
+    WeatherStationSource.nws: NwsWeatherProvider.instance,
+    WeatherStationSource.yourProvider: YourProviderWeatherProvider.instance, // Add here
+  };
+
+  // ... rest of registry code
+}
+```
+
+## Data Flow
+
+### Station Fetching
+```
+1. User views map at zoom ≥ 10
+2. WeatherStationService.getStationsInBounds() called
+3. Service checks which providers are enabled (via SharedPreferences)
+4. Service calls fetchStations() on each enabled provider in parallel
+5. Results are combined and deduplicated
+6. Stations displayed as markers on map
+```
+
+### Weather Data Fetching
+```
+1. WeatherStationService.getWeatherForStations() called
+2. Stations grouped by source
+3. Each provider's fetchWeatherData() called with its stations
+4. Results combined into Map<stationKey, WindData>
+5. Wind data displayed on markers
+```
+
+## UI Integration
+
+The provider automatically appears in the Map Filter dialog once registered:
+
+**File:** `lib/presentation/widgets/map_filter_dialog.dart`
+
+The dialog dynamically generates checkboxes from `WeatherStationProviderRegistry.getAllSources()`:
+
+```dart
+// METAR provider
+_buildProviderCheckbox(
+  value: _metarEnabled,
+  label: 'METAR (Aviation)',
+  subtitle: WeatherStationProviderRegistry.getProvider(WeatherStationSource.metar).description,
+  onChanged: (value) => setState(() {
+    _metarEnabled = value ?? true;
+    _applyFiltersImmediately();
+  }),
+),
+
+// Your provider will appear here automatically
+```
+
+## Implementation Checklist
+
+- [ ] Add enum value to `WeatherStationSource`
+- [ ] Create provider implementation file
+- [ ] Implement all `WeatherStationProvider` interface methods
+- [ ] Add provider to `WeatherStationProviderRegistry`
+- [ ] Add API endpoints/authentication if needed
+- [ ] Implement proper caching (stations and weather data)
+- [ ] Add structured logging for debugging
+- [ ] Handle errors gracefully (timeouts, invalid responses)
+- [ ] Add user agent header: `User-Agent: FreeFlightLog/1.0`
+- [ ] Test with various bounding boxes and zoom levels
+- [ ] Add attribution to About screen (automatic via `attributionName`/`attributionUrl`)
+- [ ] Update preferences handling if API key required
+
+## Example APIs to Consider
+
+### Global Coverage
+- **OpenWeatherMap** - Global, requires API key, paid tiers available
+- **WeatherAPI.com** - Global, free tier available
+- **Tomorrow.io** - Global, weather stations and observations
+
+### Regional Coverage
+- **DWD (Germany)** - Free, German weather service
+- **Met Office (UK)** - Free, UK weather service
+- **Météo-France** - Free, French weather service
+- **BOM (Australia)** - Free, Australian weather service
+- **MetService (NZ)** - Free, New Zealand weather service
+
+### Aviation-Specific
+- **CheckWX** - Global METAR/TAF aggregator, free tier
+- **AWC Text Data Server** - US aviation weather text products
+
+## Best Practices
+
+### Performance
+- Cache station lists (they rarely change)
+- Batch weather data requests when possible
+- Use connection pooling for multiple requests
+- Implement request deduplication for concurrent calls
+- Set reasonable timeouts (10-30 seconds)
+
+### Error Handling
+- Log all API errors with structured logging
+- Return empty lists/maps on failure (don't crash)
+- Handle rate limiting gracefully
+- Provide user-friendly error messages
+
+### Caching Strategy
+```dart
+// Station list: Long TTL (1 hour+)
+Duration get cacheTTL => MapConstants.stationListCacheTTL;
+
+// Weather data: Short TTL (5-15 minutes)
+Duration get cacheTTL => MapConstants.weatherStationCacheTTL;
+```
+
+### API Etiquette
+- Always include `User-Agent: FreeFlightLog/1.0`
+- Respect rate limits
+- Cache aggressively to minimize requests
+- Include attribution as required by terms of service
+- Check API terms for commercial use restrictions
+
+## Testing
+
+1. **Enable provider** in Map Filter dialog
+2. **Zoom in** to zoom level ≥ 10
+3. **Verify stations appear** on map
+4. **Check wind data** displays on markers
+5. **Test cache** by moving map and returning
+6. **Test with provider disabled** - markers should disappear
+7. **Test error cases** - network timeout, invalid API key, etc.
+8. **Check logs** for structured logging output
+
+## Debugging
+
+Enable debug logging in `LoggingService` to see:
+- `[WEATHER_STATION_FETCH_START]` - Provider fetch initiated
+- `[WEATHER_STATION_FETCH_COMPLETE]` - Station count by provider
+- `[STATION_FETCH_SUCCESS]` - Total stations with data
+- Provider-specific logs (e.g., `[METAR_API_REQUEST]`, `[NWS_OBSERVATION_SUCCESS]`)
+
+## Configuration Storage
+
+Provider settings are stored in `SharedPreferences`:
+
+```dart
+// Enable/disable provider
+final key = 'weather_provider_${source.name}_enabled';
+await prefs.setBool(key, enabled);
+
+// API key (if required)
+final apiKeyKey = 'weather_provider_${source.name}_api_key';
+await prefs.setString(apiKeyKey, apiKey);
+```
+
+## Related Files
+
+- **Core Interface:** `lib/services/weather_providers/weather_station_provider.dart`
+- **Service Coordinator:** `lib/services/weather_station_service.dart`
+- **Data Models:** `lib/data/models/weather_station.dart`, `lib/data/models/wind_data.dart`
+- **UI Integration:** `lib/presentation/widgets/map_filter_dialog.dart`
+- **Map Display:** `lib/presentation/widgets/weather_station_marker.dart`
+- **Examples:** `lib/services/weather_providers/metar_weather_provider.dart`, `lib/services/weather_providers/nws_weather_provider.dart`
+
+## Support
+
+For questions or issues, check:
+- [Technical Design Document](TECHNICAL_DESIGN.md)
+- [Functional Specification](FUNCTIONAL_SPECIFICATION.md)
+- Existing provider implementations for reference

--- a/docs/ADDING_WEATHER_PROVIDERS.md
+++ b/docs/ADDING_WEATHER_PROVIDERS.md
@@ -352,32 +352,18 @@ curl -s "https://aviationweather.gov/api/data/metar?bbox=36.5,-122,37,-121&forma
 
 ### NWS (National Weather Service)
 
-Get observation for a specific station (two-step process):
-
-Step 1: Get station metadata:
+Get station metadata:
 ```bash
 curl -s "https://api.weather.gov/stations/KSNS" \
   -H "Accept: application/geo+json" \
   -H "User-Agent: FreeFlightLog/1.0" | python3 -m json.tool
 ```
 
-Step 2: Get latest observation:
+Get latest observation:
 ```bash
 curl -s "https://api.weather.gov/stations/KSNS/observations/latest" \
   -H "Accept: application/geo+json" \
   -H "User-Agent: FreeFlightLog/1.0" | python3 -m json.tool
-```
-
-Extract wind data:
-```bash
-curl -s "https://api.weather.gov/stations/KSNS/observations/latest" \
-  -H "Accept: application/geo+json" \
-  -H "User-Agent: FreeFlightLog/1.0" | \
-  python3 -c "import sys, json; data=json.load(sys.stdin); props=data['properties']; \
-print(f\"Station: {props['stationName']}\"); \
-print(f\"Wind: {props['windDirection']['value']}° at {props['windSpeed']['value']} {props['windSpeed']['unitCode'].split(':')[1]}\"); \
-print(f\"Gusts: {props['windGust']['value']}\"); \
-print(f\"Time: {props['timestamp']}\")"
 ```
 
 **Response format:** GeoJSON with wind speed already in km/h (`unitCode: "wmoUnit:km_h-1"`), direction in degrees

--- a/docs/ADDING_WEATHER_PROVIDERS.md
+++ b/docs/ADDING_WEATHER_PROVIDERS.md
@@ -317,3 +317,13 @@ For questions or issues, check:
 - [Technical Design Document](TECHNICAL_DESIGN.md)
 - [Functional Specification](FUNCTIONAL_SPECIFICATION.md)
 - Existing provider implementations for reference
+
+
+## Data Sources
+
+### NWS
+The US national weather service
+- Limited to US only
+- Two approaches. 
+  - Get the n nearest stations to a point by looing up the station nearest a grid (2.5km area). Then find the stations that are in teh BB and look up each individually. Use agressive caching
+  - DOwnload 

--- a/docs/ADDING_WEATHER_PROVIDERS.md
+++ b/docs/ADDING_WEATHER_PROVIDERS.md
@@ -21,9 +21,11 @@ WeatherStationProvider (interface)
 ## Core Components
 
 ### 1. WeatherStationSource Enum
+
 **File:** `lib/data/models/weather_station_source.dart`
 
 Add your provider identifier:
+
 ```dart
 enum WeatherStationSource {
   metar,
@@ -33,6 +35,7 @@ enum WeatherStationSource {
 ```
 
 ### 2. WeatherStationProvider Interface
+
 **File:** `lib/services/weather_providers/weather_station_provider.dart`
 
 All providers must implement this interface:
@@ -62,6 +65,7 @@ abstract class WeatherStationProvider {
 ```
 
 ### 3. Create Provider Implementation
+
 **File:** `lib/services/weather_providers/your_provider_weather_provider.dart`
 
 ```dart
@@ -129,6 +133,7 @@ class YourProviderWeatherProvider implements WeatherStationProvider {
 ```
 
 ### 4. Register Provider
+
 **File:** `lib/services/weather_providers/weather_station_provider.dart`
 
 Add to the registry:
@@ -148,6 +153,7 @@ class WeatherStationProviderRegistry {
 ## Data Flow
 
 ### Station Fetching
+
 ```
 1. User views map at zoom ≥ 10
 2. WeatherStationService.getStationsInBounds() called
@@ -158,6 +164,7 @@ class WeatherStationProviderRegistry {
 ```
 
 ### Weather Data Fetching
+
 ```
 1. WeatherStationService.getWeatherForStations() called
 2. Stations grouped by source
@@ -207,11 +214,13 @@ _buildProviderCheckbox(
 ## Example APIs to Consider
 
 ### Global Coverage
+
 - **OpenWeatherMap** - Global, requires API key, paid tiers available
 - **WeatherAPI.com** - Global, free tier available
 - **Tomorrow.io** - Global, weather stations and observations
 
 ### Regional Coverage
+
 - **DWD (Germany)** - Free, German weather service
 - **Met Office (UK)** - Free, UK weather service
 - **Météo-France** - Free, French weather service
@@ -219,12 +228,14 @@ _buildProviderCheckbox(
 - **MetService (NZ)** - Free, New Zealand weather service
 
 ### Aviation-Specific
+
 - **CheckWX** - Global METAR/TAF aggregator, free tier
 - **AWC Text Data Server** - US aviation weather text products
 
 ## Best Practices
 
 ### Performance
+
 - Cache station lists (they rarely change)
 - Batch weather data requests when possible
 - Use connection pooling for multiple requests
@@ -232,12 +243,14 @@ _buildProviderCheckbox(
 - Set reasonable timeouts (10-30 seconds)
 
 ### Error Handling
+
 - Log all API errors with structured logging
 - Return empty lists/maps on failure (don't crash)
 - Handle rate limiting gracefully
 - Provide user-friendly error messages
 
 ### Caching Strategy
+
 ```dart
 // Station list: Long TTL (1 hour+)
 Duration get cacheTTL => MapConstants.stationListCacheTTL;
@@ -247,6 +260,7 @@ Duration get cacheTTL => MapConstants.weatherStationCacheTTL;
 ```
 
 ### API Etiquette
+
 - Always include `User-Agent: FreeFlightLog/1.0`
 - Respect rate limits
 - Cache aggressively to minimize requests
@@ -267,6 +281,7 @@ Duration get cacheTTL => MapConstants.weatherStationCacheTTL;
 ## Debugging
 
 Enable debug logging in `LoggingService` to see:
+
 - `[WEATHER_STATION_FETCH_START]` - Provider fetch initiated
 - `[WEATHER_STATION_FETCH_COMPLETE]` - Station count by provider
 - `[STATION_FETCH_SUCCESS]` - Total stations with data
@@ -298,6 +313,7 @@ await prefs.setString(apiKeyKey, apiKey);
 ## Support
 
 For questions or issues, check:
+
 - [Technical Design Document](TECHNICAL_DESIGN.md)
 - [Functional Specification](FUNCTIONAL_SPECIFICATION.md)
 - Existing provider implementations for reference

--- a/free_flight_log_app/lib/data/models/weather_station.dart
+++ b/free_flight_log_app/lib/data/models/weather_station.dart
@@ -1,10 +1,14 @@
 import 'wind_data.dart';
+import 'weather_station_source.dart';
 
-/// METAR weather station from aviationweather.gov
+/// Weather station from various data providers (METAR, NOAA CDO, etc.)
 /// Represents an actual meteorological station with location and weather data
 class WeatherStation {
   /// Unique station identifier
   final String id;
+
+  /// Data source/provider for this station
+  final WeatherStationSource source;
 
   /// Station name (if available from API)
   final String? name;
@@ -21,41 +25,49 @@ class WeatherStation {
   /// Station elevation in meters (if available)
   final double? elevation;
 
+  /// Dataset ID (for providers like NOAA CDO that have multiple datasets)
+  final String? datasetId;
+
   const WeatherStation({
     required this.id,
+    required this.source,
     this.name,
     required this.latitude,
     required this.longitude,
     this.windData,
     this.elevation,
+    this.datasetId,
   });
 
   /// Create a copy with updated wind data
   WeatherStation copyWith({WindData? windData}) {
     return WeatherStation(
       id: id,
+      source: source,
       name: name,
       latitude: latitude,
       longitude: longitude,
       windData: windData ?? this.windData,
       elevation: elevation,
+      datasetId: datasetId,
     );
   }
 
-  /// Create a unique key for this station based on its ID
-  String get key => id;
+  /// Create a unique key for this station based on source and ID
+  /// Ensures uniqueness across multiple providers
+  String get key => '${source.name}:$id';
 
   @override
   String toString() {
-    return 'WeatherStation(id: $id, name: $name, lat: $latitude, lon: $longitude, elevation: $elevation)';
+    return 'WeatherStation(source: ${source.name}, id: $id, name: $name, lat: $latitude, lon: $longitude, elevation: $elevation)';
   }
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
-    return other is WeatherStation && other.id == id;
+    return other is WeatherStation && other.source == source && other.id == id;
   }
 
   @override
-  int get hashCode => id.hashCode;
+  int get hashCode => Object.hash(source, id);
 }

--- a/free_flight_log_app/lib/data/models/weather_station.dart
+++ b/free_flight_log_app/lib/data/models/weather_station.dart
@@ -28,6 +28,9 @@ class WeatherStation {
   /// Dataset ID (for providers like NOAA CDO that have multiple datasets)
   final String? datasetId;
 
+  /// Observation type (e.g., "Airport (METAR)", "CWOP Citizen Station")
+  final String? observationType;
+
   const WeatherStation({
     required this.id,
     required this.source,
@@ -37,6 +40,7 @@ class WeatherStation {
     this.windData,
     this.elevation,
     this.datasetId,
+    this.observationType,
   });
 
   /// Create a copy with updated wind data
@@ -50,7 +54,26 @@ class WeatherStation {
       windData: windData ?? this.windData,
       elevation: elevation,
       datasetId: datasetId,
+      observationType: observationType,
     );
+  }
+
+  /// Infer observation type from station ID pattern
+  /// Different station ID prefixes indicate different types of observation stations
+  static String inferObservationType(String stationId) {
+    if (stationId.startsWith('K') && stationId.length == 4) {
+      return 'Airport (METAR)';
+    } else if (stationId.startsWith('P') && stationId.length == 4) {
+      return 'Pacific Airport';
+    } else if (stationId.startsWith('C') || stationId.startsWith('CW')) {
+      return 'CWOP Citizen Station';
+    } else if (stationId.startsWith('DW')) {
+      return 'Military Station';
+    } else if (RegExp(r'^\d+$').hasMatch(stationId)) {
+      return 'Marine Buoy';
+    } else {
+      return 'Weather Station';
+    }
   }
 
   /// Create a unique key for this station based on source and ID

--- a/free_flight_log_app/lib/data/models/weather_station_source.dart
+++ b/free_flight_log_app/lib/data/models/weather_station_source.dart
@@ -1,0 +1,14 @@
+/// Source/provider for weather station data
+///
+/// Pure enum identifier for weather station data providers.
+/// All provider-specific information (names, URLs, methods) is in the provider classes.
+/// Use source.name to get string ID ("metar", "nws", etc.)
+enum WeatherStationSource {
+  /// METAR data from aviationweather.gov
+  /// Airport weather stations with real-time observations
+  metar,
+
+  /// National Weather Service (NWS) from api.weather.gov
+  /// Real-time weather observations from non-airport stations
+  nws,
+}

--- a/free_flight_log_app/lib/presentation/screens/about_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/about_screen.dart
@@ -399,7 +399,7 @@ class _AboutScreenState extends State<AboutScreen> {
                           ),
                           const SizedBox(width: 8),
                           Text(
-                            'Aviation Weather Center (NOAA/NWS)',
+                            'Weather Data Sources',
                             style: TextStyle(
                               color: Theme.of(context).colorScheme.primary,
                               decoration: TextDecoration.underline,
@@ -410,7 +410,7 @@ class _AboutScreenState extends State<AboutScreen> {
                     ),
                     const SizedBox(height: 8),
                     Text(
-                      'Real-time METAR reports from airports and weather stations worldwide.',
+                      'Real-time weather observations from multiple providers.',
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
                         color: Colors.grey[600],
                       ),
@@ -472,7 +472,8 @@ class _AboutScreenState extends State<AboutScreen> {
                       '• Paragliding sites: ParaglidingEarth API\n'
                       '• Airspace data: OpenAIP API\n'
                       '• Weather forecasts: Open-Meteo API\n'
-                      '• METAR station data: Aviation Weather Center (NOAA)',
+                      '• METAR stations: Aviation Weather Center (NOAA)\n'
+                      '• NWS stations: US National Weather Service (NOAA)',
                       style: Theme.of(context).textTheme.bodySmall,
                     ),
                   ],

--- a/free_flight_log_app/lib/presentation/screens/nearby_sites_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/nearby_sites_screen.dart
@@ -2964,7 +2964,7 @@ class _DraggableFilterDialogState extends State<_DraggableFilterDialog> {
                 final screenSize = MediaQuery.of(context).size;
                 _position = Offset(
                   _position.dx.clamp(0, screenSize.width - 300), // Assume dialog width ~300
-                  _position.dy.clamp(0, screenSize.height - 400), // Assume dialog height ~400
+                  _position.dy.clamp(0, screenSize.height - 600), // Assume dialog height ~600
                 );
               });
             },

--- a/free_flight_log_app/lib/presentation/screens/nearby_sites_screen.dart
+++ b/free_flight_log_app/lib/presentation/screens/nearby_sites_screen.dart
@@ -1024,6 +1024,8 @@ class _NearbySitesScreenState extends State<NearbySitesScreen> {
       final previousAirspaceEnabled = _airspaceEnabled;
       final previousForecastEnabled = _forecastEnabled;
       final previousWeatherStationsEnabled = _weatherStationsEnabled;
+      final previousMetarEnabled = _metarEnabled;
+      final previousNwsEnabled = _nwsEnabled;
 
       // Update non-airspace states immediately
       setState(() {
@@ -1137,6 +1139,20 @@ class _NearbySitesScreenState extends State<NearbySitesScreen> {
           _fetchWeatherStations();
         }
         LoggingService.action('MapFilter', 'weather_stations_enabled', {'will_fetch': currentZoom >= MapConstants.minForecastZoom});
+      } else if (weatherStationsEnabled && (metarEnabled != previousMetarEnabled || nwsEnabled != previousNwsEnabled)) {
+        // Weather station providers changed - refresh stations
+        final currentZoom = _mapController.camera.zoom;
+        if (currentZoom >= MapConstants.minForecastZoom) {
+          // Clear existing stations and re-fetch with new provider configuration
+          WeatherStationService.instance.clearCache();
+          _fetchWeatherStations();
+        }
+        LoggingService.action('MapFilter', 'weather_providers_changed', {
+          'metar_enabled': metarEnabled,
+          'nws_enabled': nwsEnabled,
+          'metar_changed': metarEnabled != previousMetarEnabled,
+          'nws_changed': nwsEnabled != previousNwsEnabled,
+        });
       }
 
       // Handle airspace visibility changes

--- a/free_flight_log_app/lib/presentation/widgets/common/map_loading_overlay.dart
+++ b/free_flight_log_app/lib/presentation/widgets/common/map_loading_overlay.dart
@@ -1,17 +1,26 @@
 import 'package:flutter/material.dart';
 
+/// State of a loading item
+enum LoadingItemState {
+  loading,
+  completed,
+  error,
+}
+
 /// Data class for a single loading item in the overlay
 class MapLoadingItem {
   final String label;
   final IconData icon;
   final Color iconColor;
   final int? count;
+  final LoadingItemState state;
 
   const MapLoadingItem({
     required this.label,
     this.icon = Icons.place,
     this.iconColor = Colors.green,
     this.count,
+    this.state = LoadingItemState.loading,
   });
 }
 
@@ -99,23 +108,17 @@ class MapLoadingOverlay extends StatelessWidget {
           color: item.iconColor.withValues(alpha: 0.8),
         ),
         const SizedBox(width: 10),
-        // Loading spinner
-        const SizedBox(
-          width: 14,
-          height: 14,
-          child: CircularProgressIndicator(
-            strokeWidth: 2,
-            valueColor: AlwaysStoppedAnimation<Color>(Colors.white70),
-            strokeCap: StrokeCap.round,
-          ),
-        ),
+        // State indicator (spinner, checkmark, or error)
+        _buildStateIndicator(item.state),
         const SizedBox(width: 10),
         // Text label with optional count
         Flexible(
           child: Text(
             item.count != null ? '${item.label} (${item.count})' : item.label,
-            style: const TextStyle(
-              color: Colors.white,
+            style: TextStyle(
+              color: item.state == LoadingItemState.error
+                  ? Colors.red.shade300
+                  : Colors.white,
               fontSize: 13,
               fontWeight: FontWeight.w500,
             ),
@@ -124,5 +127,32 @@ class MapLoadingOverlay extends StatelessWidget {
         ),
       ],
     );
+  }
+
+  Widget _buildStateIndicator(LoadingItemState state) {
+    switch (state) {
+      case LoadingItemState.loading:
+        return const SizedBox(
+          width: 14,
+          height: 14,
+          child: CircularProgressIndicator(
+            strokeWidth: 2,
+            valueColor: AlwaysStoppedAnimation<Color>(Colors.white70),
+            strokeCap: StrokeCap.round,
+          ),
+        );
+      case LoadingItemState.completed:
+        return Icon(
+          Icons.check_circle,
+          size: 14,
+          color: Colors.green.shade400,
+        );
+      case LoadingItemState.error:
+        return Icon(
+          Icons.error,
+          size: 14,
+          color: Colors.red.shade400,
+        );
+    }
   }
 }

--- a/free_flight_log_app/lib/presentation/widgets/map_filter_dialog.dart
+++ b/free_flight_log_app/lib/presentation/widgets/map_filter_dialog.dart
@@ -326,7 +326,7 @@ class _MapFilterDialogState extends State<MapFilterDialog> {
               child: InkWell(
                 onTap: () => setState(() {
                   _sitesEnabled = !_sitesEnabled;
-                  _applyFiltersDebounced();
+                  _applyFiltersImmediately();
                 }),
                 borderRadius: BorderRadius.circular(4),
                 child: SizedBox(
@@ -341,7 +341,7 @@ class _MapFilterDialogState extends State<MapFilterDialog> {
                           value: _sitesEnabled,
                           onChanged: (value) => setState(() {
                             _sitesEnabled = value ?? true;
-                            _applyFiltersDebounced();
+                            _applyFiltersImmediately();
                           }),
                           activeColor: Colors.blue,
                           checkColor: Colors.white,
@@ -361,53 +361,52 @@ class _MapFilterDialogState extends State<MapFilterDialog> {
               ),
             ),
             const SizedBox(width: 16), // Space between checkboxes
-            // Forecast checkbox (only shown when sites are enabled)
-            if (_sitesEnabled)
-              Tooltip(
-                message: 'Show wind forecast and flyability for sites',
-                textStyle: const TextStyle(color: Colors.white, fontSize: 12),
-                decoration: BoxDecoration(
-                  color: const Color(0xFF1E1E1E),
-                  borderRadius: BorderRadius.circular(6),
-                  border: Border.all(color: Colors.white24),
-                ),
-                child: InkWell(
-                  onTap: () => setState(() {
-                    _forecastEnabled = !_forecastEnabled;
-                    _applyFiltersDebounced();
-                  }),
-                  borderRadius: BorderRadius.circular(4),
-                  child: SizedBox(
-                    height: 24,
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        SizedBox(
-                          width: 20,
-                          height: 20,
-                          child: Checkbox(
-                            value: _forecastEnabled,
-                            onChanged: (value) => setState(() {
-                              _forecastEnabled = value ?? true;
-                              _applyFiltersDebounced();
-                            }),
-                            activeColor: Colors.blue,
-                            checkColor: Colors.white,
-                            side: const BorderSide(color: Colors.white54),
-                            materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                            visualDensity: VisualDensity.compact,
-                          ),
+            // Forecast checkbox (disabled when sites are disabled)
+            Tooltip(
+              message: 'Show wind forecast and flyability for sites',
+              textStyle: const TextStyle(color: Colors.white, fontSize: 12),
+              decoration: BoxDecoration(
+                color: const Color(0xFF1E1E1E),
+                borderRadius: BorderRadius.circular(6),
+                border: Border.all(color: Colors.white24),
+              ),
+              child: InkWell(
+                onTap: _sitesEnabled ? () => setState(() {
+                  _forecastEnabled = !_forecastEnabled;
+                  _applyFiltersImmediately();
+                }) : null,
+                borderRadius: BorderRadius.circular(4),
+                child: SizedBox(
+                  height: 24,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: Checkbox(
+                          value: _forecastEnabled,
+                          onChanged: _sitesEnabled ? (value) => setState(() {
+                            _forecastEnabled = value ?? true;
+                            _applyFiltersImmediately();
+                          }) : null,
+                          activeColor: Colors.blue,
+                          checkColor: Colors.white,
+                          side: const BorderSide(color: Colors.white54),
+                          materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                          visualDensity: VisualDensity.compact,
                         ),
-                        const SizedBox(width: 4),
-                        const Text(
-                          'Forecast',
-                          style: TextStyle(color: Colors.white, fontSize: 12),
-                        ),
-                      ],
-                    ),
+                      ),
+                      const SizedBox(width: 4),
+                      const Text(
+                        'Forecast',
+                        style: TextStyle(color: Colors.white, fontSize: 12),
+                      ),
+                    ],
                   ),
                 ),
               ),
+            ),
           ],
         ),
         const SizedBox(height: 8),
@@ -425,7 +424,7 @@ class _MapFilterDialogState extends State<MapFilterDialog> {
               child: InkWell(
                 onTap: () => setState(() {
                   _weatherStationsEnabled = !_weatherStationsEnabled;
-                  _applyFiltersDebounced();
+                  _applyFiltersImmediately();
                 }),
                 borderRadius: BorderRadius.circular(4),
                 child: SizedBox(
@@ -440,7 +439,7 @@ class _MapFilterDialogState extends State<MapFilterDialog> {
                           value: _weatherStationsEnabled,
                           onChanged: (value) => setState(() {
                             _weatherStationsEnabled = value ?? true;
-                            _applyFiltersDebounced();
+                            _applyFiltersImmediately();
                           }),
                           activeColor: Colors.blue,
                           checkColor: Colors.white,
@@ -451,7 +450,7 @@ class _MapFilterDialogState extends State<MapFilterDialog> {
                       ),
                       const SizedBox(width: 4),
                       const Text(
-                        'Weather',
+                        'Weather Stations',
                         style: TextStyle(color: Colors.white, fontSize: 12),
                       ),
                     ],
@@ -461,39 +460,37 @@ class _MapFilterDialogState extends State<MapFilterDialog> {
             ),
           ],
         ),
-        // Weather provider checkboxes (indented, only visible when stations enabled)
-        if (_weatherStationsEnabled) ...[
-          const SizedBox(height: 4),
-          Padding(
-            padding: const EdgeInsets.only(left: 24),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                // METAR provider
-                _buildProviderCheckbox(
-                  value: _metarEnabled,
-                  label: 'METAR (Aviation)',
-                  subtitle: WeatherStationProviderRegistry.getProvider(WeatherStationSource.metar).description,
-                  onChanged: (value) => setState(() {
-                    _metarEnabled = value ?? true;
-                    _applyFiltersDebounced();
-                  }),
-                ),
-                const SizedBox(height: 2),
-                // NWS provider (US only)
-                _buildProviderCheckbox(
-                  value: _nwsEnabled,
-                  label: 'NWS (US only)',
-                  subtitle: WeatherStationProviderRegistry.getProvider(WeatherStationSource.nws).description,
-                  onChanged: (value) => setState(() {
-                    _nwsEnabled = value ?? true;
-                    _applyFiltersDebounced();
-                  }),
-                ),
-              ],
-            ),
+        // Weather provider checkboxes (indented, disabled when stations disabled)
+        const SizedBox(height: 4),
+        Padding(
+          padding: const EdgeInsets.only(left: 24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // METAR provider
+              _buildProviderCheckbox(
+                value: _metarEnabled,
+                label: 'METAR (Aviation)',
+                subtitle: WeatherStationProviderRegistry.getProvider(WeatherStationSource.metar).description,
+                onChanged: _weatherStationsEnabled ? (value) => setState(() {
+                  _metarEnabled = value ?? true;
+                  _applyFiltersImmediately();
+                }) : null,
+              ),
+              const SizedBox(height: 2),
+              // NWS provider (US only)
+              _buildProviderCheckbox(
+                value: _nwsEnabled,
+                label: 'NWS (US only)',
+                subtitle: WeatherStationProviderRegistry.getProvider(WeatherStationSource.nws).description,
+                onChanged: _weatherStationsEnabled ? (value) => setState(() {
+                  _nwsEnabled = value ?? true;
+                  _applyFiltersImmediately();
+                }) : null,
+              ),
+            ],
           ),
-        ],
+        ),
         const SizedBox(height: 8),
         // Row 3: Airspace, Clip
         Row(
@@ -508,10 +505,19 @@ class _MapFilterDialogState extends State<MapFilterDialog> {
                 border: Border.all(color: Colors.white24),
               ),
               child: InkWell(
-                onTap: () => setState(() {
-                  _airspaceEnabled = !_airspaceEnabled;
-                  _applyFiltersDebounced();
-                }),
+                onTap: () {
+                  final wasDisabled = !_airspaceEnabled;
+                  setState(() {
+                    _airspaceEnabled = !_airspaceEnabled;
+                    _applyFiltersImmediately();
+                  });
+                  // Update controllers after enabling airspace so dropdowns reflect saved values
+                  if (wasDisabled && _airspaceEnabled) {
+                    WidgetsBinding.instance.addPostFrameCallback((_) {
+                      _updateControllerSelections();
+                    });
+                  }
+                },
                 borderRadius: BorderRadius.circular(4),
                 child: SizedBox(
                   height: 24,
@@ -523,10 +529,19 @@ class _MapFilterDialogState extends State<MapFilterDialog> {
                         height: 20,
                         child: Checkbox(
                           value: _airspaceEnabled,
-                          onChanged: (value) => setState(() {
-                            _airspaceEnabled = value ?? true;
-                            _applyFiltersDebounced();
-                          }),
+                          onChanged: (value) {
+                            final wasDisabled = !_airspaceEnabled;
+                            setState(() {
+                              _airspaceEnabled = value ?? true;
+                              _applyFiltersImmediately();
+                            });
+                            // Update controllers after enabling airspace so dropdowns reflect saved values
+                            if (wasDisabled && _airspaceEnabled) {
+                              WidgetsBinding.instance.addPostFrameCallback((_) {
+                                _updateControllerSelections();
+                              });
+                            }
+                          },
                           activeColor: Colors.blue,
                           checkColor: Colors.white,
                           side: const BorderSide(color: Colors.white54),
@@ -545,57 +560,56 @@ class _MapFilterDialogState extends State<MapFilterDialog> {
               ),
             ),
             const SizedBox(width: 16), // Space between checkboxes
-            // Clip checkbox (only shown when airspace is enabled)
-            if (_airspaceEnabled)
-              Tooltip(
-                message: 'Only show the bottom layer at each point',
-                textStyle: const TextStyle(color: Colors.white, fontSize: 12),
-                decoration: BoxDecoration(
-                  color: const Color(0xFF1E1E1E),
-                  borderRadius: BorderRadius.circular(6),
-                  border: Border.all(color: Colors.white24),
-                ),
-                child: InkWell(
-                  onTap: () {
-                    setState(() {
-                      _clippingEnabled = !_clippingEnabled;
-                      _applyFiltersDebounced();
-                    });
-                  },
-                  borderRadius: BorderRadius.circular(4),
-                  child: SizedBox(
-                    height: 24,
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        SizedBox(
-                          width: 20,
-                          height: 20,
-                          child: Checkbox(
-                            value: _clippingEnabled,
-                            onChanged: (value) {
-                              setState(() {
-                                _clippingEnabled = value ?? true;
-                                _applyFiltersDebounced();
-                              });
-                            },
-                            activeColor: Colors.blue,
-                            checkColor: Colors.white,
-                            side: const BorderSide(color: Colors.white54),
-                            materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                            visualDensity: VisualDensity.compact,
-                          ),
+            // Clip checkbox (disabled when airspace is disabled)
+            Tooltip(
+              message: 'Only show the bottom layer at each point',
+              textStyle: const TextStyle(color: Colors.white, fontSize: 12),
+              decoration: BoxDecoration(
+                color: const Color(0xFF1E1E1E),
+                borderRadius: BorderRadius.circular(6),
+                border: Border.all(color: Colors.white24),
+              ),
+              child: InkWell(
+                onTap: _airspaceEnabled ? () {
+                  setState(() {
+                    _clippingEnabled = !_clippingEnabled;
+                    _applyFiltersImmediately();
+                  });
+                } : null,
+                borderRadius: BorderRadius.circular(4),
+                child: SizedBox(
+                  height: 24,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: Checkbox(
+                          value: _clippingEnabled,
+                          onChanged: _airspaceEnabled ? (value) {
+                            setState(() {
+                              _clippingEnabled = value ?? true;
+                              _applyFiltersImmediately();
+                            });
+                          } : null,
+                          activeColor: Colors.blue,
+                          checkColor: Colors.white,
+                          side: const BorderSide(color: Colors.white54),
+                          materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                          visualDensity: VisualDensity.compact,
                         ),
-                        const SizedBox(width: 4),
-                        const Text(
-                          'Clip',
-                          style: TextStyle(color: Colors.white, fontSize: 12),
-                        ),
-                      ],
-                    ),
+                      ),
+                      const SizedBox(width: 4),
+                      const Text(
+                        'Clip',
+                        style: TextStyle(color: Colors.white, fontSize: 12),
+                      ),
+                    ],
                   ),
                 ),
               ),
+            ),
           ],
         ),
       ],
@@ -994,10 +1008,10 @@ class _MapFilterDialogState extends State<MapFilterDialog> {
     required bool value,
     required String label,
     required String subtitle,
-    required ValueChanged<bool?> onChanged,
+    required ValueChanged<bool?>? onChanged,
   }) {
     return InkWell(
-      onTap: () => onChanged(!value),
+      onTap: onChanged != null ? () => onChanged(!value) : null,
       borderRadius: BorderRadius.circular(4),
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 4),

--- a/free_flight_log_app/lib/presentation/widgets/map_filter_dialog.dart
+++ b/free_flight_log_app/lib/presentation/widgets/map_filter_dialog.dart
@@ -185,7 +185,7 @@ class _MapFilterDialogState extends State<MapFilterDialog> {
       backgroundColor: Colors.transparent,
       child: Container(
         width: MediaQuery.of(context).size.width > 350 ? 320 : MediaQuery.of(context).size.width * 0.9,
-        constraints: const BoxConstraints(maxHeight: 500),
+        constraints: const BoxConstraints(maxHeight: 600),
         decoration: BoxDecoration(
           color: const Color(0xFF1E1E1E),
           borderRadius: BorderRadius.circular(12),
@@ -241,44 +241,51 @@ class _MapFilterDialogState extends State<MapFilterDialog> {
                     _buildLayersSection(),
 
                     // Two-column layout: (Types + Classes) | Altitude
-                    // Only shown when airspace is enabled
-                    if (_airspaceEnabled) ...[
-                      const SizedBox(height: 16),
-                      Container(
-                        decoration: BoxDecoration(
-                          color: Colors.white.withValues(alpha: 0.05),
-                          borderRadius: BorderRadius.circular(4),
-                          border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
-                        ),
-                        padding: const EdgeInsets.all(8),
-                        child: Row(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            // Left column: Types and Classes stacked
-                            Expanded(
-                              flex: 7,  // Much wider column (78% width)
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.stretch,
-                                children: [
-                                  // Airspace Types
-                                  _buildTypesColumn(),
-                                  const SizedBox(height: 12),
-                                  // ICAO Classes
-                                  _buildClassesColumn(),
-                                ],
-                              ),
+                    // Always shown, indented, disabled when airspace is disabled
+                    const SizedBox(height: 8),
+                    Padding(
+                      padding: const EdgeInsets.only(left: 24),
+                      child: IgnorePointer(
+                        ignoring: !_airspaceEnabled,
+                        child: Opacity(
+                          opacity: _airspaceEnabled ? 1.0 : 0.4,
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: Colors.white.withValues(alpha: 0.05),
+                              borderRadius: BorderRadius.circular(4),
+                              border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
                             ),
-                            const SizedBox(width: 12),
+                            padding: const EdgeInsets.all(8),
+                            child: Row(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                // Left column: Types and Classes stacked
+                                Expanded(
+                                  flex: 7,  // Much wider column (78% width)
+                                  child: Column(
+                                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                                    children: [
+                                      // Airspace Types
+                                      _buildTypesColumn(),
+                                      const SizedBox(height: 12),
+                                      // ICAO Classes
+                                      _buildClassesColumn(),
+                                    ],
+                                  ),
+                                ),
+                                const SizedBox(width: 12),
 
-                            // Right column: Altitude
-                            Expanded(
-                              flex: 2,  // Narrower column (33% width)
-                              child: _buildAltitudeColumn(),
+                                // Right column: Altitude
+                                Expanded(
+                                  flex: 2,  // Narrower column (33% width)
+                                  child: _buildAltitudeColumn(),
+                                ),
+                              ],
                             ),
-                          ],
+                          ),
                         ),
                       ),
-                    ],
+                    ),
                   ],
                 ),
               ),
@@ -311,103 +318,65 @@ class _MapFilterDialogState extends State<MapFilterDialog> {
           ),
         ),
         const SizedBox(height: 8),
-        // Row 1: Sites, Forecast
-        Row(
-          children: [
-            // Sites checkbox
-            Tooltip(
-              message: 'Show all the Paragliding Earth flying sites for this area',
-              textStyle: const TextStyle(color: Colors.white, fontSize: 12),
-              decoration: BoxDecoration(
-                color: const Color(0xFF1E1E1E),
-                borderRadius: BorderRadius.circular(6),
-                border: Border.all(color: Colors.white24),
-              ),
-              child: InkWell(
-                onTap: () => setState(() {
-                  _sitesEnabled = !_sitesEnabled;
-                  _applyFiltersImmediately();
-                }),
-                borderRadius: BorderRadius.circular(4),
-                child: SizedBox(
-                  height: 24,
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      SizedBox(
-                        width: 20,
-                        height: 20,
-                        child: Checkbox(
-                          value: _sitesEnabled,
-                          onChanged: (value) => setState(() {
-                            _sitesEnabled = value ?? true;
-                            _applyFiltersImmediately();
-                          }),
-                          activeColor: Colors.blue,
-                          checkColor: Colors.white,
-                          side: const BorderSide(color: Colors.white54),
-                          materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                          visualDensity: VisualDensity.compact,
-                        ),
-                      ),
-                      const SizedBox(width: 4),
-                      const Text(
-                        'Sites',
-                        style: TextStyle(color: Colors.white, fontSize: 12),
-                      ),
-                    ],
+        // Row 1: Sites
+        Tooltip(
+          message: 'Show all the Paragliding Earth flying sites for this area',
+          textStyle: const TextStyle(color: Colors.white, fontSize: 12),
+          decoration: BoxDecoration(
+            color: const Color(0xFF1E1E1E),
+            borderRadius: BorderRadius.circular(6),
+            border: Border.all(color: Colors.white24),
+          ),
+          child: InkWell(
+            onTap: () => setState(() {
+              _sitesEnabled = !_sitesEnabled;
+              _applyFiltersImmediately();
+            }),
+            borderRadius: BorderRadius.circular(4),
+            child: SizedBox(
+              height: 24,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: Checkbox(
+                      value: _sitesEnabled,
+                      onChanged: (value) => setState(() {
+                        _sitesEnabled = value ?? true;
+                        _applyFiltersImmediately();
+                      }),
+                      activeColor: Colors.blue,
+                      checkColor: Colors.white,
+                      side: const BorderSide(color: Colors.white54),
+                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      visualDensity: VisualDensity.compact,
+                    ),
                   ),
-                ),
+                  const SizedBox(width: 4),
+                  const Text(
+                    'Sites',
+                    style: TextStyle(color: Colors.white, fontSize: 12),
+                  ),
+                ],
               ),
             ),
-            const SizedBox(width: 16), // Space between checkboxes
-            // Forecast checkbox (disabled when sites are disabled)
-            Tooltip(
-              message: 'Show wind forecast and flyability for sites',
-              textStyle: const TextStyle(color: Colors.white, fontSize: 12),
-              decoration: BoxDecoration(
-                color: const Color(0xFF1E1E1E),
-                borderRadius: BorderRadius.circular(6),
-                border: Border.all(color: Colors.white24),
-              ),
-              child: InkWell(
-                onTap: _sitesEnabled ? () => setState(() {
-                  _forecastEnabled = !_forecastEnabled;
-                  _applyFiltersImmediately();
-                }) : null,
-                borderRadius: BorderRadius.circular(4),
-                child: SizedBox(
-                  height: 24,
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      SizedBox(
-                        width: 20,
-                        height: 20,
-                        child: Checkbox(
-                          value: _forecastEnabled,
-                          onChanged: _sitesEnabled ? (value) => setState(() {
-                            _forecastEnabled = value ?? true;
-                            _applyFiltersImmediately();
-                          }) : null,
-                          activeColor: Colors.blue,
-                          checkColor: Colors.white,
-                          side: const BorderSide(color: Colors.white54),
-                          materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                          visualDensity: VisualDensity.compact,
-                        ),
-                      ),
-                      const SizedBox(width: 4),
-                      const Text(
-                        'Forecast',
-                        style: TextStyle(color: Colors.white, fontSize: 12),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-          ],
+          ),
+        ),
+        // Forecast checkbox (indented, disabled when sites are disabled)
+        const SizedBox(height: 4),
+        Padding(
+          padding: const EdgeInsets.only(left: 24),
+          child: _buildProviderCheckbox(
+            value: _forecastEnabled,
+            label: 'Forecast',
+            subtitle: 'Wind forecast and flyability for sites',
+            onChanged: _sitesEnabled ? (value) => setState(() {
+              _forecastEnabled = value ?? true;
+              _applyFiltersImmediately();
+            }) : null,
+          ),
         ),
         const SizedBox(height: 8),
         // Row 2: Weather
@@ -492,125 +461,83 @@ class _MapFilterDialogState extends State<MapFilterDialog> {
           ),
         ),
         const SizedBox(height: 8),
-        // Row 3: Airspace, Clip
-        Row(
-          children: [
-            // Airspace checkbox
-            Tooltip(
-              message: 'Overlay the OpenAIP airspaces for this area',
-              textStyle: const TextStyle(color: Colors.white, fontSize: 12),
-              decoration: BoxDecoration(
-                color: const Color(0xFF1E1E1E),
-                borderRadius: BorderRadius.circular(6),
-                border: Border.all(color: Colors.white24),
-              ),
-              child: InkWell(
-                onTap: () {
-                  final wasDisabled = !_airspaceEnabled;
-                  setState(() {
-                    _airspaceEnabled = !_airspaceEnabled;
-                    _applyFiltersImmediately();
-                  });
-                  // Update controllers after enabling airspace so dropdowns reflect saved values
-                  if (wasDisabled && _airspaceEnabled) {
-                    WidgetsBinding.instance.addPostFrameCallback((_) {
-                      _updateControllerSelections();
-                    });
-                  }
-                },
-                borderRadius: BorderRadius.circular(4),
-                child: SizedBox(
-                  height: 24,
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      SizedBox(
-                        width: 20,
-                        height: 20,
-                        child: Checkbox(
-                          value: _airspaceEnabled,
-                          onChanged: (value) {
-                            final wasDisabled = !_airspaceEnabled;
-                            setState(() {
-                              _airspaceEnabled = value ?? true;
-                              _applyFiltersImmediately();
-                            });
-                            // Update controllers after enabling airspace so dropdowns reflect saved values
-                            if (wasDisabled && _airspaceEnabled) {
-                              WidgetsBinding.instance.addPostFrameCallback((_) {
-                                _updateControllerSelections();
-                              });
-                            }
-                          },
-                          activeColor: Colors.blue,
-                          checkColor: Colors.white,
-                          side: const BorderSide(color: Colors.white54),
-                          materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                          visualDensity: VisualDensity.compact,
-                        ),
-                      ),
-                      const SizedBox(width: 4),
-                      const Text(
-                        'Airspace',
-                        style: TextStyle(color: Colors.white, fontSize: 12),
-                      ),
-                    ],
+        // Row 3: Airspace
+        Tooltip(
+          message: 'Overlay the OpenAIP airspaces for this area',
+          textStyle: const TextStyle(color: Colors.white, fontSize: 12),
+          decoration: BoxDecoration(
+            color: const Color(0xFF1E1E1E),
+            borderRadius: BorderRadius.circular(6),
+            border: Border.all(color: Colors.white24),
+          ),
+          child: InkWell(
+            onTap: () {
+              final wasDisabled = !_airspaceEnabled;
+              setState(() {
+                _airspaceEnabled = !_airspaceEnabled;
+                _applyFiltersImmediately();
+              });
+              // Update controllers after enabling airspace so dropdowns reflect saved values
+              if (wasDisabled && _airspaceEnabled) {
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  _updateControllerSelections();
+                });
+              }
+            },
+            borderRadius: BorderRadius.circular(4),
+            child: SizedBox(
+              height: 24,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: Checkbox(
+                      value: _airspaceEnabled,
+                      onChanged: (value) {
+                        final wasDisabled = !_airspaceEnabled;
+                        setState(() {
+                          _airspaceEnabled = value ?? true;
+                          _applyFiltersImmediately();
+                        });
+                        // Update controllers after enabling airspace so dropdowns reflect saved values
+                        if (wasDisabled && _airspaceEnabled) {
+                          WidgetsBinding.instance.addPostFrameCallback((_) {
+                            _updateControllerSelections();
+                          });
+                        }
+                      },
+                      activeColor: Colors.blue,
+                      checkColor: Colors.white,
+                      side: const BorderSide(color: Colors.white54),
+                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      visualDensity: VisualDensity.compact,
+                    ),
                   ),
-                ),
+                  const SizedBox(width: 4),
+                  const Text(
+                    'Airspace',
+                    style: TextStyle(color: Colors.white, fontSize: 12),
+                  ),
+                ],
               ),
             ),
-            const SizedBox(width: 16), // Space between checkboxes
-            // Clip checkbox (disabled when airspace is disabled)
-            Tooltip(
-              message: 'Only show the bottom layer at each point',
-              textStyle: const TextStyle(color: Colors.white, fontSize: 12),
-              decoration: BoxDecoration(
-                color: const Color(0xFF1E1E1E),
-                borderRadius: BorderRadius.circular(6),
-                border: Border.all(color: Colors.white24),
-              ),
-              child: InkWell(
-                onTap: _airspaceEnabled ? () {
-                  setState(() {
-                    _clippingEnabled = !_clippingEnabled;
-                    _applyFiltersImmediately();
-                  });
-                } : null,
-                borderRadius: BorderRadius.circular(4),
-                child: SizedBox(
-                  height: 24,
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      SizedBox(
-                        width: 20,
-                        height: 20,
-                        child: Checkbox(
-                          value: _clippingEnabled,
-                          onChanged: _airspaceEnabled ? (value) {
-                            setState(() {
-                              _clippingEnabled = value ?? true;
-                              _applyFiltersImmediately();
-                            });
-                          } : null,
-                          activeColor: Colors.blue,
-                          checkColor: Colors.white,
-                          side: const BorderSide(color: Colors.white54),
-                          materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                          visualDensity: VisualDensity.compact,
-                        ),
-                      ),
-                      const SizedBox(width: 4),
-                      const Text(
-                        'Clip',
-                        style: TextStyle(color: Colors.white, fontSize: 12),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-          ],
+          ),
+        ),
+        // Clip checkbox (indented, disabled when airspace is disabled)
+        const SizedBox(height: 4),
+        Padding(
+          padding: const EdgeInsets.only(left: 24),
+          child: _buildProviderCheckbox(
+            value: _clippingEnabled,
+            label: 'Clip',
+            subtitle: 'Only show the bottom layer at each point',
+            onChanged: _airspaceEnabled ? (value) => setState(() {
+              _clippingEnabled = value ?? true;
+              _applyFiltersImmediately();
+            }) : null,
+          ),
         ),
       ],
     );
@@ -866,7 +793,7 @@ class _MapFilterDialogState extends State<MapFilterDialog> {
 
   Widget _buildAltitudeColumn() {
     return Padding(
-      padding: const EdgeInsets.only(left: 8),
+      padding: const EdgeInsets.only(left: 4), // Reduced from 8 to 4
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -896,7 +823,7 @@ class _MapFilterDialogState extends State<MapFilterDialog> {
                   Text('0', style: TextStyle(color: Colors.white54, fontSize: 8)),
                 ],
               ),
-              const SizedBox(width: 4),
+              const SizedBox(width: 2), // Reduced from 4 to 2
               // Vertical slider
               Expanded(
                 child: Padding(
@@ -942,7 +869,7 @@ class _MapFilterDialogState extends State<MapFilterDialog> {
                   ),
                 ),
               ),
-              const SizedBox(width: 4),
+              const SizedBox(width: 2), // Reduced from 4 to 2
               // Current value display
               SizedBox(
                 width: 25,

--- a/free_flight_log_app/lib/presentation/widgets/nearby_sites_map.dart
+++ b/free_flight_log_app/lib/presentation/widgets/nearby_sites_map.dart
@@ -114,6 +114,7 @@ class _NearbySitesMapState extends BaseMapState<NearbySitesMap> {
   @override
   void onMapReady() {
     super.onMapReady();
+
     // Notify parent of initial bounds
     if (widget.onBoundsChanged != null) {
       final bounds = mapController.camera.visibleBounds;
@@ -403,8 +404,8 @@ class _NearbySitesMapState extends BaseMapState<NearbySitesMap> {
 
     // Build new markers and cache them
     final markers = widget.weatherStations.map((station) {
-      // Get wind data for this station
-      final windData = widget.stationWindData[station.id];
+      // Get wind data for this station using the unique key (source:id)
+      final windData = widget.stationWindData[station.key];
 
       // Create station with wind data
       final stationWithWind = station.copyWith(windData: windData);

--- a/free_flight_log_app/lib/presentation/widgets/weather_station_marker.dart
+++ b/free_flight_log_app/lib/presentation/widgets/weather_station_marker.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'dart:math' as math;
 import '../../data/models/weather_station.dart';
+import '../../data/models/weather_station_source.dart';
 import '../../data/models/wind_data.dart';
 import '../../services/weather_providers/weather_station_provider_registry.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -290,12 +291,22 @@ class _WeatherStationDialog extends StatelessWidget {
                               ),
                             ),
                             const SizedBox(height: 8),
-                            // Time, location, elevation
+                            // Time and type on first line
                             Wrap(
                               spacing: 8,
                               runSpacing: 4,
                               children: [
                                 _buildInfoChip(Icons.access_time, _getTimeAgo(windData.timestamp)),
+                                if (station.observationType != null)
+                                  _buildInfoChip(Icons.sensors, station.observationType!),
+                              ],
+                            ),
+                            const SizedBox(height: 4),
+                            // Location and elevation on second line
+                            Wrap(
+                              spacing: 8,
+                              runSpacing: 4,
+                              children: [
                                 _buildInfoChip(Icons.location_on, '${station.latitude.toStringAsFixed(2)}°, ${station.longitude.toStringAsFixed(2)}°'),
                                 if (station.elevation != null)
                                   _buildInfoChip(Icons.terrain, '${station.elevation!.toStringAsFixed(0)}m'),
@@ -343,10 +354,15 @@ class _WeatherStationDialog extends StatelessWidget {
   Widget _buildAttribution(WeatherStation station) {
     final provider = WeatherStationProviderRegistry.getProvider(station.source);
 
+    // For METAR stations, link to specific station observation page
+    final url = station.source == WeatherStationSource.metar
+        ? 'https://aviationweather.gov/data/metar/?decoded=1&ids=${station.id}'
+        : provider.attributionUrl;
+
     return TextButton(
       onPressed: () async {
         await launchUrl(
-          Uri.parse(provider.attributionUrl),
+          Uri.parse(url),
           mode: LaunchMode.externalApplication,
         );
       },

--- a/free_flight_log_app/lib/presentation/widgets/weather_station_marker.dart
+++ b/free_flight_log_app/lib/presentation/widgets/weather_station_marker.dart
@@ -136,9 +136,12 @@ class _WeatherStationPainter extends CustomPainter {
   }
 
   void _drawSpeedBarbs(Canvas canvas, Offset shaftEnd, double angle, double speedKmh, Paint paint) {
+    // Round to nearest 5 km/h (meteorological standard)
+    final roundedSpeed = (speedKmh / 5).round() * 5.0;
+
     // Wind barbs: each full barb = 10 km/h, half barb = 5 km/h
-    final fullBarbs = (speedKmh / 10).floor();
-    final halfBarb = (speedKmh % 10) >= 5;
+    final fullBarbs = (roundedSpeed / 10).floor();
+    final halfBarb = (roundedSpeed % 10) >= 5;
 
     final barbLength = 10.0;  // Longer barbs (more prominent)
     final barbSpacing = 5.0;  // Spacing between barbs

--- a/free_flight_log_app/lib/services/weather_providers/metar_weather_provider.dart
+++ b/free_flight_log_app/lib/services/weather_providers/metar_weather_provider.dart
@@ -1,0 +1,377 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+import '../../data/models/weather_station.dart';
+import '../../data/models/weather_station_source.dart';
+import '../../data/models/wind_data.dart';
+import '../../utils/map_constants.dart';
+import '../logging_service.dart';
+import 'weather_station_provider.dart';
+
+/// METAR weather station provider from aviationweather.gov
+/// Provides airport weather stations with real-time observations
+class MetarWeatherProvider implements WeatherStationProvider {
+  static final MetarWeatherProvider instance = MetarWeatherProvider._();
+  MetarWeatherProvider._();
+
+  /// Conversion factor: knots to km/h
+  static const double knotsToKmh = 1.852;
+
+  /// Cache for station lists: "bbox_key" -> {stations, timestamp}
+  final Map<String, _StationCacheEntry> _stationCache = {};
+
+  /// Cache for pending station list requests to prevent duplicate API calls
+  final Map<String, Future<List<WeatherStation>>> _pendingStationRequests = {};
+
+  @override
+  WeatherStationSource get source => WeatherStationSource.metar;
+
+  @override
+  String get displayName => 'METAR (Aviation)';
+
+  @override
+  String get description => 'Airport weather stations';
+
+  @override
+  String get attributionName => 'Aviation Weather Center';
+
+  @override
+  String get attributionUrl => 'https://aviationweather.gov/';
+
+  @override
+  Duration get cacheTTL => MapConstants.weatherStationCacheTTL;
+
+  @override
+  bool get requiresApiKey => false;
+
+  @override
+  Future<bool> isConfigured() async {
+    // METAR doesn't require configuration
+    return true;
+  }
+
+  @override
+  Future<List<WeatherStation>> fetchStations(LatLngBounds bounds) async {
+    // Generate cache key from bounds
+    final cacheKey = _getBoundsCacheKey(bounds);
+
+    // Check exact cache match first
+    final cached = _stationCache[cacheKey];
+    if (cached != null && !cached.isExpired) {
+      LoggingService.info('METAR station cache hit for $cacheKey (${cached.stations.length} stations)');
+      return cached.stations;
+    }
+
+    // Check if any cached bbox contains the requested bbox
+    final containingCache = _findContainingCache(bounds);
+    if (containingCache != null) {
+      final filteredStations = containingCache.stations.where((station) {
+        return bounds.contains(LatLng(station.latitude, station.longitude));
+      }).toList();
+
+      LoggingService.structured('METAR_CACHE_SUBSET', {
+        'cache_key': cacheKey,
+        'cached_total': containingCache.stations.length,
+        'filtered_count': filteredStations.length,
+      });
+
+      return filteredStations;
+    }
+
+    // Check if request is already pending
+    if (_pendingStationRequests.containsKey(cacheKey)) {
+      LoggingService.info('Waiting for pending METAR station request: $cacheKey');
+      return _pendingStationRequests[cacheKey]!;
+    }
+
+    // Create new request
+    final future = _fetchStationsInBounds(bounds, cacheKey);
+    _pendingStationRequests[cacheKey] = future;
+
+    try {
+      final result = await future;
+      return result;
+    } finally {
+      _pendingStationRequests.remove(cacheKey);
+    }
+  }
+
+  @override
+  Future<Map<String, WindData>> fetchWeatherData(
+    List<WeatherStation> stations,
+  ) async {
+    if (stations.isEmpty) return {};
+
+    // METAR stations already have wind data embedded from the API response
+    // Just extract it and map by station key
+    final Map<String, WindData> result = {};
+    for (final station in stations) {
+      if (station.windData != null) {
+        result[station.key] = station.windData!;
+      }
+    }
+
+    LoggingService.structured('METAR_WEATHER_EXTRACTED', {
+      'total_stations': stations.length,
+      'stations_with_data': result.length,
+    });
+
+    return result;
+  }
+
+  @override
+  void clearCache() {
+    _stationCache.clear();
+    LoggingService.info('METAR station cache cleared');
+  }
+
+  @override
+  Map<String, dynamic> getCacheStats() {
+    final validEntries = _stationCache.values.where((e) => !e.isExpired).length;
+    final totalStations = _stationCache.values
+        .where((e) => !e.isExpired)
+        .fold<int>(0, (sum, entry) => sum + entry.stations.length);
+
+    return {
+      'total_cache_entries': _stationCache.length,
+      'valid_cache_entries': validEntries,
+      'total_cached_stations': totalStations,
+      'pending_requests': _pendingStationRequests.length,
+    };
+  }
+
+  /// Fetch METAR stations from aviationweather.gov
+  /// Returns stations with embedded wind data
+  Future<List<WeatherStation>> _fetchStationsInBounds(
+    LatLngBounds bounds,
+    String cacheKey,
+  ) async {
+    try {
+      final stopwatch = Stopwatch()..start();
+
+      // Build bbox string: minLat,minLon,maxLat,maxLon
+      final bbox = '${bounds.south.toStringAsFixed(2)},${bounds.west.toStringAsFixed(2)},'
+                   '${bounds.north.toStringAsFixed(2)},${bounds.east.toStringAsFixed(2)}';
+
+      // Build METAR API URL
+      final url = Uri.parse(
+        'https://aviationweather.gov/api/data/metar?bbox=$bbox&format=json',
+      );
+
+      LoggingService.structured('METAR_REQUEST_START', {
+        'bbox': bbox,
+        'url': url.toString(),
+        'cache_key': cacheKey,
+      });
+
+      // Make API request with appropriate headers
+      final response = await http.get(
+        url,
+        headers: {
+          'Accept': 'application/json',
+          'User-Agent': 'FreeFlightLog/1.0',
+        },
+      ).timeout(
+        const Duration(seconds: 30),
+        onTimeout: () {
+          stopwatch.stop();
+          LoggingService.structured('METAR_TIMEOUT', {
+            'bbox': bbox,
+            'duration_ms': stopwatch.elapsedMilliseconds,
+            'timeout_seconds': 30,
+          });
+          return http.Response('{"error": "Request timeout"}', 408);
+        },
+      );
+
+      stopwatch.stop();
+
+      LoggingService.structured('METAR_RESPONSE_RECEIVED', {
+        'status_code': response.statusCode,
+        'duration_ms': stopwatch.elapsedMilliseconds,
+        'content_length': response.body.length,
+        'bbox': bbox,
+      });
+
+      if (response.statusCode == 200) {
+        final networkTime = stopwatch.elapsedMilliseconds;
+
+        // Start parse timing
+        final parseStopwatch = Stopwatch()..start();
+        final List<dynamic> stationList = jsonDecode(response.body) as List;
+        final List<WeatherStation> stations = [];
+
+        for (final stationJson in stationList) {
+          try {
+            final station = _parseMetarStation(stationJson as Map<String, dynamic>);
+            if (station != null) {
+              stations.add(station);
+            }
+          } catch (e) {
+            LoggingService.error('Failed to parse METAR station', e);
+          }
+        }
+
+        parseStopwatch.stop();
+
+        LoggingService.performance(
+          'METAR parsing',
+          Duration(milliseconds: parseStopwatch.elapsedMilliseconds),
+          '${stations.length} stations parsed',
+        );
+
+        // Cache the results
+        _stationCache[cacheKey] = _StationCacheEntry(
+          stations: stations,
+          timestamp: DateTime.now(),
+        );
+
+        LoggingService.structured('METAR_STATIONS_SUCCESS', {
+          'station_count': stations.length,
+          'network_ms': networkTime,
+          'parse_ms': parseStopwatch.elapsedMilliseconds,
+          'total_ms': stopwatch.elapsedMilliseconds,
+          'cache_key': cacheKey,
+        });
+
+        return stations;
+      } else if (response.statusCode == 204) {
+        // 204 No Content - no stations in this region
+        LoggingService.structured('METAR_NO_DATA', {
+          'bbox': bbox,
+          'duration_ms': stopwatch.elapsedMilliseconds,
+        });
+
+        // Cache empty result
+        _stationCache[cacheKey] = _StationCacheEntry(
+          stations: [],
+          timestamp: DateTime.now(),
+        );
+
+        return [];
+      } else if (response.statusCode == 408) {
+        // Request timeout
+        return [];
+      } else {
+        LoggingService.structured('METAR_HTTP_ERROR', {
+          'status_code': response.statusCode,
+          'bbox': bbox,
+          'response_body': response.body.substring(0, response.body.length > 500 ? 500 : response.body.length),
+          'duration_ms': stopwatch.elapsedMilliseconds,
+        });
+        return [];
+      }
+    } catch (e, stackTrace) {
+      LoggingService.structured('METAR_REQUEST_FAILED', {
+        'error_type': e.runtimeType.toString(),
+        'error_message': e.toString(),
+        'bbox': '${bounds.south.toStringAsFixed(2)},${bounds.west.toStringAsFixed(2)},${bounds.north.toStringAsFixed(2)},${bounds.east.toStringAsFixed(2)}',
+        'cache_key': cacheKey,
+      });
+      LoggingService.error('Failed to fetch METAR stations', e, stackTrace);
+      return [];
+    }
+  }
+
+  /// Parse a METAR station JSON object into a WeatherStation
+  WeatherStation? _parseMetarStation(Map<String, dynamic> json) {
+    try {
+      final icaoId = json['icaoId'] as String?;
+      final lat = json['lat'] as num?;
+      final lon = json['lon'] as num?;
+
+      if (icaoId == null || lat == null || lon == null) {
+        return null;
+      }
+
+      // Extract wind data
+      WindData? windData;
+      final wdir = json['wdir'] as int?;
+      final wspd = json['wspd'] as int?;
+      final wgst = json['wgst'] as int?;
+      final reportTime = json['reportTime'] as String?;
+
+      if (wdir != null && wspd != null) {
+        // Convert from knots to km/h
+        final windSpeedKmh = wspd * knotsToKmh;
+        final windGustsKmh = wgst != null ? wgst * knotsToKmh : null;
+
+        windData = WindData(
+          speedKmh: windSpeedKmh,
+          directionDegrees: wdir.toDouble(),
+          gustsKmh: windGustsKmh,
+          timestamp: reportTime != null
+              ? DateTime.parse(reportTime)
+              : DateTime.now(),
+        );
+      }
+
+      return WeatherStation(
+        id: icaoId,
+        source: WeatherStationSource.metar,
+        name: json['name'] as String?,
+        latitude: lat.toDouble(),
+        longitude: lon.toDouble(),
+        elevation: json['elev'] != null ? (json['elev'] as num).toDouble() : null,
+        windData: windData,
+      );
+    } catch (e) {
+      LoggingService.error('Error parsing METAR station', e);
+      return null;
+    }
+  }
+
+  /// Generate cache key from bounding box
+  String _getBoundsCacheKey(LatLngBounds bounds) {
+    // Round to 0.1 degrees for reasonable cache granularity
+    final west = (bounds.west * 10).round() / 10;
+    final south = (bounds.south * 10).round() / 10;
+    final east = (bounds.east * 10).round() / 10;
+    final north = (bounds.north * 10).round() / 10;
+
+    return '$west,$south,$east,$north';
+  }
+
+  /// Find a cached entry whose bounds contain the requested bounds
+  _StationCacheEntry? _findContainingCache(LatLngBounds requestedBounds) {
+    for (final entry in _stationCache.entries) {
+      if (entry.value.isExpired) continue;
+
+      final parts = entry.key.split(',');
+      if (parts.length != 4) continue;
+
+      try {
+        final cachedWest = double.parse(parts[0]);
+        final cachedSouth = double.parse(parts[1]);
+        final cachedEast = double.parse(parts[2]);
+        final cachedNorth = double.parse(parts[3]);
+
+        if (cachedWest <= requestedBounds.west &&
+            cachedSouth <= requestedBounds.south &&
+            cachedEast >= requestedBounds.east &&
+            cachedNorth >= requestedBounds.north) {
+          return entry.value;
+        }
+      } catch (e) {
+        continue;
+      }
+    }
+    return null;
+  }
+}
+
+/// Cache entry for station lists with expiration
+class _StationCacheEntry {
+  final List<WeatherStation> stations;
+  final DateTime timestamp;
+
+  _StationCacheEntry({
+    required this.stations,
+    required this.timestamp,
+  });
+
+  bool get isExpired {
+    return DateTime.now().difference(timestamp) > MapConstants.stationListCacheTTL;
+  }
+}

--- a/free_flight_log_app/lib/services/weather_providers/metar_weather_provider.dart
+++ b/free_flight_log_app/lib/services/weather_providers/metar_weather_provider.dart
@@ -315,6 +315,7 @@ class MetarWeatherProvider implements WeatherStationProvider {
         longitude: lon.toDouble(),
         elevation: json['elev'] != null ? (json['elev'] as num).toDouble() : null,
         windData: windData,
+        observationType: 'Airport (METAR)',
       );
     } catch (e) {
       LoggingService.error('Error parsing METAR station', e);

--- a/free_flight_log_app/lib/services/weather_providers/nws_weather_provider.dart
+++ b/free_flight_log_app/lib/services/weather_providers/nws_weather_provider.dart
@@ -1,0 +1,399 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+import '../../data/models/weather_station.dart';
+import '../../data/models/weather_station_source.dart';
+import '../../data/models/wind_data.dart';
+import '../../utils/map_constants.dart';
+import '../logging_service.dart';
+import 'weather_station_provider.dart';
+
+/// National Weather Service (NWS) weather station provider
+/// Provides real-time weather observations from api.weather.gov
+///
+/// IMPORTANT: This provider only works for locations within the United States.
+/// International locations will return 0 stations.
+///
+/// Free, no API key required
+class NwsWeatherProvider implements WeatherStationProvider {
+  static final NwsWeatherProvider instance = NwsWeatherProvider._();
+  NwsWeatherProvider._();
+
+  static const String _baseUrl = 'https://api.weather.gov';
+
+  /// Cache for station lists: "bbox_key" -> {stations, timestamp}
+  final Map<String, _StationCacheEntry> _stationCache = {};
+
+  /// Cache for pending requests
+  final Map<String, Future<List<WeatherStation>>> _pendingStationRequests = {};
+
+  @override
+  WeatherStationSource get source => WeatherStationSource.nws;
+
+  @override
+  String get displayName => 'NWS Observations (US only)';
+
+  @override
+  String get description => 'US National Weather Service stations';
+
+  @override
+  String get attributionName => 'US National Weather Service';
+
+  @override
+  String get attributionUrl => 'https://www.weather.gov/';
+
+  @override
+  Duration get cacheTTL => MapConstants.weatherStationCacheTTL;
+
+  @override
+  bool get requiresApiKey => false;
+
+  @override
+  Future<bool> isConfigured() async {
+    // NWS doesn't require configuration
+    return true;
+  }
+
+  @override
+  Future<List<WeatherStation>> fetchStations(LatLngBounds bounds) async {
+    // Generate cache key
+    final cacheKey = _getBoundsCacheKey(bounds);
+
+    // Check cache
+    final cached = _stationCache[cacheKey];
+    if (cached != null && !cached.isExpired) {
+      LoggingService.info('NWS station cache hit for $cacheKey (${cached.stations.length} stations)');
+      return cached.stations;
+    }
+
+    // Check if request pending
+    if (_pendingStationRequests.containsKey(cacheKey)) {
+      LoggingService.info('Waiting for pending NWS station request: $cacheKey');
+      return _pendingStationRequests[cacheKey]!;
+    }
+
+    // Create new request
+    final future = _fetchStationsInBounds(bounds, cacheKey);
+    _pendingStationRequests[cacheKey] = future;
+
+    try {
+      final result = await future;
+      return result;
+    } finally {
+      _pendingStationRequests.remove(cacheKey);
+    }
+  }
+
+  @override
+  Future<Map<String, WindData>> fetchWeatherData(
+    List<WeatherStation> stations,
+  ) async {
+    if (stations.isEmpty) return {};
+
+    // NWS stations fetch latest observations individually
+    final Map<String, WindData> result = {};
+
+    // Fetch observations for stations in parallel (limit to avoid overwhelming API)
+    final futures = <Future<void>>[];
+
+    for (final station in stations) {
+      futures.add(_fetchStationObservation(station).then((windData) {
+        if (windData != null) {
+          result[station.key] = windData;
+        }
+      }));
+    }
+
+    await Future.wait(futures);
+
+    LoggingService.structured('NWS_WEATHER_EXTRACTED', {
+      'total_stations': stations.length,
+      'stations_with_data': result.length,
+    });
+
+    return result;
+  }
+
+  @override
+  void clearCache() {
+    _stationCache.clear();
+    LoggingService.info('NWS station cache cleared');
+  }
+
+  @override
+  Map<String, dynamic> getCacheStats() {
+    final validEntries = _stationCache.values.where((e) => !e.isExpired).length;
+    final totalStations = _stationCache.values
+        .where((e) => !e.isExpired)
+        .fold<int>(0, (sum, entry) => sum + entry.stations.length);
+
+    return {
+      'total_cache_entries': _stationCache.length,
+      'valid_cache_entries': validEntries,
+      'total_cached_stations': totalStations,
+      'pending_requests': _pendingStationRequests.length,
+    };
+  }
+
+  /// Fetch NWS stations within bounds
+  Future<List<WeatherStation>> _fetchStationsInBounds(
+    LatLngBounds bounds,
+    String cacheKey,
+  ) async {
+    try {
+      final stopwatch = Stopwatch()..start();
+
+      // NWS doesn't support bbox query, so we fetch all stations and filter
+      final url = Uri.parse('$_baseUrl/stations?limit=500');
+
+      LoggingService.structured('NWS_REQUEST_START', {
+        'bounds': '${bounds.south},${bounds.west},${bounds.north},${bounds.east}',
+        'url': url.toString(),
+        'cache_key': cacheKey,
+      });
+
+      final response = await http.get(
+        url,
+        headers: {
+          'Accept': 'application/geo+json',
+          'User-Agent': 'FreeFlightLog/1.0',
+        },
+      ).timeout(
+        const Duration(seconds: 30),
+        onTimeout: () {
+          stopwatch.stop();
+          LoggingService.structured('NWS_TIMEOUT', {
+            'duration_ms': stopwatch.elapsedMilliseconds,
+            'timeout_seconds': 30,
+          });
+          return http.Response('{"error": "Request timeout"}', 408);
+        },
+      );
+
+      stopwatch.stop();
+
+      LoggingService.structured('NWS_RESPONSE_RECEIVED', {
+        'status_code': response.statusCode,
+        'duration_ms': stopwatch.elapsedMilliseconds,
+        'content_length': response.body.length,
+      });
+
+      if (response.statusCode == 200) {
+        final networkTime = stopwatch.elapsedMilliseconds;
+
+        // Parse GeoJSON response
+        final parseStopwatch = Stopwatch()..start();
+        final responseData = jsonDecode(response.body) as Map<String, dynamic>;
+        final features = responseData['features'] as List?;
+
+        if (features == null) {
+          LoggingService.info('NWS: No features in response');
+          _stationCache[cacheKey] = _StationCacheEntry(
+            stations: [],
+            timestamp: DateTime.now(),
+          );
+          return [];
+        }
+
+        final List<WeatherStation> allStations = [];
+        for (final feature in features) {
+          try {
+            final station = _parseNwsStation(feature as Map<String, dynamic>);
+            if (station != null) {
+              allStations.add(station);
+            }
+          } catch (e) {
+            LoggingService.error('Failed to parse NWS station', e);
+          }
+        }
+
+        // Filter stations within bounds
+        final stationsInBounds = allStations.where((station) {
+          return bounds.contains(LatLng(station.latitude, station.longitude));
+        }).toList();
+
+        parseStopwatch.stop();
+
+        LoggingService.performance(
+          'NWS parsing',
+          Duration(milliseconds: parseStopwatch.elapsedMilliseconds),
+          '${stationsInBounds.length} stations in bounds (${allStations.length} total)',
+        );
+
+        // Cache the filtered results
+        _stationCache[cacheKey] = _StationCacheEntry(
+          stations: stationsInBounds,
+          timestamp: DateTime.now(),
+        );
+
+        LoggingService.structured('NWS_STATIONS_SUCCESS', {
+          'station_count': stationsInBounds.length,
+          'total_fetched': allStations.length,
+          'network_ms': networkTime,
+          'parse_ms': parseStopwatch.elapsedMilliseconds,
+          'cache_key': cacheKey,
+        });
+
+        return stationsInBounds;
+      } else if (response.statusCode == 408) {
+        // Request timeout
+        return [];
+      } else {
+        LoggingService.structured('NWS_HTTP_ERROR', {
+          'status_code': response.statusCode,
+          'response_body': response.body.substring(0, response.body.length > 500 ? 500 : response.body.length),
+        });
+        return [];
+      }
+    } catch (e, stackTrace) {
+      LoggingService.structured('NWS_REQUEST_FAILED', {
+        'error_type': e.runtimeType.toString(),
+        'error_message': e.toString(),
+        'cache_key': cacheKey,
+      });
+      LoggingService.error('Failed to fetch NWS stations', e, stackTrace);
+      return [];
+    }
+  }
+
+  /// Parse NWS GeoJSON station feature
+  WeatherStation? _parseNwsStation(Map<String, dynamic> feature) {
+    try {
+      final properties = feature['properties'] as Map<String, dynamic>?;
+      final geometry = feature['geometry'] as Map<String, dynamic>?;
+
+      if (properties == null || geometry == null) return null;
+
+      final stationId = properties['stationIdentifier'] as String?;
+      if (stationId == null) return null;
+
+      final coordinates = geometry['coordinates'] as List?;
+      if (coordinates == null || coordinates.length < 2) return null;
+
+      final longitude = (coordinates[0] as num).toDouble();
+      final latitude = (coordinates[1] as num).toDouble();
+
+      // Extract elevation
+      double? elevation;
+      final elevData = properties['elevation'] as Map<String, dynamic>?;
+      if (elevData != null) {
+        elevation = (elevData['value'] as num?)?.toDouble();
+      }
+
+      return WeatherStation(
+        id: stationId,
+        source: WeatherStationSource.nws,
+        name: properties['name'] as String?,
+        latitude: latitude,
+        longitude: longitude,
+        elevation: elevation,
+        windData: null, // Fetched separately
+      );
+    } catch (e) {
+      LoggingService.error('Error parsing NWS station', e);
+      return null;
+    }
+  }
+
+  /// Fetch latest observation for a station
+  Future<WindData?> _fetchStationObservation(WeatherStation station) async {
+    try {
+      final url = Uri.parse('$_baseUrl/stations/${station.id}/observations/latest');
+
+      final response = await http.get(
+        url,
+        headers: {
+          'Accept': 'application/geo+json',
+          'User-Agent': 'FreeFlightLog/1.0',
+        },
+      ).timeout(const Duration(seconds: 10));
+
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body) as Map<String, dynamic>;
+        final properties = data['properties'] as Map<String, dynamic>?;
+
+        if (properties == null) return null;
+
+        // Extract wind data
+        final windSpeed = properties['windSpeed'] as Map<String, dynamic>?;
+        final windDirection = properties['windDirection'] as Map<String, dynamic>?;
+        final windGust = properties['windGust'] as Map<String, dynamic>?;
+        final timestamp = properties['timestamp'] as String?;
+
+        if (windSpeed == null || windDirection == null || timestamp == null) {
+          LoggingService.structured('NWS_OBSERVATION_MISSING_DATA', {
+            'station_id': station.id,
+            'has_wind_speed': windSpeed != null,
+            'has_wind_direction': windDirection != null,
+            'has_timestamp': timestamp != null,
+          });
+          return null;
+        }
+
+        final speedValue = windSpeed['value'] as num?;
+        final directionValue = windDirection['value'] as num?;
+
+        if (speedValue == null || directionValue == null) {
+          LoggingService.structured('NWS_OBSERVATION_NULL_VALUES', {
+            'station_id': station.id,
+            'speed_value': speedValue,
+            'direction_value': directionValue,
+          });
+          return null;
+        }
+
+        final gustValue = windGust?['value'] as num?;
+
+        LoggingService.structured('NWS_OBSERVATION_SUCCESS', {
+          'station_id': station.id,
+          'speed_kmh': speedValue.toDouble(),
+          'direction_deg': directionValue.toDouble(),
+          'gust_kmh': gustValue?.toDouble(),
+        });
+
+        return WindData(
+          speedKmh: speedValue.toDouble(),
+          directionDegrees: directionValue.toDouble(),
+          gustsKmh: gustValue?.toDouble(),
+          timestamp: DateTime.parse(timestamp),
+        );
+      }
+
+      return null;
+    } catch (e) {
+      LoggingService.structured('NWS_OBSERVATION_ERROR', {
+        'station_id': station.id,
+        'station_name': station.name,
+        'error': e.toString(),
+      });
+      return null;
+    }
+  }
+
+  /// Generate cache key from bounding box
+  String _getBoundsCacheKey(LatLngBounds bounds) {
+    // Round to 0.1 degrees for reasonable cache granularity
+    final west = (bounds.west * 10).round() / 10;
+    final south = (bounds.south * 10).round() / 10;
+    final east = (bounds.east * 10).round() / 10;
+    final north = (bounds.north * 10).round() / 10;
+
+    return '$west,$south,$east,$north';
+  }
+}
+
+/// Cache entry for station lists with expiration
+class _StationCacheEntry {
+  final List<WeatherStation> stations;
+  final DateTime timestamp;
+
+  _StationCacheEntry({
+    required this.stations,
+    required this.timestamp,
+  });
+
+  bool get isExpired {
+    return DateTime.now().difference(timestamp) > MapConstants.stationListCacheTTL;
+  }
+}

--- a/free_flight_log_app/lib/services/weather_providers/nws_weather_provider.dart
+++ b/free_flight_log_app/lib/services/weather_providers/nws_weather_provider.dart
@@ -398,6 +398,7 @@ class NwsWeatherProvider implements WeatherStationProvider {
         longitude: longitude,
         elevation: elevation,
         windData: null, // Fetched separately
+        observationType: WeatherStation.inferObservationType(stationId),
       );
     } catch (e) {
       LoggingService.error('Error parsing NWS station', e);

--- a/free_flight_log_app/lib/services/weather_providers/weather_station_provider.dart
+++ b/free_flight_log_app/lib/services/weather_providers/weather_station_provider.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_map/flutter_map.dart';
+import '../../data/models/weather_station.dart';
+import '../../data/models/wind_data.dart';
+import '../../data/models/weather_station_source.dart';
+
+/// Abstract interface for weather station data providers
+/// Allows multiple data sources (METAR, NOAA CDO, etc.) to be used interchangeably
+abstract class WeatherStationProvider {
+  /// Unique provider identifier (e.g., "metar", "noaa-cdo")
+  WeatherStationSource get source;
+
+  /// Human-readable provider name for UI display
+  String get displayName;
+
+  /// Short description for UI (e.g., filter dialog subtitles)
+  String get description;
+
+  /// Full attribution name for data source (e.g., "Aviation Weather Center")
+  String get attributionName;
+
+  /// Attribution URL for data source (e.g., "https://aviationweather.gov/")
+  String get attributionUrl;
+
+  /// Cache duration for this provider's data
+  /// Weather data freshness varies by provider
+  Duration get cacheTTL;
+
+  /// Whether this provider requires an API key
+  bool get requiresApiKey;
+
+  /// Fetch weather stations within a bounding box
+  /// Returns list of stations with coordinates and metadata
+  /// May or may not include wind data depending on provider API
+  Future<List<WeatherStation>> fetchStations(LatLngBounds bounds);
+
+  /// Fetch current weather data for a list of stations
+  /// Returns map of station ID -> WindData
+  /// Some providers return weather data with station metadata, others require separate call
+  Future<Map<String, WindData>> fetchWeatherData(
+    List<WeatherStation> stations,
+  );
+
+  /// Check if provider is properly configured and ready to use
+  /// For example, checks if required API key is present
+  Future<bool> isConfigured();
+
+  /// Clear any cached data for this provider
+  void clearCache();
+
+  /// Get cache statistics for debugging
+  Map<String, dynamic> getCacheStats();
+}

--- a/free_flight_log_app/lib/services/weather_providers/weather_station_provider_registry.dart
+++ b/free_flight_log_app/lib/services/weather_providers/weather_station_provider_registry.dart
@@ -1,0 +1,37 @@
+import '../../data/models/weather_station_source.dart';
+import 'weather_station_provider.dart';
+import 'metar_weather_provider.dart';
+import 'nws_weather_provider.dart';
+
+/// Centralized registry mapping sources to provider implementations
+///
+/// Provides a single source of truth for accessing weather station providers
+/// based on their source type. Simplifies provider lookup and ensures type safety.
+class WeatherStationProviderRegistry {
+  /// Map of sources to their provider implementations
+  static final Map<WeatherStationSource, WeatherStationProvider> _providers = {
+    WeatherStationSource.metar: MetarWeatherProvider.instance,
+    WeatherStationSource.nws: NwsWeatherProvider.instance,
+  };
+
+  /// Get provider for a specific source
+  ///
+  /// Throws [StateError] if no provider is registered for the source
+  static WeatherStationProvider getProvider(WeatherStationSource source) {
+    final provider = _providers[source];
+    if (provider == null) {
+      throw StateError('No provider registered for source: $source');
+    }
+    return provider;
+  }
+
+  /// Get all registered providers
+  static List<WeatherStationProvider> getAllProviders() {
+    return _providers.values.toList();
+  }
+
+  /// Get all registered sources
+  static List<WeatherStationSource> getAllSources() {
+    return _providers.keys.toList();
+  }
+}

--- a/free_flight_log_app/lib/services/weather_station_service.dart
+++ b/free_flight_log_app/lib/services/weather_station_service.dart
@@ -26,7 +26,8 @@ class WeatherStationService {
 
 
   /// Distance threshold for considering stations as duplicates (meters)
-  static const double _deduplicationDistanceMeters = 100.0;
+  /// Increased to 150m to handle coordinate precision differences between providers
+  static const double _deduplicationDistanceMeters = 150.0;
 
   /// Get weather stations in a bounding box from all enabled providers
   /// Fetches in parallel, then deduplicates and returns combined results

--- a/free_flight_log_app/lib/utils/map_constants.dart
+++ b/free_flight_log_app/lib/utils/map_constants.dart
@@ -26,6 +26,10 @@ class MapConstants {
   static const Duration weatherStationCacheTTL = Duration(minutes: 30); // METAR updates every 30min
   static const Duration stationListCacheTTL = Duration(minutes: 30); // Combined with weather data
 
+  // NWS-specific caching
+  static const Duration nwsStationListCacheTTL = Duration(hours: 24); // Stations don't move/change
+  static const Duration nwsObservationCacheTTL = Duration(minutes: 10); // Observations update 1-60min
+
   // Map UI constants
   static const double mapPadding = 0.005;
 


### PR DESCRIPTION
## Summary

Implements a comprehensive multi-provider weather station architecture supporting Aviation Weather Center (METAR) and National Weather Service (NWS) data sources with intelligent deduplication, caching, and real-time progress feedback.

### Key Features

**Provider Architecture**
- Abstract `WeatherStationProvider` interface for extensibility
- Provider registry for centralized management
- METAR provider: Airport weather stations with embedded wind data
- NWS provider: Comprehensive US network including CWOP citizen stations
- Bbox-containment caching strategy (24hr stations, 10min observations)

**Station Classification**
- Observation type inference from station ID patterns
- Classifications: Airport (METAR), CWOP Citizen, Pacific Airport, Military, Marine Buoy
- Station-specific attribution links to detailed observation pages

**Intelligent Deduplication**
- Distance-based deduplication (150m threshold)
- Handles coordinate precision differences between providers
- Priority: stations with wind data > newer timestamps
- Structured logging for transparency

**User Experience**
- Real-time progress indicators showing provider fetch status
- Improved map filter dialog with hierarchical layout
- Reorganized station popup (time+type, then coords+elevation)
- Immediate filter updates without confirmation dialogs

**Performance**
- Parallel provider fetching with individual caching
- Fast failure for non-US NWS requests (~600ms vs 30s timeout)
- LRU-style bbox containment reduces redundant API calls

### Documentation

- Comprehensive guide for adding new weather providers (`docs/ADDING_WEATHER_PROVIDERS.md`)
- Curl commands for testing provider APIs
- Data source characteristics and quality notes

## Test plan

- [x] Verify METAR stations show "Airport (METAR)" observation type
- [x] Verify NWS stations show inferred types (CWOP, Airport, etc.)
- [x] Verify KCVH deduplication (METAR + NWS coordinates 119.76m apart)
- [x] Verify station popup displays time+type on line 1, coords+elevation on line 2
- [x] Verify METAR attribution links to station-specific observation page
- [x] Test progress indicators during provider fetch
- [x] Test NWS fast-fail for non-US locations (Perth, Australia)
- [x] Verify map filter immediate updates without confirmation
- [x] Verify caching reduces API calls on zoom/pan

🤖 Generated with [Claude Code](https://claude.com/claude-code)