### PR TITLE
Report the key source from any key, not just FFVL

### DIFF
--- a/the_paragliding_app/.gitignore
+++ b/the_paragliding_app/.gitignore
@@ -55,7 +55,6 @@ app.*.map.json
 .env.local
 .env.production
 .env.*
-!.env.example
-# API keys for local dev, passed via --dart-define-from-file
+# API keys for local dev, passed via --dart-define-from-file.
+# env.example.json is committed and deliberately not matched by this pattern.
 env.json
-!env.example.json

--- a/the_paragliding_app/lib/services/api_keys.dart
+++ b/the_paragliding_app/lib/services/api_keys.dart
@@ -30,6 +30,9 @@ class ApiKeys {
   /// Cesium Ion Access Token (optional, for 3D map visualization)
   static const String cesiumIonToken = String.fromEnvironment('CESIUM_ION_TOKEN');
 
+  static bool get _anyKeyConfigured =>
+      ffvlApiKey.isNotEmpty || openAipApiKey.isNotEmpty || cesiumIonToken.isNotEmpty;
+
   /// Log which keys are configured, and warn about the one the app needs.
   ///
   /// Called once at startup. This is the quickest way to tell whether a build
@@ -40,7 +43,10 @@ class ApiKeys {
       'ffvl_configured': ffvlApiKey.isNotEmpty,
       'openaip_configured': openAipApiKey.isNotEmpty,
       'cesium_configured': cesiumIonToken.isNotEmpty,
-      'source': ffvlApiKey.isNotEmpty ? 'dart-define' : 'none',
+      // Any key being set proves the defines landed. Keying this off FFVL alone
+      // reported "none" for a build that had OpenAIP and Cesium but no FFVL
+      // secret - contradicting the openaip_configured: true on the same line.
+      'source': _anyKeyConfigured ? 'dart-define' : 'none',
     });
 
     if (ffvlApiKey.isEmpty) {


### PR DESCRIPTION
Follow-up to #284, from reviewing what that PR landed.

## The bug

```dart
'source': ffvlApiKey.isNotEmpty ? 'dart-define' : 'none',
```

`API_KEYS_STATUS` inferred `source` from **FFVL alone**. A build with OpenAIP and Cesium injected but no FFVL secret logged `source: none` immediately next to `openaip_configured: true` — contradicting itself on the same line.

This was live, not hypothetical: `FFVL_API_KEY` was missing from the repository secrets until today, so every CI build reported `source: none` while two of three keys landed correctly.

`README_API_KEYS.md` points at this line as *the* way to verify a build picked up its keys — which made it the one diagnostic that lied. Introduced in #284; mine.

## Verified

| defines passed | `source` before | `source` after |
|---|---|---|
| OpenAIP + Cesium, no FFVL | `none` ❌ | `dart-define` ✅ |
| none at all | `none` | `none` ✅ |

`flutter analyze` clean, 113 tests pass.

## Also

Two dead `.gitignore` rules removed:

- `!.env.example` — that file was deleted in #284, so the negation refers to nothing
- `!env.example.json` — a no-op; the `env.json` pattern never matched it, so there was nothing to negate

Replaced with a comment recording *why* `env.example.json` is safe to commit. Confirmed after the change that `env.json` is still ignored and `env.example.json` is still tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)