### PR TITLE
fix: make log book totals follow the filtered list

### DIFF
--- a/the_paragliding_app/lib/presentation/screens/flight_list_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/flight_list_screen.dart
@@ -47,8 +47,6 @@ class FlightListScreenState extends State<FlightListScreen> {
   // State variables
   List<Flight> _flights = [];
   List<Flight> _sortedFlights = [];
-  int _totalFlights = 0;
-  int _totalDuration = 0;
   bool _isLoading = false;
   String? _errorMessage;
   
@@ -112,17 +110,11 @@ class FlightListScreenState extends State<FlightListScreen> {
       final flights = await _databaseService.getAllFlights();
       final flightsDuration = DateTime.now().difference(flightsStartTime);
 
-      // Get totals from database
-      final statsStartTime = DateTime.now();
-      final stats = await _databaseService.getOverallStatistics();
-      final statsDuration = DateTime.now().difference(statsStartTime);
-
       final totalDuration = DateTime.now().difference(totalStartTime);
 
       // Log breakdown of timings
       LoggingService.structured('FLIGHT_LIST_LOAD_BREAKDOWN', {
         'flights_query_ms': flightsDuration.inMilliseconds,
-        'stats_query_ms': statsDuration.inMilliseconds,
         'total_ms': totalDuration.inMilliseconds,
         'flight_count': flights.length,
       });
@@ -132,8 +124,6 @@ class FlightListScreenState extends State<FlightListScreen> {
       if (mounted) {
         setState(() {
           _flights = flights;
-          _totalFlights = stats['totalFlights'] as int? ?? 0;
-          _totalDuration = stats['totalDuration'] as int? ?? 0;
           _sortFlights();
           _isLoading = false;
         });
@@ -435,17 +425,21 @@ class FlightListScreenState extends State<FlightListScreen> {
 
 
   Widget _buildFlightList(List<Flight> flights) {
+    // Totals describe the rows actually listed, so they follow the search and
+    // date-range filters. effectiveDuration matches what each row displays.
+    final totalDuration = flights.fold<int>(0, (sum, f) => sum + f.effectiveDuration);
+
     return Column(
       children: [
         AppStatCardGroup.flightList(
           cards: [
             AppStatCard.flightList(
               label: 'Total Flights',
-              value: _totalFlights.toString(),
+              value: flights.length.toString(),
             ),
             AppStatCard.flightList(
               label: 'Total Time',
-              value: DateTimeUtils.formatDuration(_totalDuration),
+              value: DateTimeUtils.formatDuration(totalDuration),
             ),
           ],
           backgroundColor: Theme.of(context).colorScheme.surface,

--- a/the_paragliding_app/lib/services/database_service.dart
+++ b/the_paragliding_app/lib/services/database_service.dart
@@ -422,35 +422,6 @@ class DatabaseService {
     return (whereClause, whereArgs);
   }
   
-  /// Get overall flight statistics (total flights, hours, max altitude)
-  Future<Map<String, dynamic>> getOverallStatistics() async {
-    LoggingService.debug('DatabaseService: Getting overall statistics');
-    
-    Database db = await _databaseHelper.database;
-    
-    List<Map<String, dynamic>> result = await db.rawQuery('''
-      SELECT 
-        COUNT(*) as total_flights,
-        SUM(duration) as total_duration,
-        MAX(max_altitude) as highest_altitude,
-        AVG(duration) as average_duration,
-        AVG(max_altitude) as average_altitude
-      FROM flights
-    ''');
-    
-    final row = result.first;
-    final stats = {
-      'totalFlights': row['total_flights'] ?? 0,
-      'totalDuration': row['total_duration'] ?? 0,
-      'highestAltitude': row['highest_altitude'] ?? 0.0,
-      'averageDuration': row['average_duration'] ?? 0.0,
-      'averageAltitude': row['average_altitude'] ?? 0.0,
-    };
-    
-    LoggingService.info('DatabaseService: Generated overall statistics for ${stats['totalFlights']} flights');
-    return stats;
-  }
-
   /// Get flight statistics grouped by year
   Future<List<Map<String, dynamic>>> getYearlyStatistics({DateTime? startDate, DateTime? endDate}) async {
     final stopwatch = Stopwatch()..start();

--- a/the_paragliding_app/test/flight_list_totals_test.dart
+++ b/the_paragliding_app/test/flight_list_totals_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:the_paragliding_app/data/models/flight.dart';
+import 'package:the_paragliding_app/presentation/screens/flight_list_screen.dart';
+import 'package:the_paragliding_app/presentation/widgets/common/app_stat_card.dart';
+import 'package:the_paragliding_app/services/database_service.dart';
+
+import 'helpers/test_helpers.dart';
+
+/// The log book header must describe the rows actually listed: filtering by site
+/// or date range has to move both totals, not just the table.
+void main() {
+  final db = DatabaseService.instance;
+
+  setUpAll(() async {
+    await TestHelpers.initializeDatabaseForTesting();
+
+    await db.insertSite(TestHelpers.createTestSite(id: 1, name: 'Alpha Launch'));
+    await db.insertSite(TestHelpers.createTestSite(id: 2, name: 'Bravo Hill'));
+
+    final recent = DateTime.now().subtract(const Duration(days: 10));
+    final old = DateTime.now().subtract(const Duration(days: 400));
+
+    // TestHelpers.createTestFlight() sets source: 'test', which the flights
+    // table's CHECK constraint rejects, so build the rows directly.
+    Flight flight(
+        {required DateTime date, required int duration, required int siteId}) {
+      final now = DateTime.now();
+      return Flight(
+        date: date,
+        launchTime: '10:00',
+        landingTime: '12:00',
+        duration: duration,
+        launchSiteId: siteId,
+        source: 'manual',
+        createdAt: now,
+        updatedAt: now,
+      );
+    }
+
+    // Alpha: 60 + 30 = 1h 30m, both recent. Bravo: 90m recent, 45m long ago.
+    await db.insertFlight(flight(date: recent, duration: 60, siteId: 1));
+    await db.insertFlight(flight(date: recent, duration: 30, siteId: 1));
+    await db.insertFlight(flight(date: recent, duration: 90, siteId: 2));
+    await db.insertFlight(flight(date: old, duration: 45, siteId: 2));
+  });
+
+  /// Read a header card's value straight off the widget, so the assertion can't
+  /// accidentally match an identical string in the table below it.
+  String statValue(WidgetTester tester, String label) {
+    return tester
+        .widget<AppStatCard>(find.byWidgetPredicate(
+            (w) => w is AppStatCard && w.label == label))
+        .value;
+  }
+
+  /// The loading skeleton shimmers forever, so pumpAndSettle() never returns on
+  /// this screen - pump a couple of frames instead.
+  Future<void> settle(WidgetTester tester) async {
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+  }
+
+  Future<void> pumpFlightList(WidgetTester tester) async {
+    await tester.pumpWidget(
+        TestHelpers.createTestApp(child: const FlightListScreen()));
+
+    // The screen loads from sqlite in a post-frame callback: real I/O, so give
+    // it real time (runAsync) rather than just pumping frames.
+    for (var i = 0; i < 60; i++) {
+      if (find.byType(AppStatCard).evaluate().isNotEmpty) return;
+      await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 50)));
+      await tester.pump();
+    }
+    fail('flight list never finished loading');
+  }
+
+  testWidgets('totals cover every flight when no filter is applied',
+      (tester) async {
+    await pumpFlightList(tester);
+
+    expect(statValue(tester, 'Total Flights'), '4');
+    expect(statValue(tester, 'Total Time'), '3h 45m'); // 60+30+90+45
+  });
+
+  testWidgets('totals follow the site search', (tester) async {
+    await pumpFlightList(tester);
+
+    await tester.enterText(find.byType(TextField), 'alpha');
+    await settle(tester);
+
+    expect(statValue(tester, 'Total Flights'), '2');
+    expect(statValue(tester, 'Total Time'), '1h 30m');
+
+    // Clearing the search restores the full totals.
+    await tester.enterText(find.byType(TextField), '');
+    await settle(tester);
+
+    expect(statValue(tester, 'Total Flights'), '4');
+    expect(statValue(tester, 'Total Time'), '3h 45m');
+  });
+
+  testWidgets('a search with no matches shows zeroed totals', (tester) async {
+    await pumpFlightList(tester);
+
+    await tester.enterText(find.byType(TextField), 'nowhere');
+    await settle(tester);
+
+    expect(statValue(tester, 'Total Flights'), '0');
+    expect(statValue(tester, 'Total Time'), '0h 0m');
+  });
+
+  testWidgets('totals follow the date range filter', (tester) async {
+    await pumpFlightList(tester);
+
+    await tester.tap(find.byIcon(Icons.calendar_today));
+    await settle(tester);
+    await tester.tap(find.text('Last 3 months').last);
+    await settle(tester);
+
+    // The 400-day-old flight drops out.
+    expect(statValue(tester, 'Total Flights'), '3');
+    expect(statValue(tester, 'Total Time'), '3h 0m');
+  });
+}


### PR DESCRIPTION
## Problem

The log book header's **Total Flights** and **Total Time** never moved when you searched for a site or picked a date range — they always described the whole database.

The two were structurally disconnected: `_loadData()` filled the totals from `DatabaseService.getOverallStatistics()` (an unfiltered `COUNT(*)` / `SUM(duration)` with no `WHERE` clause), while `_sortFlights()` filtered an in-memory list. Filtering never touched the totals, and a filter change didn't even re-run `_loadData()`.

A second, quieter disagreement: the header summed the raw `duration` column, but each row renders `flight.effectiveDuration`, which prefers detected takeoff/landing times — so the header could differ from the sum of the visible rows even with no filter applied.

## Fix

Derive both totals from the filtered list `_buildFlightList()` already receives. The whole list is in memory (`getAllFlights()` has no `LIMIT`, and the `DataTable` builds every row eagerly), so there's nothing to page around, and a single source of truth can't drift out of sync with the filter. The time now sums `effectiveDuration`, matching the Duration column.

`getOverallStatistics()` had no other caller, so it's removed along with the per-load stats query — one less DB round-trip on every load.

## Verification

- New `test/flight_list_totals_test.dart`: unfiltered totals, site search, empty result set, and the "Last 3 months" preset. Confirmed non-vacuous — 3 of the 4 fail against the pre-fix code.
- `flutter analyze` clean; `flutter test --concurrency=1` green (113 passed, 16 skipped).
- Ran on Linux desktop (182 flights) and on a Pixel 9 (181 flights). Load log now reads `flights_query_ms=228 | total_ms=228` — no `stats_query_ms` — with no errors in the device log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)