### PR TITLE
Sign Android releases in CI and publish to the Play internal track

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,16 +4,45 @@ on:
   push:
     tags:
       - 'v*' # Trigger on version tags
-  workflow_dispatch: # Allow manual trigger
+  workflow_dispatch: # Manual trigger - builds and verifies, does not publish
 
 env:
   # Must ship Dart >= 3.8.1 to satisfy the pubspec SDK constraint
   FLUTTER_VERSION: "3.41.6"
 
 jobs:
-  build-android:
-    name: Build Android APK
+  check-version:
+    name: Check tag matches pubspec
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Play rejects a reused versionCode, but only after the whole build has run
+      # and been uploaded. Catching a tag that disagrees with pubspec costs seconds.
+      - name: Compare tag with pubspec version
+        run: |
+          cd the_paragliding_app
+          pubspec=$(grep '^version:' pubspec.yaml | awk '{print $2}')   # e.g. 1.0.2+10
+          tag="${GITHUB_REF_NAME#v}"                                    # e.g. 1.0.2 or 1.0.2+10
+          echo "pubspec=$pubspec tag=$tag"
+          if [ "$tag" != "$pubspec" ] && [ "$tag" != "${pubspec%%+*}" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match pubspec version $pubspec - bump pubspec.yaml or retag"
+            exit 1
+          fi
+
+  release-android:
+    name: Build signed Android release
+    runs-on: ubuntu-latest
+    needs: [check-version]
+    # check-version is skipped on workflow_dispatch; without this the whole job
+    # would be skipped with it.
+    if: always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped')
+    # Gates on a required reviewer, and scopes the signing and Play secrets to this
+    # environment instead of the whole repository.
+    environment: play-internal
 
     steps:
       - name: Checkout repository
@@ -25,22 +54,88 @@ jobs:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
 
+      # Fail in seconds rather than after a ~15 minute build that cannot publish.
+      - name: Check Play credentials are present
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          PLAY_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -z "$PLAY_JSON" ]; then
+            echo "::error::PLAY_STORE_SERVICE_ACCOUNT_JSON is not set - see GOOGLE_PLAY_DEPLOYMENT.md"
+            exit 1
+          fi
+
+      # Without key.properties, build.gradle.kts falls back to the debug keystore
+      # and only println's a warning - producing artifacts Play rejects and GitHub
+      # releases that are debug-signed. Written to RUNNER_TEMP so the keystore is
+      # never inside the workspace, where it could be picked up as an asset.
+      - name: Restore upload keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          if [ -z "$ANDROID_KEYSTORE_BASE64" ]; then
+            echo "::error::ANDROID_KEYSTORE_BASE64 is not set - the build would silently use the debug key"
+            exit 1
+          fi
+          keystore="$RUNNER_TEMP/upload-keystore.jks"
+          printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 -d > "$keystore"
+          cat > the_paragliding_app/android/key.properties <<PROPS
+          storeFile=$keystore
+          storePassword=$ANDROID_KEYSTORE_PASSWORD
+          keyAlias=$ANDROID_KEY_ALIAS
+          keyPassword=$ANDROID_KEY_PASSWORD
+          PROPS
+
       - name: Get dependencies
         run: |
           cd the_paragliding_app
           flutter pub get
 
-      - name: Build APK with API keys
-        env:
-          FFVL_API_KEY: ${{ secrets.FFVL_API_KEY }}
-          OPENAIP_API_KEY: ${{ secrets.OPENAIP_API_KEY }}
-          CESIUM_ION_TOKEN: ${{ secrets.CESIUM_ION_TOKEN }}
+      - name: Build APK and App Bundle
         run: |
           cd the_paragliding_app
           flutter build apk --release \
             --dart-define=FFVL_API_KEY=${{ secrets.FFVL_API_KEY }} \
             --dart-define=OPENAIP_API_KEY=${{ secrets.OPENAIP_API_KEY }} \
             --dart-define=CESIUM_ION_TOKEN=${{ secrets.CESIUM_ION_TOKEN }}
+          flutter build appbundle --release \
+            --dart-define=FFVL_API_KEY=${{ secrets.FFVL_API_KEY }} \
+            --dart-define=OPENAIP_API_KEY=${{ secrets.OPENAIP_API_KEY }} \
+            --dart-define=CESIUM_ION_TOKEN=${{ secrets.CESIUM_ION_TOKEN }}
+
+      # These two assertions are the point of this job. A debug-signed bundle and a
+      # bundle with .env baked in both build cleanly and look completely normal:
+      # the first is rejected by Play, the second shipped API keys in plaintext to
+      # every user (#284). Neither was detectable from build output.
+      - name: Verify signing and bundle contents
+        env:
+          EXPECTED_SHA256: ${{ vars.UPLOAD_CERT_SHA256 }}
+        run: |
+          cd the_paragliding_app
+          aab=build/app/outputs/bundle/release/app-release.aab
+
+          if [ -z "$EXPECTED_SHA256" ]; then
+            echo "::error::vars.UPLOAD_CERT_SHA256 is not set - cannot prove this was signed with the upload key"
+            exit 1
+          fi
+
+          actual=$(keytool -printcert -jarfile "$aab" | awk '/SHA256:/{print $2; exit}')
+          echo "signing SHA256: $actual"
+          if [ "$actual" != "$EXPECTED_SHA256" ]; then
+            echo "::error::AAB is not signed with the upload key (expected $EXPECTED_SHA256)"
+            keytool -printcert -jarfile "$aab" | grep -E 'Owner:|SHA256:' || true
+            exit 1
+          fi
+
+          if unzip -l "$aab" | grep -q 'flutter_assets/\.env'; then
+            echo "::error::.env is bundled as an asset - API keys would ship in plaintext (regression of #284)"
+            exit 1
+          fi
+
+          echo "OK: signed with the upload key, no .env in the bundle"
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
@@ -48,42 +143,24 @@ jobs:
           name: app-release-apk
           path: the_paragliding_app/build/app/outputs/flutter-apk/app-release.apk
 
-  build-android-bundle:
-    name: Build Android App Bundle
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: stable
-
-      - name: Get dependencies
-        run: |
-          cd the_paragliding_app
-          flutter pub get
-
-      - name: Build App Bundle with API keys
-        env:
-          FFVL_API_KEY: ${{ secrets.FFVL_API_KEY }}
-          OPENAIP_API_KEY: ${{ secrets.OPENAIP_API_KEY }}
-          CESIUM_ION_TOKEN: ${{ secrets.CESIUM_ION_TOKEN }}
-        run: |
-          cd the_paragliding_app
-          flutter build appbundle --release \
-            --dart-define=FFVL_API_KEY=${{ secrets.FFVL_API_KEY }} \
-            --dart-define=OPENAIP_API_KEY=${{ secrets.OPENAIP_API_KEY }} \
-            --dart-define=CESIUM_ION_TOKEN=${{ secrets.CESIUM_ION_TOKEN }}
-
       - name: Upload App Bundle artifact
         uses: actions/upload-artifact@v4
         with:
           name: app-release-bundle
           path: the_paragliding_app/build/app/outputs/bundle/release/app-release.aab
+
+      # mappingFile matters because isMinifyEnabled = true - without it Play shows
+      # obfuscated stack traces for every crash.
+      - name: Publish to Play internal track
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
+          packageName: com.theparaglidingapp
+          releaseFiles: the_paragliding_app/build/app/outputs/bundle/release/app-release.aab
+          mappingFile: the_paragliding_app/build/app/outputs/mapping/release/mapping.txt
+          track: internal
+          status: completed
 
   build-ios:
     name: Build iOS (without signing)
@@ -105,10 +182,6 @@ jobs:
           flutter pub get
 
       - name: Build iOS (no signing)
-        env:
-          FFVL_API_KEY: ${{ secrets.FFVL_API_KEY }}
-          OPENAIP_API_KEY: ${{ secrets.OPENAIP_API_KEY }}
-          CESIUM_ION_TOKEN: ${{ secrets.CESIUM_ION_TOKEN }}
         run: |
           cd the_paragliding_app
           flutter build ios --release --no-codesign \
@@ -118,7 +191,7 @@ jobs:
 
   create-release:
     name: Create GitHub Release
-    needs: [build-android, build-android-bundle]
+    needs: [release-android]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
 
@@ -128,17 +201,12 @@ jobs:
         with:
           name: app-release-apk
 
-      - name: Download App Bundle artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: app-release-bundle
-
+      # Only the APK is attached now: an .aab is not installable by end users, and
+      # Play is the distribution path for it.
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          files: |
-            app-release.apk
-            app-release.aab
+          files: app-release.apk
           generate_release_notes: true
           draft: false
           prerelease: false

--- a/GOOGLE_PLAY_DEPLOYMENT.md
+++ b/GOOGLE_PLAY_DEPLOYMENT.md
@@ -1,185 +1,123 @@
-# Google Play Automated Deployment
+# Google Play Deployment
 
-This guide explains how to set up automated deployment to Google Play Store using GitHub Actions.
+Releases are built and published by `.github/workflows/build.yml`. Pushing a `v*` tag builds a
+signed APK and App Bundle, verifies them, and publishes the bundle to the Play **internal**
+track.
 
-## Prerequisites
+## Releasing
 
-1. **Google Play Developer Account** ($25 one-time fee)
-2. **Published app** (at least one manual upload)
-3. **App signing by Google Play** (recommended)
-
-## Setup Steps
-
-### Step 1: Create Service Account
-
-1. Go to [Google Play Console](https://play.google.com/console)
-2. Navigate to **Setup → API access**
-3. Click **Create new service account**
-4. Follow the link to Google Cloud Console
-5. In Google Cloud Console:
-   - Click **Create Service Account**
-   - Name: `github-actions-deploy`
-   - Role: Select **Service Account User**
-   - Click **Create Key** → **JSON**
-   - Download the JSON key file (keep it secure!)
-
-### Step 2: Grant Permissions in Play Console
-
-1. Back in Play Console → **API access**
-2. Find your new service account
-3. Click **Grant access**
-4. Select permissions:
-   - **Release management** (required)
-   - **Release to production** (if deploying to production)
-   - **View app information** (required)
-5. Select your app
-6. Click **Apply**
-
-### Step 3: Set up App Signing
-
-#### Option A: Let Google manage signing (Recommended)
-1. Go to **Setup → App signing**
-2. Follow Google's app signing enrollment
-3. Upload your existing keystore (if you have one)
-4. Google will handle signing for distribution
-
-#### Option B: Self-managed signing
-1. Keep your keystore file secure
-2. You'll need to add it to GitHub Secrets
-
-### Step 4: Add GitHub Secrets
-
-Go to your GitHub repository → Settings → Secrets and add:
-
-#### Required Secrets:
-- `PLAY_STORE_SERVICE_ACCOUNT_JSON` - The entire JSON content from Step 1
-- `ANDROID_KEYSTORE` - Base64 encoded keystore (if self-signing)
-- `ANDROID_KEYSTORE_PASSWORD` - Keystore password (if self-signing)
-- `ANDROID_KEY_ALIAS` - Key alias (if self-signing)
-- `ANDROID_KEY_PASSWORD` - Key password (if self-signing)
-
-#### To encode keystore as base64:
 ```bash
-base64 -i your-keystore.jks | tr -d '\n' > keystore-base64.txt
+# 1. bump the build number (versionCode) - Play rejects a reused one
+$EDITOR the_paragliding_app/pubspec.yaml     # version: 1.0.2+11
+git commit -am "chore: Bump build number to 1.0.2+11"
+
+# 2. tag and push
+git tag v1.0.2+11 && git push origin main --tags
 ```
 
-### Step 5: Update GitHub Workflow
+The tag must agree with `pubspec.yaml` — the `check-version` job fails fast otherwise, rather
+than letting Play reject the upload after a full build.
 
-See `.github/workflows/build.yml` for the complete workflow with Play Store deployment.
+Then **approve the deployment**: the `release-android` job targets the `play-internal`
+environment, which has a required reviewer, so it waits in the Actions tab until approved. That
+is the last point at which a mistaken tag can be stopped.
 
-## Deployment Tracks
+After approval, CI:
 
-Google Play offers several deployment tracks:
+1. Restores the upload keystore and writes `android/key.properties`
+2. Builds APK + AAB with the API keys injected via `--dart-define`
+3. **Verifies** the bundle (see below) — hard failure, not a warning
+4. Publishes the AAB to the internal track with `mapping.txt`
+5. Attaches the APK to a GitHub Release
 
-- **Internal testing** - Limited to internal testers (fastest)
-- **Closed testing (Alpha)** - Limited group of testers
-- **Closed testing (Beta)** - Larger group of testers
-- **Open testing** - Public beta
-- **Production** - Full release
+Internal testing has no review delay; testers see it within minutes.
 
-## Version Management
+`workflow_dispatch` runs the same build and verification but **does not publish** — use it to
+test pipeline changes.
 
-### Version Code
-- Must increment with each upload
-- Use GitHub run number: `${{ github.run_number }}`
-- Or timestamp: `$(date +%s)`
+## What CI verifies
 
-### Version Name
-- Human-readable version (e.g., "1.2.3")
-- Extract from tag or pubspec.yaml
+Two failure modes that produce a perfectly normal-looking build, both now hard errors:
 
-## Workflow Configuration
+| check | why |
+|---|---|
+| AAB signing cert == `vars.UPLOAD_CERT_SHA256` | Without `key.properties`, `build.gradle.kts` falls back to the **debug** key and only `println`s a warning. Play rejects the upload, and before this check GitHub Releases were being published debug-signed. |
+| no `flutter_assets/.env` in the bundle | `.env` was once declared as an asset, shipping API keys in plaintext to every user (#284). This stops that regressing. |
 
-The workflow uses `r0adkll/upload-google-play@v1` action for deployment.
+The expected fingerprint is a repository **variable**, not a secret — it is a public certificate
+fingerprint:
 
-### Basic Upload
-```yaml
-- uses: r0adkll/upload-google-play@v1
-  with:
-    serviceAccountJsonPlainText: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
-    packageName: com.theparaglidingapp
-    releaseFiles: app-release.aab
-    track: internal
+```
+UPLOAD_CERT_SHA256 = 1F:05:AD:55:3A:CB:78:8C:38:CB:13:7D:61:06:B6:D6:EC:3C:04:0D:90:89:AA:A8:00:14:70:6E:63:7A:7E:F2
 ```
 
-### With Release Notes
-```yaml
-- uses: r0adkll/upload-google-play@v1
-  with:
-    serviceAccountJsonPlainText: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
-    packageName: com.theparaglidingapp
-    releaseFiles: app-release.aab
-    track: production
-    status: completed
-    releaseNotes: |
-      New features:
-      - Feature 1
-      - Feature 2
-      Bug fixes:
-      - Fix 1
-```
+## Configuration
 
-## Testing the Setup
+### Environment `play-internal` (already created)
 
-1. **Test with internal track first**
-   ```yaml
-   track: internal
-   status: draft
+Required reviewer: repository owner. Signing and Play credentials are scoped to this
+environment rather than the whole repository, so no other workflow can read them.
+
+**Environment secrets** (set from the local keystore):
+
+| secret | source |
+|---|---|
+| `ANDROID_KEYSTORE_BASE64` | `base64 -w0 upload-keystore-new.jks` |
+| `ANDROID_KEYSTORE_PASSWORD` | `storePassword` in `android/key.properties` |
+| `ANDROID_KEY_ALIAS` | `upload` |
+| `ANDROID_KEY_PASSWORD` | `keyPassword` in `android/key.properties` |
+| `PLAY_STORE_SERVICE_ACCOUNT_JSON` | **still to be set** — see below |
+
+**Repository secrets** (shared with `ci.yml`): `FFVL_API_KEY`, `OPENAIP_API_KEY`,
+`CESIUM_ION_TOKEN`.
+
+### Remaining setup: the Play service account
+
+This cannot be scripted — it needs the Google Cloud and Play Console UIs.
+
+1. **Play Console → Setup → API access → Create new service account**, following the link into
+   Google Cloud Console
+2. In Google Cloud: create the service account, then **Create Key → JSON** and download it
+3. Back in Play Console → API access → **Grant access** to that service account, with at least
+   **Release management** and **View app information**, scoped to this app
+4. Add the JSON as an environment secret:
+   ```bash
+   gh secret set PLAY_STORE_SERVICE_ACCOUNT_JSON --env play-internal < service-account.json
+   rm service-account.json
    ```
 
-2. **Verify in Play Console**
-   - Check the internal testing track
-   - Ensure the AAB was uploaded correctly
+Permission changes in Play Console can take a few minutes to take effect.
 
-3. **Gradual rollout**
-   ```yaml
-   track: production
-   status: inProgress
-   userFraction: 0.1  # 10% rollout
-   ```
+## Why the keystore is safe to put in CI
+
+This app is enrolled in **Play App Signing**, so `upload-keystore-new.jks` is an *upload* key —
+Google holds the actual app signing key. A compromised upload key can be reset through Play
+Console. If the project were self-signing, putting the key in CI would risk permanently losing
+the ability to update the listing, and this pipeline would be a bad idea.
+
+Keep a backup of the keystore **and** `key.properties` regardless; the passwords are useless
+without the keystore and vice versa.
+
+## Version management
+
+`pubspec.yaml` is the single source of truth. `versionCode` comes from the `+N` suffix and must
+increase with every upload.
+
+Do **not** switch to `github.run_number` — earlier releases were built locally from pubspec, so a
+run-number scheme would desynchronise from what is already published.
 
 ## Troubleshooting
 
-### Error: "APK specifies a version code that has already been used"
-- Increment version code in pubspec.yaml
-- Or use dynamic version code with run number
+| Error | Cause | Fix |
+|---|---|---|
+| `Tag vX does not match pubspec version` | Tagged without bumping | Bump `pubspec.yaml`, retag |
+| `AAB is not signed with the upload key` | Keystore secret missing or wrong | Check the `play-internal` environment secrets |
+| `.env is bundled as an asset` | Someone re-added `.env` to `assets:` | Remove it; keys come from `--dart-define` (see README_API_KEYS.md) |
+| `Version code N has already been used` | `versionCode` not bumped | Bump the `+N` suffix |
+| `The caller does not have permission` | Service account lacks Play access | Re-check the grant in Play Console → API access |
+| `Invalid JWT` | Malformed service account JSON secret | Re-set it from the original file with `gh secret set ... <` |
 
-### Error: "The caller does not have permission"
-- Check service account permissions in Play Console
-- Ensure the app is selected in permissions
+## Promoting to production
 
-### Error: "Package name not found"
-- Verify package name matches Play Console
-- Ensure app is published (at least internal)
-
-### Error: "Invalid JWT"
-- Check service account JSON is correctly added to secrets
-- Ensure no extra spaces or line breaks
-
-## Security Best Practices
-
-1. **Never commit secrets to repository**
-2. **Use GitHub Secrets for all sensitive data**
-3. **Restrict workflow triggers** to protected branches
-4. **Enable branch protection** for main/production
-5. **Use environment-specific tracks** (dev→internal, main→production)
-
-## Example Release Process
-
-1. Create release branch: `release/v1.2.3`
-2. Update version in `pubspec.yaml`
-3. Create PR to main
-4. Merge PR (triggers workflow)
-5. Workflow:
-   - Builds signed AAB
-   - Uploads to internal track
-   - Creates GitHub release
-6. Test in internal track
-7. Promote to production in Play Console
-
-## Useful Resources
-
-- [Google Play Console Help](https://support.google.com/googleplay/android-developer)
-- [Fastlane Alternative](https://docs.fastlane.tools/getting-started/android/release-deployment/)
-- [GitHub Action: upload-google-play](https://github.com/r0adkll/upload-google-play)
-- [Flutter Build Documentation](https://docs.flutter.dev/deployment/android)
+Deliberately manual. Test on the internal track, then promote the release in Play Console →
+Production, ideally as a staged rollout. Nothing in CI touches the production track.


### PR DESCRIPTION
## The problem

`build.yml` had **no keystore handling at all** — no secret, no `key.properties` step. So `android/app/build.gradle.kts` hit its debug fallback on every run, which only `println`s a warning. Two consequences:

1. CI could not produce anything Play would accept — the blocker for any upload automation
2. **`create-release` has been publishing debug-signed artifacts** to GitHub Releases as `app-release.apk` / `app-release.aab`. Anyone installing from a GitHub release got a debug-signed build. That was wrong independently of Play.

## What tagging does now

`git tag v1.0.2+11 && git push --tags` →

1. **`check-version`** — fails in seconds if the tag disagrees with `pubspec.yaml`, instead of letting Play reject a reused `versionCode` after a full build
2. **Approval gate** — `release-android` targets the `play-internal` environment with a required reviewer, so it waits in the Actions tab
3. Restores the upload keystore, writes `key.properties`, builds signed APK + AAB
4. **Verifies** (below)
5. Publishes the AAB to the **internal** track with `mapping.txt`
6. Attaches the APK to a GitHub Release

`workflow_dispatch` runs everything *except* the publish — for testing pipeline changes.

## The verification steps are the substance

Both of these failure modes produce a build that looks completely normal, and both have already bitten this project:

| check | what it catches |
|---|---|
| AAB cert == `vars.UPLOAD_CERT_SHA256` | Missing `key.properties` → silent debug signing → Play rejection. Happened in a worktree earlier today; the warning is invisible in build output. |
| no `flutter_assets/.env` in the bundle | `.env` as an asset shipped API keys in plaintext to every user (#284). Stops that regressing. |

The fingerprint is a repo **variable**, not a secret — it's a public certificate fingerprint.

## Structure

Consolidated `build-android` + `build-android-bundle` into one `release-android` job, so the keystore is handled in exactly one place rather than passed between jobs. Dropped the `.aab` from the GitHub Release — it isn't installable, and Play distributes it now.

## Security

Signing and Play secrets are scoped to the `play-internal` **environment**, not the repository, so no other workflow can read them.

This is acceptable because the project is enrolled in **Play App Signing** — the local `.jks` is an *upload* key, which Google can reset if it leaks. If the project were self-signing, putting the key in CI would risk permanently losing the ability to update the listing, and I would not have proposed it.

## Verified before pushing

- All 8 `run:` blocks pass `bash -n` with GitHub expressions stubbed
- Version guard simulated: `v1.0.2+10` and `v1.0.2` accept; `v1.0.3` and `v1.0.2+9` reject
- The stored secrets were validated locally by replicating the CI restore step exactly: base64 round-trips byte-identical, and the extracted password opens the keystore with alias `upload` present
- `UPLOAD_CERT_SHA256` matches `upload-cert-new.pem` and today's verified bundle

## Still required before the first tagged release

`PLAY_STORE_SERVICE_ACCOUNT_JSON` — needs the Google Cloud + Play Console UIs, so it can't be scripted. Steps are in `GOOGLE_PLAY_DEPLOYMENT.md`. The build fails fast with a pointed message until it exists.

**Worth doing once it's set:** a negative test — point `ANDROID_KEYSTORE_BASE64` at a throwaway keystore and confirm the build *fails* at the fingerprint check. An assertion never seen failing isn't known to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)