### PR TITLE
feat: Chase cam — smoothed focal, stable thermals, user gestures

### DIFF
--- a/the_paragliding_app/assets/cesium/cesium.js
+++ b/the_paragliding_app/assets/cesium/cesium.js
@@ -433,16 +433,15 @@ class FlightDataSource extends Cesium.CustomDataSource {
         // Store position property for reuse
         this.positionProperty = positionProperty;
 
-        // Create pilot entity (raw position so the dot lines up with the visible track)
+        const availability = new Cesium.TimeIntervalCollection([
+            new Cesium.TimeInterval({ start: this.startTime, stop: this.stopTime })
+        ]);
+
+        // 1) Visible pilot dot — sits exactly on the raw GPS track.
         this.pilotEntity = this.entities.add({
             id: 'pilot',
             name: 'Pilot',
-            availability: new Cesium.TimeIntervalCollection([
-                new Cesium.TimeInterval({
-                    start: this.startTime,
-                    stop: this.stopTime
-                })
-            ]),
+            availability: availability,
             position: positionProperty,
             point: {
                 pixelSize: 16,
@@ -454,6 +453,61 @@ class FlightDataSource extends Cesium.CustomDataSource {
                 scaleByDistance: new Cesium.NearFarScalar(1000, 1.5, 100000, 0.5)
             }
         });
+
+        // 2) Invisible chase target — smoothed position used purely as the
+        //    `viewer.trackedEntity` source. Cesium's VELOCITY-frame tracker derives
+        //    a smooth chase frame from the smooth position derivative.
+        //    Camera centres on this point (slightly off the visible dot during turns,
+        //    by the smoothing distance) and sits 1 km behind in flight direction, 200 m up.
+        const smoothedPositionProperty = this._buildSmoothedPositionProperty();
+        const GHOST_BACK = 1000;  // metres behind in flight direction
+        const GHOST_UP = 200;     // metres above
+        this.chaseTargetEntity = this.entities.add({
+            id: 'chase-target',
+            name: 'Chase target (invisible)',
+            availability: availability,
+            position: smoothedPositionProperty,
+            viewFrom: new Cesium.Cartesian3(-GHOST_BACK, 0, GHOST_UP),
+            trackingReferenceFrame: Cesium.TrackingReferenceFrame.VELOCITY,
+            // Effectively-invisible point so Cesium treats this as a real, trackable entity.
+            // Using show:true with a 1px transparent dot — show:false may make the chase
+            // tracker skip this entity's position updates each frame.
+            point: { pixelSize: 1, color: Cesium.Color.TRANSPARENT }
+        });
+    }
+
+    /**
+     * Pre-compute a SampledPositionProperty whose samples are the raw IGC positions
+     * averaged over a 60s window (±30s). Smoothing serves the chase camera only —
+     * the visible pilot dot uses the raw positionProperty. The 60s window is wide
+     * enough to remove GPS jitter and average a thermal circle (~20s) into its net
+     * drift direction, so Cesium's VELOCITY-frame tracker sees a smooth velocity.
+     */
+    _buildSmoothedPositionProperty() {
+        const HALF_WINDOW_SECONDS = 30;
+        const smoothedPositions = new Array(this.positions.length);
+        let lo = 0, hi = 0;
+        for (let i = 0; i < this.positions.length; i++) {
+            while (lo < i && Cesium.JulianDate.secondsDifference(this.times[i], this.times[lo]) > HALF_WINDOW_SECONDS) lo++;
+            while (hi < this.positions.length - 1 && Cesium.JulianDate.secondsDifference(this.times[hi + 1], this.times[i]) <= HALF_WINDOW_SECONDS) hi++;
+            let sx = 0, sy = 0, sz = 0;
+            for (let j = lo; j <= hi; j++) {
+                sx += this.positions[j].x;
+                sy += this.positions[j].y;
+                sz += this.positions[j].z;
+            }
+            const n = hi - lo + 1;
+            smoothedPositions[i] = new Cesium.Cartesian3(sx / n, sy / n, sz / n);
+        }
+        const prop = new Cesium.SampledPositionProperty();
+        prop.setInterpolationOptions({
+            interpolationDegree: 1,
+            interpolationAlgorithm: Cesium.LinearApproximation
+        });
+        prop.forwardExtrapolationType = Cesium.ExtrapolationType.HOLD;
+        prop.backwardExtrapolationType = Cesium.ExtrapolationType.HOLD;
+        prop.addSamples(this.times, smoothedPositions);
+        return prop;
     }
     
     _createCurtainWall() {
@@ -1641,166 +1695,63 @@ class CesiumFlightApp {
     }
 
     _enableChaseCam() {
+        const target = this.flightDataSource.chaseTargetEntity;
         const pilot = this.flightDataSource.pilotEntity;
-        if (!pilot) return;
-
-        // Chase parameters (units = metres / clock-seconds)
-        const LAG_SECONDS = 60;         // time constant for AZIMUTH only (angle around pilot).
-                                        // Distance and height respond instantly — so zoom and
-                                        // pilot altitude changes are not lagged.
-        const DIST_BACK = 500;          // base horizontal metres behind pilot (× zoom)
-        const DIST_UP = 200;            // base metres above pilot (× zoom)
-        const DIR_SAMPLE_SECONDS = 30;  // half-window for direction sampling (60s total)
-        const ZOOM_MIN = 0.1, ZOOM_MAX = 20;
-
+        if (!target || !pilot) {
+            console.log('[CHASE] missing entities; target=' + !!target + ' pilot=' + !!pilot);
+            return;
+        }
         const viewer = this.viewer;
-        const self = this;
-        const scratchFuture = new Cesium.JulianDate();
-        const scratchPast = new Cesium.JulianDate();
-        const scratchDir = new Cesium.Cartesian3();
-        const scratchEnu = new Cesium.Matrix4();
-        const scratchEnuInv = new Cesium.Matrix4();
-        const scratchDirLocal = new Cesium.Cartesian3();
-        const scratchOffsetLocal = new Cesium.Cartesian3();
-        const scratchCamWorld = new Cesium.Cartesian3();
+        const t = viewer.clock.currentTime;
+        const targetPos = target.position && target.position.getValue(t);
+        console.log('[CHASE_PRE] sceneMode=' + viewer.scene.mode +
+            ' targetPosDefined=' + !!targetPos +
+            ' targetHasViewFrom=' + !!target.viewFrom +
+            ' targetTrackingFrame=' + target.trackingReferenceFrame +
+            ' VELOCITY=' + Cesium.TrackingReferenceFrame.VELOCITY);
 
-        self._chaseAzimuth = null;     // smoothed angle around pilot, radians (0 = camera south of pilot looking north)
-        self._chaseLastTime = null;
-        self._chaseZoomFactor = 1.0;
-
-        // Input handler — Cesium's default zoom would still fire but our per-tick setView
-        // overrides it; we capture the gesture ourselves and apply it as a zoom multiplier.
-        const inputHandler = new Cesium.ScreenSpaceEventHandler(viewer.scene.canvas);
-        self._chaseInputHandler = inputHandler;
-
-        // Also attach raw touch listeners on the canvas as a fallback to compute pinch
-        const canvas = viewer.scene.canvas;
-        let _pinchPrevDist = null;
-        const _touchDist = (touches) => {
-            if (touches.length < 2) return null;
-            const dx = touches[0].clientX - touches[1].clientX;
-            const dy = touches[0].clientY - touches[1].clientY;
-            return Math.hypot(dx, dy);
-        };
-        const _onTouchStart = (e) => {
-            _pinchPrevDist = _touchDist(e.touches);
-        };
-        const _onTouchMove = (e) => {
-            const d = _touchDist(e.touches);
-            if (d != null && _pinchPrevDist != null && _pinchPrevDist > 0) {
-                self._chaseZoomFactor = clampZoom(self._chaseZoomFactor * (_pinchPrevDist / d));
-            }
-            _pinchPrevDist = d;
-        };
-        const _onTouchEnd = () => { _pinchPrevDist = null; };
-        canvas.addEventListener('touchstart', _onTouchStart, { passive: true });
-        canvas.addEventListener('touchmove', _onTouchMove, { passive: true });
-        canvas.addEventListener('touchend', _onTouchEnd, { passive: true });
-        canvas.addEventListener('touchcancel', _onTouchEnd, { passive: true });
-        self._chaseTouchCleanup = () => {
-            canvas.removeEventListener('touchstart', _onTouchStart);
-            canvas.removeEventListener('touchmove', _onTouchMove);
-            canvas.removeEventListener('touchend', _onTouchEnd);
-            canvas.removeEventListener('touchcancel', _onTouchEnd);
-        };
-        const clampZoom = (z) => Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, z));
-        // Mouse wheel (desktop)
-        inputHandler.setInputAction((delta) => {
-            self._chaseZoomFactor = clampZoom(self._chaseZoomFactor * Math.exp(-delta * 0.001));
-        }, Cesium.ScreenSpaceEventType.WHEEL);
-        // (Pinch is handled by the native touchmove listener below to avoid double-counting
-        // — Cesium's PINCH_MOVE and our raw touchmove both fire for the same gesture.)
-
-        self._chaseTickRemove = viewer.clock.onTick.addEventListener((clock) => {
-            const t = clock.currentTime;
-            const pilotPos = pilot.position.getValue(t);
-            if (!pilotPos) return;
-
-            // Flight direction sampled over a wide window (averages GPS noise + thermal circling)
-            Cesium.JulianDate.addSeconds(t, DIR_SAMPLE_SECONDS, scratchFuture);
-            Cesium.JulianDate.addSeconds(t, -DIR_SAMPLE_SECONDS, scratchPast);
-            const pFuture = pilot.position.getValue(scratchFuture);
-            const pPast = pilot.position.getValue(scratchPast);
-
-            // Build pilot-local ENU once (used for both target azimuth calc and final camera position)
-            Cesium.Transforms.eastNorthUpToFixedFrame(pilotPos, undefined, scratchEnu);
-            Cesium.Matrix4.inverseTransformation(scratchEnu, scratchEnuInv);
-
-            // Compute target azimuth (compass angle of flight direction in ENU at pilot)
-            // azimuth: 0 = north, π/2 = east, etc. Camera sits OPPOSITE the flight direction
-            // (= flight_azimuth + π) so it's behind the pilot.
-            let targetAzimuth = self._chaseAzimuth;
-            if (pFuture && pPast) {
-                Cesium.Cartesian3.subtract(pFuture, pPast, scratchDir);
-                if (Cesium.Cartesian3.magnitude(scratchDir) > 1e-3) {
-                    Cesium.Matrix4.multiplyByPointAsVector(scratchEnuInv, scratchDir, scratchDirLocal);
-                    // ENU axes: x=east, y=north → flight azimuth = atan2(east, north)
-                    const flightAzimuth = Math.atan2(scratchDirLocal.x, scratchDirLocal.y);
-                    targetAzimuth = flightAzimuth + Math.PI; // camera on opposite side
-                }
-            }
-            if (targetAzimuth == null) targetAzimuth = 0;
-
-            // Lerp the smoothed azimuth toward target (handle wraparound)
-            if (self._chaseAzimuth == null) {
-                self._chaseAzimuth = targetAzimuth;
-                self._chaseLastTime = Cesium.JulianDate.clone(t);
-            } else {
-                const dt = Cesium.JulianDate.secondsDifference(t, self._chaseLastTime);
-                if (dt > 0) {
-                    const factor = 1 - Math.exp(-dt / LAG_SECONDS);
-                    let dh = targetAzimuth - self._chaseAzimuth;
-                    while (dh > Math.PI) dh -= 2 * Math.PI;
-                    while (dh < -Math.PI) dh += 2 * Math.PI;
-                    self._chaseAzimuth += dh * factor;
-                } else if (dt < 0) {
-                    self._chaseAzimuth = targetAzimuth;
-                }
-                Cesium.JulianDate.clone(t, self._chaseLastTime);
-            }
-
-            // Compute camera position in pilot-local ENU:
-            //   x (east)  = sin(azimuth) × DIST_BACK × zoom
-            //   y (north) = cos(azimuth) × DIST_BACK × zoom
-            //   z (up)    = DIST_UP × zoom    ← INSTANT (no lag, tracks pilot altitude exactly)
-            const dist = DIST_BACK * self._chaseZoomFactor;
-            const height = DIST_UP * self._chaseZoomFactor;
-            scratchOffsetLocal.x = Math.sin(self._chaseAzimuth) * dist;
-            scratchOffsetLocal.y = Math.cos(self._chaseAzimuth) * dist;
-            scratchOffsetLocal.z = height;
-            // Convert to world: world_camera = pilotEnu × offset_local (as point)
-            Cesium.Matrix4.multiplyByPoint(scratchEnu, scratchOffsetLocal, scratchCamWorld);
-
-            // Camera looks at pilot. Compute heading (camera azimuth + π so we look toward pilot)
-            // and pitch (downward angle = atan(height / dist)).
-            const lookHeading = self._chaseAzimuth + Math.PI;
-            const lookPitch = -Math.atan2(height, dist);
-
-            viewer.scene.camera.setView({
-                destination: scratchCamWorld,
-                orientation: { heading: lookHeading, pitch: lookPitch, roll: 0 }
-            });
+        viewer.trackedEntity = target;
+        console.log('[CHASE_SET] trackedEntity.id=' + (viewer.trackedEntity && viewer.trackedEntity.id));
+        // Per-second tick: confirm both target position AND camera position are updating
+        let lastLog = Date.now();
+        if (this._chaseTickListener) this._chaseTickListener();
+        this._chaseTickListener = viewer.clock.onTick.addEventListener((clock) => {
+            const now = Date.now();
+            if (now - lastLog < 1000) return;
+            lastLog = now;
+            const tt = clock.currentTime;
+            const tp = target.position && target.position.getValue(tt);
+            const cp = viewer.scene.camera.positionWC;
+            console.log('[CHASE_TICK] clk=' + Cesium.JulianDate.toIso8601(tt).slice(11,19) +
+                ' mult=' + clock.multiplier +
+                ' tracked=' + (viewer.trackedEntity && viewer.trackedEntity.id) +
+                ' targetPos=' + (tp ? Math.round(tp.x)+','+Math.round(tp.y)+','+Math.round(tp.z) : 'null') +
+                ' camPos=' + Math.round(cp.x)+','+Math.round(cp.y)+','+Math.round(cp.z));
         });
+        setTimeout(() => {
+            const te = viewer.trackedEntity;
+            const camPos = viewer.scene.camera.positionWC;
+            console.log('[CHASE_POST_500ms] trackedEntity.id=' + (te && te.id) +
+                ' camPos=' + JSON.stringify({x: Math.round(camPos.x), y: Math.round(camPos.y), z: Math.round(camPos.z)}));
+        }, 500);
+        setTimeout(() => {
+            const te = viewer.trackedEntity;
+            const camPos = viewer.scene.camera.positionWC;
+            console.log('[CHASE_POST_3s] trackedEntity.id=' + (te && te.id) +
+                ' camPos=' + JSON.stringify({x: Math.round(camPos.x), y: Math.round(camPos.y), z: Math.round(camPos.z)}));
+        }, 3000);
 
         this.cameraFollowing = true;
     }
 
     _disableChaseCam() {
-        if (this._chaseTickRemove) {
-            this._chaseTickRemove();
-            this._chaseTickRemove = null;
+        if (this._chaseTickListener) {
+            this._chaseTickListener();
+            this._chaseTickListener = null;
         }
-        if (this._chaseInputHandler) {
-            this._chaseInputHandler.destroy();
-            this._chaseInputHandler = null;
+        if (this.viewer) {
+            this.viewer.trackedEntity = undefined;
         }
-        if (this._chaseTouchCleanup) {
-            this._chaseTouchCleanup();
-            this._chaseTouchCleanup = null;
-        }
-        this._chaseAzimuth = null;
-        this._chaseLastTime = null;
-        this._chaseZoomFactor = 1.0;
         this.cameraFollowing = false;
     }
     

--- a/the_paragliding_app/assets/cesium/cesium.js
+++ b/the_paragliding_app/assets/cesium/cesium.js
@@ -1689,6 +1689,8 @@ class CesiumFlightApp {
         const DIST_BACK = 600;          // base horizontal metres behind smoothed focal (× zoom)
         const DIST_UP = 200;            // base metres above smoothed focal (× zoom)
         const DIR_SAMPLE_SECONDS = 30;  // half-window for direction sampling (60s total)
+        const STATIONARY_SPEED_MPS = 1.94;  // 7 km/h: below this, hold the last azimuth
+                                            // (pilot is essentially circling, no useful direction).
         const ZOOM_MIN = 0.1, ZOOM_MAX = 20;
         // The chase camera centres on a 60s-smoothed point (smoothedPos), not the raw
         // pilot. During thermalling the smoothed point barely moves, so the camera
@@ -1775,10 +1777,15 @@ class CesiumFlightApp {
             // Compute target azimuth (compass angle of flight direction in ENU at pilot)
             // azimuth: 0 = north, π/2 = east, etc. Camera sits OPPOSITE the flight direction
             // (= flight_azimuth + π) so it's behind the pilot.
+            // If the pilot's smoothed ground speed is below STATIONARY_SPEED_MPS we treat
+            // them as essentially circling and HOLD the last azimuth — no update at all,
+            // so the camera stays put through the thermal in light/no-wind conditions.
             let targetAzimuth = self._chaseAzimuth;
             if (pFuture && pPast) {
                 Cesium.Cartesian3.subtract(pFuture, pPast, scratchDir);
-                if (Cesium.Cartesian3.magnitude(scratchDir) > 1e-3) {
+                const winSec = DIR_SAMPLE_SECONDS * 2;
+                const groundSpeed = Cesium.Cartesian3.magnitude(scratchDir) / winSec;
+                if (groundSpeed >= STATIONARY_SPEED_MPS) {
                     Cesium.Matrix4.multiplyByPointAsVector(scratchEnuInv, scratchDir, scratchDirLocal);
                     // ENU axes: x=east, y=north → flight azimuth = atan2(east, north)
                     const flightAzimuth = Math.atan2(scratchDirLocal.x, scratchDirLocal.y);

--- a/the_paragliding_app/assets/cesium/cesium.js
+++ b/the_paragliding_app/assets/cesium/cesium.js
@@ -1759,12 +1759,14 @@ class CesiumFlightApp {
             const focalPos = smoothedPos.getValue(t);
             if (!focalPos) return;
 
-            // Flight direction sampled over a wide window of RAW positions
-            // (averages GPS noise + thermal circling); independent of focal smoothing.
+            // Flight direction sampled from SMOOTHED positions over a 60s window.
+            // Each endpoint is itself a ±30s average, so the delta vector reflects
+            // pure drift of the thermal centre — circle motion is already cancelled
+            // out → camera azimuth stays still while pilot circles.
             Cesium.JulianDate.addSeconds(t, DIR_SAMPLE_SECONDS, scratchFuture);
             Cesium.JulianDate.addSeconds(t, -DIR_SAMPLE_SECONDS, scratchPast);
-            const pFuture = pilot.position.getValue(scratchFuture);
-            const pPast = pilot.position.getValue(scratchPast);
+            const pFuture = smoothedPos.getValue(scratchFuture);
+            const pPast = smoothedPos.getValue(scratchPast);
 
             // Build focal-local ENU once (used for both target azimuth calc and final camera position)
             Cesium.Transforms.eastNorthUpToFixedFrame(focalPos, undefined, scratchEnu);

--- a/the_paragliding_app/assets/cesium/cesium.js
+++ b/the_paragliding_app/assets/cesium/cesium.js
@@ -1711,15 +1711,27 @@ class CesiumFlightApp {
         self._chaseAzimuth = null;     // smoothed angle around pilot, radians (0 = camera south of pilot looking north)
         self._chaseLastTime = null;
         self._chaseZoomFactor = 1.0;
+        self._chaseUserAzimuthOffset = 0;  // radians, accumulated from horizontal drag
+        self._chaseUserHeightOffset = 0;   // metres, added to DIST_UP × zoom (vertical drag)
 
         // Input handler — Cesium's default zoom would still fire but our per-tick setView
         // overrides it; we capture the gesture ourselves and apply it as a zoom multiplier.
         const inputHandler = new Cesium.ScreenSpaceEventHandler(viewer.scene.canvas);
         self._chaseInputHandler = inputHandler;
 
-        // Also attach raw touch listeners on the canvas as a fallback to compute pinch
+        // Native touch listeners on the canvas:
+        //  - 2-finger pinch → zoom (scale DIST_BACK / DIST_UP)
+        //  - 1-finger horizontal drag → orbit camera around pilot (azimuth offset)
+        //  - 1-finger vertical drag → raise/lower camera (height offset)
+        // Drag offsets persist across pilot motion — set "side-on view" once and the
+        // chase keeps that side-on relationship as the pilot flies.
         const canvas = viewer.scene.canvas;
+        const AZIMUTH_RAD_PER_PX = (2 * Math.PI) / 720;  // 720 px drag = full rotation
+        const HEIGHT_M_PER_PX = 1.0;                      // 1 px = 1 m camera-height change
+        const HEIGHT_MIN_M = 30;                          // never below 30 m above pilot
+        const HEIGHT_MAX_M = 50000;                       // sanity cap
         let _pinchPrevDist = null;
+        let _dragPrev = null;
         const _touchDist = (touches) => {
             if (touches.length < 2) return null;
             const dx = touches[0].clientX - touches[1].clientX;
@@ -1728,15 +1740,30 @@ class CesiumFlightApp {
         };
         const _onTouchStart = (e) => {
             _pinchPrevDist = _touchDist(e.touches);
+            _dragPrev = e.touches.length === 1
+                ? { x: e.touches[0].clientX, y: e.touches[0].clientY }
+                : null;
         };
         const _onTouchMove = (e) => {
-            const d = _touchDist(e.touches);
-            if (d != null && _pinchPrevDist != null && _pinchPrevDist > 0) {
-                self._chaseZoomFactor = clampZoom(self._chaseZoomFactor * (_pinchPrevDist / d));
+            if (e.touches.length >= 2) {
+                // Pinch — zoom
+                const d = _touchDist(e.touches);
+                if (d != null && _pinchPrevDist != null && _pinchPrevDist > 0) {
+                    self._chaseZoomFactor = clampZoom(self._chaseZoomFactor * (_pinchPrevDist / d));
+                }
+                _pinchPrevDist = d;
+                _dragPrev = null;
+            } else if (e.touches.length === 1 && _dragPrev) {
+                // Single-finger drag — orbit + tilt
+                const dx = e.touches[0].clientX - _dragPrev.x;
+                const dy = e.touches[0].clientY - _dragPrev.y;
+                self._chaseUserAzimuthOffset += dx * AZIMUTH_RAD_PER_PX;
+                // Drag down (positive dy) → camera rises (more god view). Cesium-default convention.
+                self._chaseUserHeightOffset += dy * HEIGHT_M_PER_PX;
+                _dragPrev = { x: e.touches[0].clientX, y: e.touches[0].clientY };
             }
-            _pinchPrevDist = d;
         };
-        const _onTouchEnd = () => { _pinchPrevDist = null; };
+        const _onTouchEnd = () => { _pinchPrevDist = null; _dragPrev = null; };
         canvas.addEventListener('touchstart', _onTouchStart, { passive: true });
         canvas.addEventListener('touchmove', _onTouchMove, { passive: true });
         canvas.addEventListener('touchend', _onTouchEnd, { passive: true });
@@ -1812,21 +1839,22 @@ class CesiumFlightApp {
                 Cesium.JulianDate.clone(t, self._chaseLastTime);
             }
 
-            // Compute camera position in pilot-local ENU:
-            //   x (east)  = sin(azimuth) × DIST_BACK × zoom
-            //   y (north) = cos(azimuth) × DIST_BACK × zoom
-            //   z (up)    = DIST_UP × zoom    ← INSTANT (no lag, tracks pilot altitude exactly)
+            // Compute camera position in pilot-local ENU. User drag offsets are layered
+            // on top of the smoothed azimuth + base height so they persist across pilot
+            // motion (drag once to set "side-on view", chase keeps that relationship).
+            const finalAzimuth = self._chaseAzimuth + self._chaseUserAzimuthOffset;
             const dist = DIST_BACK * self._chaseZoomFactor;
-            const height = DIST_UP * self._chaseZoomFactor;
-            scratchOffsetLocal.x = Math.sin(self._chaseAzimuth) * dist;
-            scratchOffsetLocal.y = Math.cos(self._chaseAzimuth) * dist;
+            const rawHeight = DIST_UP * self._chaseZoomFactor + self._chaseUserHeightOffset;
+            const height = Math.max(HEIGHT_MIN_M, Math.min(HEIGHT_MAX_M, rawHeight));
+            scratchOffsetLocal.x = Math.sin(finalAzimuth) * dist;
+            scratchOffsetLocal.y = Math.cos(finalAzimuth) * dist;
             scratchOffsetLocal.z = height;
             // Convert to world: world_camera = pilotEnu × offset_local (as point)
             Cesium.Matrix4.multiplyByPoint(scratchEnu, scratchOffsetLocal, scratchCamWorld);
 
             // Camera looks at pilot. Compute heading (camera azimuth + π so we look toward pilot)
             // and pitch (downward angle = atan(height / dist)).
-            const lookHeading = self._chaseAzimuth + Math.PI;
+            const lookHeading = finalAzimuth + Math.PI;
             const lookPitch = -Math.atan2(height, dist);
 
             viewer.scene.camera.setView({
@@ -1854,6 +1882,8 @@ class CesiumFlightApp {
         this._chaseAzimuth = null;
         this._chaseLastTime = null;
         this._chaseZoomFactor = 1.0;
+        this._chaseUserAzimuthOffset = 0;
+        this._chaseUserHeightOffset = 0;
         this.cameraFollowing = false;
     }
     

--- a/the_paragliding_app/assets/cesium/cesium.js
+++ b/the_paragliding_app/assets/cesium/cesium.js
@@ -433,15 +433,22 @@ class FlightDataSource extends Cesium.CustomDataSource {
         // Store position property for reuse
         this.positionProperty = positionProperty;
 
-        const availability = new Cesium.TimeIntervalCollection([
-            new Cesium.TimeInterval({ start: this.startTime, stop: this.stopTime })
-        ]);
+        // Pre-compute a smoothed (60s window) position. Used by the chase cam as
+        // the camera FOCAL POINT — so the camera stays still while the pilot
+        // circles in a thermal (the smoothed centre barely moves), and the visible
+        // raw-position dot drifts naturally around the screen centre.
+        this.smoothedPositionProperty = this._buildSmoothedPositionProperty(30);
 
-        // 1) Visible pilot dot — sits exactly on the raw GPS track.
+        // Create pilot entity (raw position so the dot lines up with the visible track)
         this.pilotEntity = this.entities.add({
             id: 'pilot',
             name: 'Pilot',
-            availability: availability,
+            availability: new Cesium.TimeIntervalCollection([
+                new Cesium.TimeInterval({
+                    start: this.startTime,
+                    stop: this.stopTime
+                })
+            ]),
             position: positionProperty,
             point: {
                 pixelSize: 16,
@@ -453,43 +460,19 @@ class FlightDataSource extends Cesium.CustomDataSource {
                 scaleByDistance: new Cesium.NearFarScalar(1000, 1.5, 100000, 0.5)
             }
         });
-
-        // 2) Invisible chase target — smoothed position used purely as the
-        //    `viewer.trackedEntity` source. Cesium's VELOCITY-frame tracker derives
-        //    a smooth chase frame from the smooth position derivative.
-        //    Camera centres on this point (slightly off the visible dot during turns,
-        //    by the smoothing distance) and sits 1 km behind in flight direction, 200 m up.
-        const smoothedPositionProperty = this._buildSmoothedPositionProperty();
-        const GHOST_BACK = 1000;  // metres behind in flight direction
-        const GHOST_UP = 200;     // metres above
-        this.chaseTargetEntity = this.entities.add({
-            id: 'chase-target',
-            name: 'Chase target (invisible)',
-            availability: availability,
-            position: smoothedPositionProperty,
-            viewFrom: new Cesium.Cartesian3(-GHOST_BACK, 0, GHOST_UP),
-            trackingReferenceFrame: Cesium.TrackingReferenceFrame.VELOCITY,
-            // Effectively-invisible point so Cesium treats this as a real, trackable entity.
-            // Using show:true with a 1px transparent dot — show:false may make the chase
-            // tracker skip this entity's position updates each frame.
-            point: { pixelSize: 1, color: Cesium.Color.TRANSPARENT }
-        });
     }
 
     /**
-     * Pre-compute a SampledPositionProperty whose samples are the raw IGC positions
-     * averaged over a 60s window (±30s). Smoothing serves the chase camera only —
-     * the visible pilot dot uses the raw positionProperty. The 60s window is wide
-     * enough to remove GPS jitter and average a thermal circle (~20s) into its net
-     * drift direction, so Cesium's VELOCITY-frame tracker sees a smooth velocity.
+     * Build a SampledPositionProperty whose samples are this.positions averaged
+     * over a window of ±halfWindowSeconds. Used to give the chase camera a
+     * stable focal point that doesn't whirl around when the pilot thermals.
      */
-    _buildSmoothedPositionProperty() {
-        const HALF_WINDOW_SECONDS = 30;
-        const smoothedPositions = new Array(this.positions.length);
+    _buildSmoothedPositionProperty(halfWindowSeconds) {
+        const smoothed = new Array(this.positions.length);
         let lo = 0, hi = 0;
         for (let i = 0; i < this.positions.length; i++) {
-            while (lo < i && Cesium.JulianDate.secondsDifference(this.times[i], this.times[lo]) > HALF_WINDOW_SECONDS) lo++;
-            while (hi < this.positions.length - 1 && Cesium.JulianDate.secondsDifference(this.times[hi + 1], this.times[i]) <= HALF_WINDOW_SECONDS) hi++;
+            while (lo < i && Cesium.JulianDate.secondsDifference(this.times[i], this.times[lo]) > halfWindowSeconds) lo++;
+            while (hi < this.positions.length - 1 && Cesium.JulianDate.secondsDifference(this.times[hi + 1], this.times[i]) <= halfWindowSeconds) hi++;
             let sx = 0, sy = 0, sz = 0;
             for (let j = lo; j <= hi; j++) {
                 sx += this.positions[j].x;
@@ -497,7 +480,7 @@ class FlightDataSource extends Cesium.CustomDataSource {
                 sz += this.positions[j].z;
             }
             const n = hi - lo + 1;
-            smoothedPositions[i] = new Cesium.Cartesian3(sx / n, sy / n, sz / n);
+            smoothed[i] = new Cesium.Cartesian3(sx / n, sy / n, sz / n);
         }
         const prop = new Cesium.SampledPositionProperty();
         prop.setInterpolationOptions({
@@ -506,7 +489,7 @@ class FlightDataSource extends Cesium.CustomDataSource {
         });
         prop.forwardExtrapolationType = Cesium.ExtrapolationType.HOLD;
         prop.backwardExtrapolationType = Cesium.ExtrapolationType.HOLD;
-        prop.addSamples(this.times, smoothedPositions);
+        prop.addSamples(this.times, smoothed);
         return prop;
     }
     
@@ -1695,63 +1678,173 @@ class CesiumFlightApp {
     }
 
     _enableChaseCam() {
-        const target = this.flightDataSource.chaseTargetEntity;
         const pilot = this.flightDataSource.pilotEntity;
-        if (!target || !pilot) {
-            console.log('[CHASE] missing entities; target=' + !!target + ' pilot=' + !!pilot);
-            return;
-        }
-        const viewer = this.viewer;
-        const t = viewer.clock.currentTime;
-        const targetPos = target.position && target.position.getValue(t);
-        console.log('[CHASE_PRE] sceneMode=' + viewer.scene.mode +
-            ' targetPosDefined=' + !!targetPos +
-            ' targetHasViewFrom=' + !!target.viewFrom +
-            ' targetTrackingFrame=' + target.trackingReferenceFrame +
-            ' VELOCITY=' + Cesium.TrackingReferenceFrame.VELOCITY);
+        const smoothedPos = this.flightDataSource.smoothedPositionProperty;
+        if (!pilot || !smoothedPos) return;
 
-        viewer.trackedEntity = target;
-        console.log('[CHASE_SET] trackedEntity.id=' + (viewer.trackedEntity && viewer.trackedEntity.id));
-        // Per-second tick: confirm both target position AND camera position are updating
-        let lastLog = Date.now();
-        if (this._chaseTickListener) this._chaseTickListener();
-        this._chaseTickListener = viewer.clock.onTick.addEventListener((clock) => {
-            const now = Date.now();
-            if (now - lastLog < 1000) return;
-            lastLog = now;
-            const tt = clock.currentTime;
-            const tp = target.position && target.position.getValue(tt);
-            const cp = viewer.scene.camera.positionWC;
-            console.log('[CHASE_TICK] clk=' + Cesium.JulianDate.toIso8601(tt).slice(11,19) +
-                ' mult=' + clock.multiplier +
-                ' tracked=' + (viewer.trackedEntity && viewer.trackedEntity.id) +
-                ' targetPos=' + (tp ? Math.round(tp.x)+','+Math.round(tp.y)+','+Math.round(tp.z) : 'null') +
-                ' camPos=' + Math.round(cp.x)+','+Math.round(cp.y)+','+Math.round(cp.z));
+        // Chase parameters (units = metres / clock-seconds)
+        const LAG_SECONDS = 60;         // time constant for AZIMUTH only (angle around pilot).
+                                        // Distance and height respond instantly — so zoom and
+                                        // pilot altitude changes are not lagged.
+        const DIST_BACK = 600;          // base horizontal metres behind smoothed focal (× zoom)
+        const DIST_UP = 200;            // base metres above smoothed focal (× zoom)
+        const DIR_SAMPLE_SECONDS = 30;  // half-window for direction sampling (60s total)
+        const ZOOM_MIN = 0.1, ZOOM_MAX = 20;
+        // The chase camera centres on a 60s-smoothed point (smoothedPos), not the raw
+        // pilot. During thermalling the smoothed point barely moves, so the camera
+        // stays roughly still while the pilot dot circles within view. During glides
+        // the smoothed point lags by ~speed × half_window (~300 m at 10 m/s).
+
+        const viewer = this.viewer;
+        const self = this;
+        const scratchFuture = new Cesium.JulianDate();
+        const scratchPast = new Cesium.JulianDate();
+        const scratchDir = new Cesium.Cartesian3();
+        const scratchEnu = new Cesium.Matrix4();
+        const scratchEnuInv = new Cesium.Matrix4();
+        const scratchDirLocal = new Cesium.Cartesian3();
+        const scratchOffsetLocal = new Cesium.Cartesian3();
+        const scratchCamWorld = new Cesium.Cartesian3();
+
+        self._chaseAzimuth = null;     // smoothed angle around pilot, radians (0 = camera south of pilot looking north)
+        self._chaseLastTime = null;
+        self._chaseZoomFactor = 1.0;
+
+        // Input handler — Cesium's default zoom would still fire but our per-tick setView
+        // overrides it; we capture the gesture ourselves and apply it as a zoom multiplier.
+        const inputHandler = new Cesium.ScreenSpaceEventHandler(viewer.scene.canvas);
+        self._chaseInputHandler = inputHandler;
+
+        // Also attach raw touch listeners on the canvas as a fallback to compute pinch
+        const canvas = viewer.scene.canvas;
+        let _pinchPrevDist = null;
+        const _touchDist = (touches) => {
+            if (touches.length < 2) return null;
+            const dx = touches[0].clientX - touches[1].clientX;
+            const dy = touches[0].clientY - touches[1].clientY;
+            return Math.hypot(dx, dy);
+        };
+        const _onTouchStart = (e) => {
+            _pinchPrevDist = _touchDist(e.touches);
+        };
+        const _onTouchMove = (e) => {
+            const d = _touchDist(e.touches);
+            if (d != null && _pinchPrevDist != null && _pinchPrevDist > 0) {
+                self._chaseZoomFactor = clampZoom(self._chaseZoomFactor * (_pinchPrevDist / d));
+            }
+            _pinchPrevDist = d;
+        };
+        const _onTouchEnd = () => { _pinchPrevDist = null; };
+        canvas.addEventListener('touchstart', _onTouchStart, { passive: true });
+        canvas.addEventListener('touchmove', _onTouchMove, { passive: true });
+        canvas.addEventListener('touchend', _onTouchEnd, { passive: true });
+        canvas.addEventListener('touchcancel', _onTouchEnd, { passive: true });
+        self._chaseTouchCleanup = () => {
+            canvas.removeEventListener('touchstart', _onTouchStart);
+            canvas.removeEventListener('touchmove', _onTouchMove);
+            canvas.removeEventListener('touchend', _onTouchEnd);
+            canvas.removeEventListener('touchcancel', _onTouchEnd);
+        };
+        const clampZoom = (z) => Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, z));
+        // Mouse wheel (desktop)
+        inputHandler.setInputAction((delta) => {
+            self._chaseZoomFactor = clampZoom(self._chaseZoomFactor * Math.exp(-delta * 0.001));
+        }, Cesium.ScreenSpaceEventType.WHEEL);
+        // (Pinch is handled by the native touchmove listener below to avoid double-counting
+        // — Cesium's PINCH_MOVE and our raw touchmove both fire for the same gesture.)
+
+        self._chaseTickRemove = viewer.clock.onTick.addEventListener((clock) => {
+            const t = clock.currentTime;
+            // Camera FOCAL POINT = smoothed pilot position (stable in thermals).
+            const focalPos = smoothedPos.getValue(t);
+            if (!focalPos) return;
+
+            // Flight direction sampled over a wide window of RAW positions
+            // (averages GPS noise + thermal circling); independent of focal smoothing.
+            Cesium.JulianDate.addSeconds(t, DIR_SAMPLE_SECONDS, scratchFuture);
+            Cesium.JulianDate.addSeconds(t, -DIR_SAMPLE_SECONDS, scratchPast);
+            const pFuture = pilot.position.getValue(scratchFuture);
+            const pPast = pilot.position.getValue(scratchPast);
+
+            // Build focal-local ENU once (used for both target azimuth calc and final camera position)
+            Cesium.Transforms.eastNorthUpToFixedFrame(focalPos, undefined, scratchEnu);
+            Cesium.Matrix4.inverseTransformation(scratchEnu, scratchEnuInv);
+
+            // Compute target azimuth (compass angle of flight direction in ENU at pilot)
+            // azimuth: 0 = north, π/2 = east, etc. Camera sits OPPOSITE the flight direction
+            // (= flight_azimuth + π) so it's behind the pilot.
+            let targetAzimuth = self._chaseAzimuth;
+            if (pFuture && pPast) {
+                Cesium.Cartesian3.subtract(pFuture, pPast, scratchDir);
+                if (Cesium.Cartesian3.magnitude(scratchDir) > 1e-3) {
+                    Cesium.Matrix4.multiplyByPointAsVector(scratchEnuInv, scratchDir, scratchDirLocal);
+                    // ENU axes: x=east, y=north → flight azimuth = atan2(east, north)
+                    const flightAzimuth = Math.atan2(scratchDirLocal.x, scratchDirLocal.y);
+                    targetAzimuth = flightAzimuth + Math.PI; // camera on opposite side
+                }
+            }
+            if (targetAzimuth == null) targetAzimuth = 0;
+
+            // Lerp the smoothed azimuth toward target (handle wraparound)
+            if (self._chaseAzimuth == null) {
+                self._chaseAzimuth = targetAzimuth;
+                self._chaseLastTime = Cesium.JulianDate.clone(t);
+            } else {
+                const dt = Cesium.JulianDate.secondsDifference(t, self._chaseLastTime);
+                if (dt > 0) {
+                    const factor = 1 - Math.exp(-dt / LAG_SECONDS);
+                    let dh = targetAzimuth - self._chaseAzimuth;
+                    while (dh > Math.PI) dh -= 2 * Math.PI;
+                    while (dh < -Math.PI) dh += 2 * Math.PI;
+                    self._chaseAzimuth += dh * factor;
+                } else if (dt < 0) {
+                    self._chaseAzimuth = targetAzimuth;
+                }
+                Cesium.JulianDate.clone(t, self._chaseLastTime);
+            }
+
+            // Compute camera position in pilot-local ENU:
+            //   x (east)  = sin(azimuth) × DIST_BACK × zoom
+            //   y (north) = cos(azimuth) × DIST_BACK × zoom
+            //   z (up)    = DIST_UP × zoom    ← INSTANT (no lag, tracks pilot altitude exactly)
+            const dist = DIST_BACK * self._chaseZoomFactor;
+            const height = DIST_UP * self._chaseZoomFactor;
+            scratchOffsetLocal.x = Math.sin(self._chaseAzimuth) * dist;
+            scratchOffsetLocal.y = Math.cos(self._chaseAzimuth) * dist;
+            scratchOffsetLocal.z = height;
+            // Convert to world: world_camera = pilotEnu × offset_local (as point)
+            Cesium.Matrix4.multiplyByPoint(scratchEnu, scratchOffsetLocal, scratchCamWorld);
+
+            // Camera looks at pilot. Compute heading (camera azimuth + π so we look toward pilot)
+            // and pitch (downward angle = atan(height / dist)).
+            const lookHeading = self._chaseAzimuth + Math.PI;
+            const lookPitch = -Math.atan2(height, dist);
+
+            viewer.scene.camera.setView({
+                destination: scratchCamWorld,
+                orientation: { heading: lookHeading, pitch: lookPitch, roll: 0 }
+            });
         });
-        setTimeout(() => {
-            const te = viewer.trackedEntity;
-            const camPos = viewer.scene.camera.positionWC;
-            console.log('[CHASE_POST_500ms] trackedEntity.id=' + (te && te.id) +
-                ' camPos=' + JSON.stringify({x: Math.round(camPos.x), y: Math.round(camPos.y), z: Math.round(camPos.z)}));
-        }, 500);
-        setTimeout(() => {
-            const te = viewer.trackedEntity;
-            const camPos = viewer.scene.camera.positionWC;
-            console.log('[CHASE_POST_3s] trackedEntity.id=' + (te && te.id) +
-                ' camPos=' + JSON.stringify({x: Math.round(camPos.x), y: Math.round(camPos.y), z: Math.round(camPos.z)}));
-        }, 3000);
 
         this.cameraFollowing = true;
     }
 
     _disableChaseCam() {
-        if (this._chaseTickListener) {
-            this._chaseTickListener();
-            this._chaseTickListener = null;
+        if (this._chaseTickRemove) {
+            this._chaseTickRemove();
+            this._chaseTickRemove = null;
         }
-        if (this.viewer) {
-            this.viewer.trackedEntity = undefined;
+        if (this._chaseInputHandler) {
+            this._chaseInputHandler.destroy();
+            this._chaseInputHandler = null;
         }
+        if (this._chaseTouchCleanup) {
+            this._chaseTouchCleanup();
+            this._chaseTouchCleanup = null;
+        }
+        this._chaseAzimuth = null;
+        this._chaseLastTime = null;
+        this._chaseZoomFactor = 1.0;
         this.cameraFollowing = false;
     }
     


### PR DESCRIPTION
## Summary

Iterative refinement of the Cesium chase cam built on top of the previous custom-tick implementation. Camera now feels stable in thermals and supports drag/pinch user input.

## Commits in this PR

1. **\`f62e8eb\`** — Restored the working custom chase from main (rolling back a brief experiment with Cesium's built-in \`viewer.trackedEntity\` that wouldn't honour entity orientation in 1.134).
2. **\`029a15e\`** — Camera focal point switched from raw pilot position to a 60 s-smoothed position. During thermals the focal barely moves; pilot dot drifts naturally within the view.
3. **\`e865632\`** — Direction sampling also uses smoothed positions, so the delta vector reflects pure thermal-centre drift (circle motion already cancelled out). Camera azimuth becomes very stable.
4. **\`67344c5\`** — Hold azimuth when smoothed ground speed < 7 km/h. Below that the pilot is essentially circling (no useful direction); camera freezes through the thermal in light/no-wind conditions.
5. **\`8cd75c7\`** — Single-finger horizontal drag = orbit around pilot, vertical drag = raise/lower camera. Pinch zoom unchanged. User offsets persist across pilot motion.

## Architecture

- \`pilotEntity\`: raw IGC \`SampledPositionProperty\`, visible yellow point, sits on the colored track.
- \`smoothedPositionProperty\` on the data source: ±30 s moving average of pilot positions.
- Custom \`clock.onTick\` chase handler: focal = smoothed pilot, direction = smoothed positions over 60 s window with speed-threshold gating, azimuth lerped with 60 s clock-time constant, height + distance update instantly. \`setView\` per tick.
- Native canvas touch listeners: pinch → \`_chaseZoomFactor\`, single-finger drag → \`_chaseUserAzimuthOffset\` + \`_chaseUserHeightOffset\`.

## Test plan

- [x] In 3D map, hit ▶ Play, click camera icon → camera locks behind pilot smoothly.
- [x] Watch a thermal section → camera stays roughly still; pilot dot circles within view.
- [x] Watch a glide → camera follows behind in glide direction.
- [x] Glide-to-thermal transition → camera direction updates over ~60 s clock time, doesn't snap.
- [x] Pinch → zoom in/out, camera distance + height both scale.
- [x] Single-finger horizontal drag → camera orbits around pilot; offset persists during continued flight.
- [x] Single-finger vertical drag → camera rises (drag down) / lowers (drag up); offset persists; clamped to 30 m – 50 km.
- [x] Toggle chase off → camera releases, normal pan/zoom returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)