### PR TITLE
Fix intermittent test failures (#280)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,20 +42,19 @@ jobs:
         run: flutter analyze
 
       - name: Test
-        # --concurrency=1: the database-heavy test files contend when run in
-        # parallel and blow the 30s default timeout, failing together in about a
-        # third of runs. Serialised they are stable, and the suite is no slower
-        # overall. This cannot live in dart_test.yaml - flutter test always passes
-        # its own -j and overrides the file.
+        # --concurrency=1 is kept as a precaution, not because the suite is still
+        # flaky. #280 fixed that, and parallel now passes 16 consecutive runs -
+        # but only measured on an 8-core dev box, and hosted runners have far
+        # fewer cores. Re-measure here before dropping this.
+        # This cannot live in dart_test.yaml - flutter test always passes its own
+        # -j and overrides the file.
         run: flutter test --concurrency=1
 
       - name: Test date ranges in a DST timezone
         # Runners are UTC, which has no DST - date arithmetic that loses a day
         # across a spring-forward boundary passes here and breaks for real users.
-        # Scoped to the date-range tests on purpose: the full suite is currently
-        # flaky under concurrent load (unrelated to timezones - different tests
-        # fail on each run), so running all of it twice would just double CI's
-        # exposure to that without adding DST coverage.
+        # Scoped to the date-range tests on purpose: running the whole suite a
+        # second time would double CI's runtime without adding DST coverage.
         env:
           TZ: America/New_York
         run: flutter test --concurrency=1 test/date_range_test.dart

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,18 +81,35 @@ does not cross the NAT), so always use an explicit `IP:port`.
 
 ```bash
 flutter analyze                       # Check for errors (run after complex, mult-file change)
-flutter test --concurrency=1          # Run all tests (see note below - plain `flutter test` is flaky)
+flutter test                          # Run all tests
 flutter test test/specific_test.dart  # Run specific test
 flutter test --tags network --run-skipped  # Live-API tests, skipped by default
 flutter_controller_enhanced cleanup   # Clean up processes if stuck
 flutter_controller_enhanced health    # Check process/pipe/readiness status
 ```
 
-**Always pass `--concurrency=1`.** The database-heavy test files each open sqlite, seed
-249 country codes and build indexes; run in parallel they contend enough to blow the 30s
-default timeout and fail together in about a third of runs, always with
-`TimeoutException` rather than a real assertion. This cannot be set in `dart_test.yaml` -
-`flutter test` always passes its own `-j` and overrides the file. CI does it in `ci.yml`.
+**Plain `flutter test` is fine locally.** It used to fail about 1 run in 3, so this file
+told you to always pass `--concurrency=1`. Issue #280 fixed the underlying test problems;
+measured over 16 consecutive runs on an 8-core dev box, parallel is now 0/16 failures and
+the fastest of the three modes (mean 46s, vs 60s serial, vs 81s serial before the fix).
+
+Keep the tests isolated, or this comes back:
+
+- **Never write fixtures to a fixed path.** Use `TestHelpers.fixturePath('name.igc')`, which
+  gives each test process its own directory. Fixed `/tmp` paths caused a real failure -
+  two test files both wrote `/tmp/test_india.igc`, and one run read a fixture back empty
+  (`Parsed 0 track points, pilot: Unknown`).
+- **The test database is in-memory** (`TestHelpers.initializeDatabaseForTesting()` sets
+  `DatabaseHelper.databasePathOverride`). Don't reintroduce a file-backed one, and don't
+  add per-test `recreateDatabase()` unless a test actually writes - eight read-only tests
+  were rebuilding the schema and re-seeding 249 country codes nine times per run.
+
+**CI still passes `--concurrency=1`** (`.github/workflows/ci.yml`). That is deliberate and
+not stale: parallel was only verified on an 8-core dev machine, and hosted runners have
+far fewer cores. Re-measure there before changing it.
+
+`concurrency:` cannot be set in `dart_test.yaml` - `flutter test` always passes its own
+`-j` and overrides the file. It has to be on the command line.
 
 ## 📁 Key Files (Most Accessed)
 
@@ -146,7 +163,8 @@ lib/
 | Track data empty | Direct IGC parsing | Use `FlightTrackLoader.loadFlightTrack()` |
 | State not updating | Widget not rebuilding | Check `setState()` calls |
 | Database locked | Concurrent operations | Use `DatabaseService` methods |
-| Tests fail with `TimeoutException` | Parallel test files contend | Run `flutter test --concurrency=1` |
+| Tests fail with `TimeoutException` | A test file opens a file-backed database, or does needless DB lifecycle churn | Keep the test DB in-memory; don't add per-test `recreateDatabase()` (see #280) |
+| Test reads its own fixture back empty | Fixture written to a fixed `/tmp` path | Use `TestHelpers.fixturePath('name.igc')` |
 | Test hits the network | Live-API test not tagged | Tag it `network`; it is skipped by default |
 | Hot reload fails | State corruption | Use `R` (hot restart) instead of `r` |
 | App won't start | Process still running | Run `flutter_controller_enhanced cleanup` |

--- a/the_paragliding_app/lib/data/datasources/database_helper.dart
+++ b/the_paragliding_app/lib/data/datasources/database_helper.dart
@@ -31,8 +31,39 @@ class DatabaseHelper {
   DatabaseHelper._privateConstructor();
   static final DatabaseHelper instance = DatabaseHelper._privateConstructor();
 
-  static Database? _database;
-  Future<Database> get database async => _database ??= await _initDatabase();
+  /// Where the database lives. Tests set this to [inMemoryDatabasePath] so each
+  /// test process gets a private database that costs nothing to build and
+  /// leaves no temp directory behind. Production never sets it.
+  static String? databasePathOverride;
+
+  static Future<Database>? _databaseFuture;
+
+  /// The shared connection, opened on first use.
+  ///
+  /// Memoises the *future*, not the resolved value. `_database ??= await
+  /// _initDatabase()` reads as equivalent but is not: the `await` suspends
+  /// before the assignment, so two callers can both find the field null and
+  /// both open a connection. Worse, while one slow open is in flight every
+  /// further caller starts another one - under load that multiplied into
+  /// repeated schema creation and country-code seeding. Assigning the future
+  /// happens synchronously, so later callers await the same open. Same shape
+  /// as AppInitializationService.ensureTables().
+  Future<Database> get database => _databaseFuture ??= _openDatabase();
+
+  Future<String> _databasePath() async =>
+      databasePathOverride ?? join(await getDatabasesPath(), _databaseName);
+
+  /// Opens the database, clearing the memo if the open fails so a rejected
+  /// future is never cached - one transient failure must not poison every
+  /// later call.
+  Future<Database> _openDatabase() async {
+    try {
+      return await _initDatabase();
+    } catch (_) {
+      _databaseFuture = null;
+      rethrow;
+    }
+  }
 
   /// Initialize database with v1.0 schema
   ///
@@ -42,7 +73,7 @@ class DatabaseHelper {
   /// POST-RELEASE STRATEGY: Start migrations from v2 when app is released.
   /// This ensures a clean baseline for production users.
   Future<Database> _initDatabase() async {
-    String path = join(await getDatabasesPath(), _databaseName);
+    final path = await _databasePath();
     LoggingService.database('INIT', 'Opening database at: $path');
 
     final db = await openDatabase(
@@ -438,19 +469,34 @@ class DatabaseHelper {
 
   /// Force recreation of the database (use when migration fails)
   Future<void> recreateDatabase() async {
-    final path = join(await getDatabasesPath(), _databaseName);
-    
-    // Close existing connection
-    if (_database != null) {
-      await _database!.close();
-      _database = null;
+    final path = await _databasePath();
+
+    // Clear the memo before awaiting anything. While the old connection is
+    // closing and the file is being removed there is no usable database, and a
+    // concurrent caller must be made to open a fresh one rather than handed the
+    // dying handle - that produced "Bad state: This database has already been
+    // closed" on PRAGMA user_version.
+    final previous = _databaseFuture;
+    _databaseFuture = null;
+
+    if (previous != null) {
+      try {
+        await (await previous).close();
+      } catch (error, stackTrace) {
+        // An open that already failed has nothing to close, and that must not
+        // stop the recreate it was called to perform.
+        LoggingService.error(
+            'DatabaseHelper: closing the old connection failed', error, stackTrace);
+      }
     }
-    
-    // Delete the database file
-    await deleteDatabase(path);
-    
-    // Recreate the database
-    _database = await _initDatabase();
+
+    // An in-memory database has no file; closing it is what discards the data.
+    if (path != inMemoryDatabasePath) {
+      await deleteDatabase(path);
+    }
+
+    _databaseFuture = _openDatabase();
+    await _databaseFuture;
   }
 
   /// Validate database schema to ensure all expected columns exist
@@ -542,12 +588,12 @@ class DatabaseHelper {
   }
 
   Future<void> close() async {
-    final db = _database;
-    if (db == null) return;
+    final pending = _databaseFuture;
+    if (pending == null) return;
     // Clear the field before awaiting: the getter must not hand out a handle
     // that is mid-close, and leaving it set meant every later call returned a
     // closed database ("Bad state: This database has already been closed").
-    _database = null;
-    await db.close();
+    _databaseFuture = null;
+    await (await pending).close();
   }
 }

--- a/the_paragliding_app/test/database_helper_test.dart
+++ b/the_paragliding_app/test/database_helper_test.dart
@@ -166,10 +166,13 @@ void main() {
       expect(aliasWingFk['table'], equals('wings'));
       expect(aliasWingFk['to'], equals('id'));
     });
-    
-    tearDown(() async {
-      // Clean up database for next test
-      await databaseHelper.recreateDatabase();
-    });
+
+    // No tearDown: every test above only reads schema metadata (PRAGMA
+    // table_info, PRAGMA foreign_key_list, getVersion, sqlite_master), so there
+    // is nothing to clean up between them. Recreating the database after each
+    // one rebuilt the schema and re-seeded 249 country codes nine times per
+    // run - 4.5s warm, 11.9s under load - for no benefit, and that cost was a
+    // contributor to issue #280's timeouts. Add cleanup back only if a test
+    // here starts writing.
   });
 }

--- a/the_paragliding_app/test/dst_transition_test.dart
+++ b/the_paragliding_app/test/dst_transition_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:the_paragliding_app/services/igc_parser.dart';
 import 'package:the_paragliding_app/services/timezone_service.dart';
 import 'dart:io';
+import 'helpers/test_helpers.dart';
 
 void main() {
   group('DST Transition Tests', () {
@@ -24,7 +25,7 @@ B0800004070300N07400300WA019780209600807000
 B0830004070400N07400400WA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_spring_dst.igc');
+        final testFile = File(TestHelpers.fixturePath('test_spring_dst.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -58,7 +59,7 @@ B0730004070100N07400100WA019780209600807000
 B0800004070200N07400200WA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_dst_start.igc');
+        final testFile = File(TestHelpers.fixturePath('test_dst_start.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -89,7 +90,7 @@ B0700004070300N07400300WA019780209600807000
 B0730004070400N07400400WA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_fall_dst.igc');
+        final testFile = File(TestHelpers.fixturePath('test_fall_dst.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -130,7 +131,7 @@ B0630004070300N07400300WA019780209600807000
 B0700004070400N07400400WA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_ambiguous_hour.igc');
+        final testFile = File(TestHelpers.fixturePath('test_ambiguous_hour.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -162,7 +163,7 @@ B1630003380200S15120200EA019780209600807000
 B1700003380300S15120300EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_sydney_dst.igc');
+        final testFile = File(TestHelpers.fixturePath('test_sydney_dst.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -192,7 +193,7 @@ B1630003380200S15120200EA019780209600807000
 B1700003380300S15120300EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_sydney_dst_end.igc');
+        final testFile = File(TestHelpers.fixturePath('test_sydney_dst_end.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -224,7 +225,7 @@ B1500003300200N11200200WA019780209600807000
 B1530003300300N11200300WA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_arizona_no_dst.igc');
+        final testFile = File(TestHelpers.fixturePath('test_arizona_no_dst.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -256,7 +257,7 @@ B0100002700200S15300200EA019780209600807000
 B0130002700300S15300300EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_queensland_no_dst.igc');
+        final testFile = File(TestHelpers.fixturePath('test_queensland_no_dst.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -287,7 +288,7 @@ B0630004070000N07400000WA019780209600807000
 B0830004070400N07400400WA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_dst_duration.igc');
+        final testFile = File(TestHelpers.fixturePath('test_dst_duration.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -313,7 +314,7 @@ B0530004070000N07400000WA019780209600807000
 B0730004070400N07400400WA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_fall_duration.igc');
+        final testFile = File(TestHelpers.fixturePath('test_fall_duration.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -342,7 +343,7 @@ B0645004070100N07400100WA019780209600807000
 B0700004070200N07400200WA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_exact_dst.igc');
+        final testFile = File(TestHelpers.fixturePath('test_exact_dst.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -368,7 +369,7 @@ B0701004070300N07400300WA019780209600807000
 B0702004070400N07400400WA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_rapid_dst.igc');
+        final testFile = File(TestHelpers.fixturePath('test_rapid_dst.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();

--- a/the_paragliding_app/test/flutter_test_config.dart
+++ b/the_paragliding_app/test/flutter_test_config.dart
@@ -21,5 +21,6 @@ Future<void> testExecutable(FutureOr<void> Function() testMain) async {
 
   await TestHelpers.initializeDatabaseForTesting();
   tearDownAll(TestHelpers.cleanupDatabaseForTesting);
+  tearDownAll(TestHelpers.cleanupFixtures);
   await testMain();
 }

--- a/the_paragliding_app/test/helpers/test_helpers.dart
+++ b/the_paragliding_app/test/helpers/test_helpers.dart
@@ -2,53 +2,72 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:the_paragliding_app/data/datasources/database_helper.dart';
 import 'package:the_paragliding_app/data/models/flight.dart';
 import 'package:the_paragliding_app/data/models/site.dart';
 import 'package:the_paragliding_app/data/models/wing.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
-import 'package:the_paragliding_app/services/logging_service.dart';
 
 /// Test helper utilities for widget testing
 class TestHelpers {
 
-  /// Temporary databases directory owned by this test process.
-  static Directory? _databasesDir;
+  static bool _initialized = false;
 
-  /// Initialize the sqflite factory for testing.
+  /// Point sqflite at an in-memory database for this test process.
   ///
-  /// Each test file runs in its own process, and each process gets its own
-  /// temporary databases directory. Without this, every test would share
-  /// `.dart_tool/sqflite_common_ffi/databases/FlightLog.db` (the ffi default,
-  /// relative to the working directory), which is both the file the desktop
-  /// dev app uses and a source of cross-file flakiness when `flutter test`
-  /// runs test files concurrently.
+  /// Each test file runs in its own process, so an in-memory database is
+  /// private to that file. Nothing touches the ffi default
+  /// (`.dart_tool/sqflite_common_ffi/databases/FlightLog.db`, which is also the
+  /// desktop dev app's database), and there is no temp directory to leak - the
+  /// previous approach left 46 `/tmp/paragliding_app_test_db_*` directories
+  /// behind, because a test file that times out never reaches its teardown.
+  ///
+  /// It is also far cheaper. Building the schema and seeding 249 country codes
+  /// against a file cost ~250ms; in memory it is microseconds. That margin is
+  /// what pushed DB-touching test files past the 30s default timeout when
+  /// `flutter test` was compiling the next file on another core (issue #280).
   ///
   /// Called automatically for every test file by `test/flutter_test_config.dart`;
   /// safe to call again from a test's `setUpAll`.
   static Future<void> initializeDatabaseForTesting() async {
-    if (_databasesDir != null) return; // Already initialized in this process.
+    if (_initialized) return; // Already initialized in this process.
     sqfliteFfiInit();
     databaseFactory = databaseFactoryFfi;
-    final dir = _databasesDir =
-        Directory.systemTemp.createTempSync('paragliding_app_test_db_');
-    await databaseFactory.setDatabasesPath(dir.path);
+    DatabaseHelper.databasePathOverride = inMemoryDatabasePath;
+    _initialized = true;
   }
 
-  /// Delete this process's temporary databases directory (best effort).
+  /// Close the in-memory database, which is what discards its contents.
   static Future<void> cleanupDatabaseForTesting() async {
-    final dir = _databasesDir;
-    _databasesDir = null;
+    if (!_initialized) return;
+    await DatabaseHelper.instance.close();
+  }
+
+  static Directory? _fixtureDirCache;
+
+  /// Directory private to this test process for fixture files.
+  ///
+  /// Tests used to write IGC fixtures to fixed paths like `/tmp/test_india.igc`
+  /// - which two different test files both wrote - and read them straight back.
+  /// A baseline run of issue #280 failed with `Parsed 0 track points, pilot:
+  /// Unknown` because one such fixture read back empty. A per-process directory
+  /// removes the whole class, including interference from anything else on the
+  /// machine that happens to use `/tmp`.
+  static Directory get _fixtureDir => _fixtureDirCache ??=
+      Directory.systemTemp.createTempSync('paragliding_app_fixtures_');
+
+  /// Absolute path for a fixture file called [name], private to this process.
+  static String fixturePath(String name) => '${_fixtureDir.path}/$name';
+
+  /// Remove this process's fixture directory (best effort).
+  static void cleanupFixtures() {
+    final dir = _fixtureDirCache;
+    _fixtureDirCache = null;
     if (dir == null) return;
     try {
-      if (dir.existsSync()) {
-        dir.deleteSync(recursive: true);
-      }
-    } catch (e) {
-      // Best effort - a leftover temp directory must never fail a test run,
-      // but it should not vanish silently either: repeated runs leaking temp
-      // databases is exactly the kind of thing nobody notices without a signal.
-      LoggingService.warning(
-          'test_helpers: failed to delete temp database dir ${dir.path}: $e');
+      if (dir.existsSync()) dir.deleteSync(recursive: true);
+    } catch (_) {
+      // A leftover temp directory must never fail a test run.
     }
   }
 

--- a/the_paragliding_app/test/multi_day_flight_test.dart
+++ b/the_paragliding_app/test/multi_day_flight_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:the_paragliding_app/services/igc_parser.dart';
 import 'package:the_paragliding_app/services/timezone_service.dart';
 import 'dart:io';
+import 'helpers/test_helpers.dart';
 
 void main() {
   group('Multi-Day Flight Tests', () {
@@ -26,7 +27,7 @@ B0130004700700N00800700EA019780209600807000
 B0200004700800N00800800EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_two_day.igc');
+        final testFile = File(TestHelpers.fixturePath('test_two_day.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -79,7 +80,7 @@ B0000004701400N00801400EA019780209600807000
 B0200004701500N00801500EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_double_midnight.igc');
+        final testFile = File(TestHelpers.fixturePath('test_double_midnight.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -132,7 +133,7 @@ B1000004701300N00801300EA019780209600807000
 B1200004701400N00801400EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_week_expedition.igc');
+        final testFile = File(TestHelpers.fixturePath('test_week_expedition.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -167,7 +168,7 @@ B1400004700800N00800800EA019780209600807000
 B1600004700900N00800900EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_overnight_stop.igc');
+        final testFile = File(TestHelpers.fixturePath('test_overnight_stop.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -209,7 +210,7 @@ B0000004700600N00800600EA019780209600807000
 B0030004700700N00800700EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_consecutive_midnight.igc');
+        final testFile = File(TestHelpers.fixturePath('test_consecutive_midnight.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -251,7 +252,7 @@ B0000008500600N04000600EA019780209600807000
 B0100008500700N04500700EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_polar_summer.igc');
+        final testFile = File(TestHelpers.fixturePath('test_polar_summer.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -300,7 +301,7 @@ B0200004701000N00801000EA019780209600807000
 B0600004701100N00801100EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_chronological_multi.igc');
+        final testFile = File(TestHelpers.fixturePath('test_chronological_multi.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -347,7 +348,7 @@ B0100004700800N00800800EA019780209600807000
 B0800004700900N00800900EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_irregular.igc');
+        final testFile = File(TestHelpers.fixturePath('test_irregular.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -390,7 +391,7 @@ B1000003300500S15100500EA019780209600807000
 B1400003300600S15100600EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_multi_tz.igc');
+        final testFile = File(TestHelpers.fixturePath('test_multi_tz.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -428,7 +429,7 @@ B0100004700300N00800300EA019780209600807000
 B0200004700400N00800400EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_new_year.igc');
+        final testFile = File(TestHelpers.fixturePath('test_new_year.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -488,7 +489,7 @@ B0200004700400N00800400EA019780209600807000
           }
         }
         
-        final testFile = File('/tmp/test_performance.igc');
+        final testFile = File(TestHelpers.fixturePath('test_performance.igc'));
         await testFile.writeAsString(buffer.toString());
         
         final stopwatch = Stopwatch()..start();

--- a/the_paragliding_app/test/timezone_boundary_test.dart
+++ b/the_paragliding_app/test/timezone_boundary_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:the_paragliding_app/services/igc_parser.dart';
 import 'package:the_paragliding_app/services/timezone_service.dart';
 import 'dart:io';
+import 'helpers/test_helpers.dart';
 
 void main() {
   group('Timezone Boundary Crossing Tests', () {
@@ -23,7 +24,7 @@ B1300004550000N00200000EA019780209600807000
 B1400004500000N00000000WA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_tz_crossing.igc');
+        final testFile = File(TestHelpers.fixturePath('test_tz_crossing.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -60,7 +61,7 @@ B1200004300000N00500000EA019780209600807000
 B1300004000000N00800000WA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_east_west.igc');
+        final testFile = File(TestHelpers.fixturePath('test_east_west.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -92,7 +93,7 @@ B1100005250000N01500000EA019780209600807000
 B1200005300000N02000000EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_west_east.igc');
+        final testFile = File(TestHelpers.fixturePath('test_west_east.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -129,7 +130,7 @@ B1100004550000N02500000EA019780209600807000
 B1200004500000N03000000EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_multi_zone.igc');
+        final testFile = File(TestHelpers.fixturePath('test_multi_zone.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -160,7 +161,7 @@ B1130004600000N00700000EA019780209600807000
 B1200004600000N00600000EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_zigzag.igc');
+        final testFile = File(TestHelpers.fixturePath('test_zigzag.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -194,7 +195,7 @@ B1300003250000N12100000WA019780209600807000
 B1400003200000N12200000WA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_land_ocean.igc');
+        final testFile = File(TestHelpers.fixturePath('test_land_ocean.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -226,7 +227,7 @@ B0300003360000S15300000EA019780209600807000
 B0400003380000S15300000EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_coastline.igc');
+        final testFile = File(TestHelpers.fixturePath('test_coastline.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -254,7 +255,7 @@ B1200006800000N02500000EA019780209600807000
 B1300006800000N03000000EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_arctic.igc');
+        final testFile = File(TestHelpers.fixturePath('test_arctic.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -286,7 +287,7 @@ B1200007200000S01000000EA019780209600807000
 B1300007300000S01500000EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_antarctic.igc');
+        final testFile = File(TestHelpers.fixturePath('test_antarctic.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -314,7 +315,7 @@ B0600001800000N15400000WA019780209600807000
 B0800001700000N15000000WA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_island_hop.igc');
+        final testFile = File(TestHelpers.fixturePath('test_island_hop.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -345,7 +346,7 @@ B1200001700000N06700000WA019780209600807000
 B1300001650000N06800000WA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_caribbean.igc');
+        final testFile = File(TestHelpers.fixturePath('test_caribbean.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -372,7 +373,7 @@ B0600004000000N11000000EA019780209600807000
 B0800004000000N12000000EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_china.igc');
+        final testFile = File(TestHelpers.fixturePath('test_china.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -396,7 +397,7 @@ B0400002800000N09000000EA019780209600807000
 B0600002800000N08500000EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_india.igc');
+        final testFile = File(TestHelpers.fixturePath('test_india.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -423,7 +424,7 @@ B0100003300000N06100000EA019780209600807000
 B0200003300000N06200000EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_iran_afghan.igc');
+        final testFile = File(TestHelpers.fixturePath('test_iran_afghan.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();

--- a/the_paragliding_app/test/timezone_cache_test.dart
+++ b/the_paragliding_app/test/timezone_cache_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:the_paragliding_app/services/igc_parser.dart';
 import 'package:the_paragliding_app/services/timezone_service.dart';
 import 'dart:io';
+import 'helpers/test_helpers.dart';
 
 void main() {
   group('Timezone Cache Tests', () {
@@ -24,7 +25,7 @@ B1200004708710N01118478EA019780209600807000
 B1300004708710N01118478EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_cache1.igc');
+        final testFile = File(TestHelpers.fixturePath('test_cache1.igc'));
         await testFile.writeAsString(testIgc);
         
         // Get initial cache stats
@@ -59,8 +60,8 @@ B1400004708710N01118478EA019780209600807000
 B1500004708710N01118478EA019780209600807000
 ''';
 
-        final testFile1 = File('/tmp/test_cache_hit1.igc');
-        final testFile2 = File('/tmp/test_cache_hit2.igc');
+        final testFile1 = File(TestHelpers.fixturePath('test_cache_hit1.igc'));
+        final testFile2 = File(TestHelpers.fixturePath('test_cache_hit2.igc'));
         await testFile1.writeAsString(testIgc1);
         await testFile2.writeAsString(testIgc2);
         
@@ -105,9 +106,9 @@ B1200003530000N13900000EA019780209600807000
 B1300003530000N13900000EA019780209600807000
 ''';
 
-        final fileSwiss = File('/tmp/test_cache_swiss.igc');
-        final fileAussie = File('/tmp/test_cache_aussie.igc');
-        final fileJapan = File('/tmp/test_cache_japan.igc');
+        final fileSwiss = File(TestHelpers.fixturePath('test_cache_swiss.igc'));
+        final fileAussie = File(TestHelpers.fixturePath('test_cache_aussie.igc'));
+        final fileJapan = File(TestHelpers.fixturePath('test_cache_japan.igc'));
         
         await fileSwiss.writeAsString(testIgcSwitzerland);
         await fileAussie.writeAsString(testIgcAustralia);
@@ -158,7 +159,7 @@ B120000${latDeg.toString().padLeft(2, '0')}${latMin.toString().padLeft(2, '0')}0
 B130000${latDeg.toString().padLeft(2, '0')}${latMin.toString().padLeft(2, '0')}000N${lonDeg.toString().padLeft(3, '0')}${lonMin.toString().padLeft(2, '0')}000EA019780209600807000
 ''';
 
-          final testFile = File('/tmp/test_lru_$i.igc');
+          final testFile = File(TestHelpers.fixturePath('test_lru_$i.igc'));
           await testFile.writeAsString(testIgc);
           
           final result = await parser.parseFile(testFile.path);
@@ -181,7 +182,7 @@ B12000010${'00'}000N010${'00'}000EA019780209600807000
 B13000010${'00'}000N010${'00'}000EA019780209600807000
 ''';
 
-        final testFileFirst = File('/tmp/test_lru_0.igc');
+        final testFileFirst = File(TestHelpers.fixturePath('test_lru_0.igc'));
         await testFileFirst.writeAsString(testIgcFirst);
         
         await parser.parseFile(testFileFirst.path);
@@ -211,7 +212,7 @@ B120000${loc['lat']}N${loc['lon']}${loc['dir']}A019780209600807000
 B130000${loc['lat']}N${loc['lon']}${loc['dir']}A019780209600807000
 ''';
 
-          final testFile = File('/tmp/test_access_$i.igc');
+          final testFile = File(TestHelpers.fixturePath('test_access_$i.igc'));
           await testFile.writeAsString(testIgc);
           await parser.parseFile(testFile.path);
         }
@@ -227,7 +228,7 @@ B140000${locations[0]['lat']}N${locations[0]['lon']}${locations[0]['dir']}A01978
 B150000${locations[0]['lat']}N${locations[0]['lon']}${locations[0]['dir']}A019780209600807000
 ''';
 
-        final testFileReaccess = File('/tmp/test_reaccess.igc');
+        final testFileReaccess = File(TestHelpers.fixturePath('test_reaccess.igc'));
         await testFileReaccess.writeAsString(testIgcReaccess);
         await parser.parseFile(testFileReaccess.path);
         
@@ -243,7 +244,7 @@ B120000${(5000000 + i * 1000).toString().padLeft(7, '0')}N${(1000000 + i * 1000)
 B130000${(5000000 + i * 1000).toString().padLeft(7, '0')}N${(1000000 + i * 1000).toString().padLeft(8, '0')}EA019780209600807000
 ''';
 
-          final testFile = File('/tmp/test_fill_$i.igc');
+          final testFile = File(TestHelpers.fixturePath('test_fill_$i.igc'));
           await testFile.writeAsString(testIgc);
           await parser.parseFile(testFile.path);
         }
@@ -260,7 +261,7 @@ B160000${locations[0]['lat']}N${locations[0]['lon']}${locations[0]['dir']}A01978
 B170000${locations[0]['lat']}N${locations[0]['lon']}${locations[0]['dir']}A019780209600807000
 ''';
 
-        final testFile0Again = File('/tmp/test_check_0.igc');
+        final testFile0Again = File(TestHelpers.fixturePath('test_check_0.igc'));
         await testFile0Again.writeAsString(testLocation0Again);
         await parser.parseFile(testFile0Again.path);
         
@@ -282,7 +283,7 @@ B120000${(4000000 + i * 100000).toString().padLeft(7, '0')}N${(1000000 + i * 100
 B130000${(4000000 + i * 100000).toString().padLeft(7, '0')}N${(1000000 + i * 100000).toString().padLeft(8, '0')}EA019780209600807000
 ''';
 
-          final testFile = File('/tmp/test_clear_$i.igc');
+          final testFile = File(TestHelpers.fixturePath('test_clear_$i.igc'));
           await testFile.writeAsString(testIgc);
           await parser.parseFile(testFile.path);
         }
@@ -309,7 +310,7 @@ B1200004708710N01118478EA019780209600807000
 B1300004708710N01118478EA019780209600807000
 ''';
 
-        final testFile1 = File('/tmp/test_before_clear.igc');
+        final testFile1 = File(TestHelpers.fixturePath('test_before_clear.igc'));
         await testFile1.writeAsString(testIgc1);
         
         final result1 = await parser.parseFile(testFile1.path);
@@ -328,7 +329,7 @@ B1400003386880S15120930EA019780209600807000
 B1500003386880S15120930EA019780209600807000
 ''';
 
-        final testFile2 = File('/tmp/test_after_clear.igc');
+        final testFile2 = File(TestHelpers.fixturePath('test_after_clear.igc'));
         await testFile2.writeAsString(testIgc2);
         
         final result2 = await parser.parseFile(testFile2.path);
@@ -356,8 +357,8 @@ B1400004708711N01118479EA019780209600807000
 B1500004708711N01118479EA019780209600807000
 ''';
 
-        final testFile1 = File('/tmp/test_key1.igc');
-        final testFile2 = File('/tmp/test_key2.igc');
+        final testFile1 = File(TestHelpers.fixturePath('test_key1.igc'));
+        final testFile2 = File(TestHelpers.fixturePath('test_key2.igc'));
         await testFile1.writeAsString(testIgc1);
         await testFile2.writeAsString(testIgc2);
         
@@ -393,7 +394,7 @@ B120000${edge['lat']}${edge['latDir']}${edge['lon']}${edge['lonDir']}A0197802096
 B130000${edge['lat']}${edge['latDir']}${edge['lon']}${edge['lonDir']}A019780209600807000
 ''';
 
-          final testFile = File('/tmp/test_edge_$i.igc');
+          final testFile = File(TestHelpers.fixturePath('test_edge_$i.igc'));
           await testFile.writeAsString(testIgc);
           
           final result = await parser.parseFile(testFile.path);
@@ -422,7 +423,7 @@ B1500004708710N01118478EA019780209600807000
 B1600004708710N01118478EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_perf.igc');
+        final testFile = File(TestHelpers.fixturePath('test_perf.igc'));
         await testFile.writeAsString(testIgc);
         
         // First parse - cache miss
@@ -457,7 +458,7 @@ B1200004708710N01118478EA019780209600807000
 B1300004708710N01118478EA019780209600807000
 ''';
 
-          final testFile = File('/tmp/test_concurrent_$i.igc');
+          final testFile = File(TestHelpers.fixturePath('test_concurrent_$i.igc'));
           await testFile.writeAsString(testIgc);
           files.add(testFile);
         }
@@ -497,7 +498,7 @@ B120000${(4000000 + i * 100000).toString().padLeft(7, '0')}N${(1000000 + i * 100
 B130000${(4000000 + i * 100000).toString().padLeft(7, '0')}N${(1000000 + i * 100000).toString().padLeft(8, '0')}EA019780209600807000
 ''';
 
-          final testFile = File('/tmp/test_stats_$i.igc');
+          final testFile = File(TestHelpers.fixturePath('test_stats_$i.igc'));
           await testFile.writeAsString(testIgc);
           await parser.parseFile(testFile.path);
         }

--- a/the_paragliding_app/test/timezone_edge_cases_test.dart
+++ b/the_paragliding_app/test/timezone_edge_cases_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:the_paragliding_app/services/igc_parser.dart';
 import 'package:the_paragliding_app/services/timezone_service.dart';
 import 'dart:io';
+import 'helpers/test_helpers.dart';
 
 void main() {
   group('Timezone Edge Cases Tests', () {
@@ -23,7 +24,7 @@ B0015003386920S15120950EA019780209600807000
 B0145003386940S15120960EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_midnight_tz.igc');
+        final testFile = File(TestHelpers.fixturePath('test_midnight_tz.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -71,7 +72,7 @@ B0830003700200N12200200WA019780209600807000
 B0945003700300N12200300WA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_midnight_neg_tz.igc');
+        final testFile = File(TestHelpers.fixturePath('test_midnight_neg_tz.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -113,7 +114,7 @@ B0000001800000S17900000EA019780209600807000
 B0100001800000S17900000WA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_dateline.igc');
+        final testFile = File(TestHelpers.fixturePath('test_dateline.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -138,7 +139,7 @@ B1000000130000N17230000EA019780209600807000
 B1100000130100N17230100EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_kiribati.igc');
+        final testFile = File(TestHelpers.fixturePath('test_kiribati.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -163,7 +164,7 @@ B1200000000000N17600000WA019780209600807000
 B1300000000100N17600100WA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_baker.igc');
+        final testFile = File(TestHelpers.fixturePath('test_baker.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -186,7 +187,7 @@ B0800002300000N07700000EA019780209600807000
 B0900002300100N07700100EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_india.igc');
+        final testFile = File(TestHelpers.fixturePath('test_india.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -209,7 +210,7 @@ B0400003500000S13835000EA019780209600807000
 B0500003500100S13835100EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_adelaide.igc');
+        final testFile = File(TestHelpers.fixturePath('test_adelaide.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -234,7 +235,7 @@ B1200009000000N00000000EA019780209600807000
 B1300009000000N00000000EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_north_pole.igc');
+        final testFile = File(TestHelpers.fixturePath('test_north_pole.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -254,7 +255,7 @@ B1200009000000S00000000EA019780209600807000
 B1300009000000S00000000EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_south_pole.igc');
+        final testFile = File(TestHelpers.fixturePath('test_south_pole.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -274,7 +275,7 @@ B1200000000000N18000000EA019780209600807000
 B1300000000000N18000000WA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_180_longitude.igc');
+        final testFile = File(TestHelpers.fixturePath('test_180_longitude.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -297,7 +298,7 @@ B1200004708710N01118478EA019780209600807000
 B1300004708710N01118478EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_invalid_tz.igc');
+        final testFile = File(TestHelpers.fixturePath('test_invalid_tz.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -318,7 +319,7 @@ B1200000000000N00000000EA019780209600807000
 B1300000000000N00000000EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_zero_coords.igc');
+        final testFile = File(TestHelpers.fixturePath('test_zero_coords.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -346,7 +347,7 @@ B0915004708710N01118478EA019780209600807000
 B0930004708710N01118478EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_chronological.igc');
+        final testFile = File(TestHelpers.fixturePath('test_chronological.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();
@@ -383,7 +384,7 @@ B1200034708710N01118478EA019780209600807000
 B1200044708710N01118478EA019780209600807000
 ''';
 
-        final testFile = File('/tmp/test_rapid.igc');
+        final testFile = File(TestHelpers.fixturePath('test_rapid.igc'));
         await testFile.writeAsString(testIgc);
         
         final parser = IgcParser();

--- a/the_paragliding_app/test/timezone_test.dart
+++ b/the_paragliding_app/test/timezone_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:the_paragliding_app/services/timezone_service.dart';
 import 'package:the_paragliding_app/services/igc_parser.dart';
 import 'dart:io';
+import 'helpers/test_helpers.dart';
 
 void main() {
   group('Timezone Detection Tests', () {
@@ -73,7 +74,7 @@ B0802004708710N01118478EA019780209600807000
 ''';
 
       // Write test file
-      final testFile = File('/tmp/test_utc.igc');
+      final testFile = File(TestHelpers.fixturePath('test_utc.igc'));
       await testFile.writeAsString(testIgc);
       
       final parser = IgcParser();
@@ -103,7 +104,7 @@ B0802004708720N01118476EA019780209600807000
 ''';
 
       // Write test file
-      final testFile = File('/tmp/test_gps.igc');
+      final testFile = File(TestHelpers.fixturePath('test_gps.igc'));
       await testFile.writeAsString(testIgc);
       
       final parser = IgcParser();
@@ -131,7 +132,7 @@ B0801000000000N00000000EA019780209600807000
 ''';
 
       // Write test file
-      final testFile = File('/tmp/test_ocean.igc');
+      final testFile = File(TestHelpers.fixturePath('test_ocean.igc'));
       await testFile.writeAsString(testIgc);
       
       final parser = IgcParser();


### PR DESCRIPTION
Fixes #280.

`flutter test --concurrency=1` failed **6 of 16 runs (37.5%)** on this machine before this change, and **0 of 16** after.

| | baseline | after |
|---|---|---|
| Failures | 6/16 | **0/16** |
| `TimeoutException` runs | 5 | **0** |
| Mean runtime | 81s | **60s** |
| Leaked temp dirs | 46 | **0** |

The max runtime actually rose (120s → 125s), so the green streak is not an artifact of a quieter machine — every baseline failure landed in the 91–120s band, and the fixed suite passed a 125s run.

## Two independent causes — neither was the suspected sqflite race

**1. 30-second stalls in database-backed test files** (5 of 6 failures). The stall happens inside a single test with no log output, then the 30s default timeout fires. Both affected files (`database_helper_test.dart`, `site_matching_cache_test.dart`) are the ones that open a database.

`database_helper_test.dart` recreated the database after every test: **9 schema builds and 9× 249 country-code seeds per run** (4.5s warm, 11.9s under load) for 8 tests that only read schema metadata via `PRAGMA` and `sqlite_master`. Tests now run against `inMemoryDatabasePath`, and that `tearDown` is gone.

**On the mechanism — read this before investigating further.** Removing the file-backed test database and 8 of 9 redundant schema rebuilds eliminates the failures reproducibly (6/16 → 0/16). But those two changes landed together, so this evidence does not isolate which one mattered, and the underlying block was never identified. What *is* ruled out, measured with `vmstat` during runs: the machine is not short of CPU (74–97% idle, ~2 of 8 cores busy), not short of memory (18GB free, no swap), and **not I/O bound (iowait 0)**. The likeliest remaining candidate is blocking inside sqflite's ffi worker isolate or its single-instance open lock, aggravated by the repeated close/delete/reopen churn — but that is a hypothesis, not a finding.

**2. A fixture read back empty** (1 failure, no timeout involved). `Parsed 0 track points, pilot: Unknown` → `Expected: not null, Actual: <null>`. 75 tests wrote IGC fixtures to fixed `/tmp` paths and parsed them straight back, and `/tmp/test_india.igc` was written by two different test files. Each test process now gets a private fixture directory via `TestHelpers.fixturePath()`.

This case **falsifies #280's stated invariant** that failures are "always `TimeoutException`, never a real assertion" — that claim is what steered the original investigation toward sqflite lifecycle.

## Also fixed: a real concurrency bug

```dart
Future<Database> get database async => _database ??= await _initDatabase();
```

`??=` with an `await` on the right memoises the *resolved value*, so the field stays null for the whole duration of the open and every caller arriving meanwhile starts another one. Visible in the failing logs as a second `Opening database` for the same path at +37s. It now memoises the future, matching `AppInitializationService.ensureTables()`. `recreateDatabase()` and `close()` clear the memo *before* awaiting, so a concurrent caller opens a fresh connection rather than receiving a closing handle.

Tests barely provoke this, but production runs genuinely concurrent startup work (`main.dart:155` `ensureTables()` alongside screens loading data), so it is worth fixing on its own merit.

## Ruled out — do not re-investigate

- **`Bad state: This database has already been closed`** — appeared in **zero** of the 16 baseline runs.
- **`[PGE_SITES_DB] Bounds query failed`** — appears identically in passing and failing runs. `site_matching_cache_test.dart` never creates `pge_sites`, so this is constant noise, not a failure signal.
- **CPU, memory or disk exhaustion** — measured, see above.
- **`AppInitializationService`'s memo surviving database deletion** — real, but `ensureTables()` never runs under `flutter test`. Filed separately as #282.

## Parallelism restored (#280's second tier)

Also measured `flutter test` with no `--concurrency=1`, 16 consecutive runs:

| mode | failures | mean | min | max |
|---|---|---|---|---|
| serial, before fix | **6/16** | 81s | 37s | 120s |
| serial, after fix | 0/16 | 60s | 29s | 125s |
| **parallel, after fix** | **0/16** | **46s** | 16s | 83s |

Zero `TimeoutException` across all 16 parallel runs. Parallel is now both green and the fastest mode, so `CLAUDE.md`'s blanket "always pass `--concurrency=1`" is gone.

**CI keeps `--concurrency=1` deliberately.** Parallel was verified only on an 8-core dev box; hosted runners have far fewer cores, and core count is exactly the variable that would bring contention back. Both `CLAUDE.md` and the `ci.yml` comment now say this, so the flag doesn't later read as an oversight and get dropped untested.

Also corrected in this PR: `CLAUDE.md` and `ci.yml` both claimed the suite fails "about a third of runs" because database-heavy files contend in parallel. Only 2 of 16 files ever opened a database, and the cost was concentrated in one file's nine redundant schema rebuilds. Replaced with the two isolation rules that actually keep it green (in-memory DB, `TestHelpers.fixturePath()`).

## Verification

```bash
for i in $(seq 1 16); do flutter test --concurrency=1 > /tmp/run_$i.log 2>&1 || echo "RUN $i FAILED"; done
for i in $(seq 1 16); do flutter test                 > /tmp/par_$i.log 2>&1 || echo "PAR $i FAILED"; done
```

`flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
