### PR TITLE
Keep API_KEYS_STATUS visible in release builds

### DIFF
--- a/the_paragliding_app/lib/services/logging_service.dart
+++ b/the_paragliding_app/lib/services/logging_service.dart
@@ -269,8 +269,28 @@ class LoggingService {
     final pairs = data.entries
         .map((e) => '${e.key}=${_formatValue(e.value)}')
         .join(' | ');
+
+    // Release builds are gated at Level.warning, so an info-level structured log
+    // never reaches logcat - a release install emits nothing from our own code at
+    // all. A few categories are worth keeping in production, and warning is the
+    // only level that survives. These are diagnostics rather than problems; the
+    // level is a transport, not a severity claim.
+    if (kReleaseMode && _releaseVisibleCategories.contains(category)) {
+      _logger.w('[$category] $pairs');
+      return;
+    }
     _logger.i('[$category] $pairs');
   }
+
+  /// Structured categories kept in release builds. Keep this list short - every
+  /// entry is noise in production logs, and the value is in being able to answer
+  /// one specific question about a build you cannot attach a debugger to.
+  ///
+  /// API_KEYS_STATUS answers "did this build get its --dart-define secrets?",
+  /// which is otherwise unanswerable for a Play-delivered install: the keys are
+  /// compile-time constants and a build without them fails silently, with
+  /// airspace overlays and 3D simply empty.
+  static const Set<String> _releaseVisibleCategories = {'API_KEYS_STATUS'};
 
   /// Lazy evaluation version of structured logging - only builds data if logging enabled
   static void structuredLazy(String category, Map<String, dynamic> Function() dataBuilder) {
@@ -279,8 +299,11 @@ class LoggingService {
       return;
     }
 
-    // Only build the expensive data if we're actually going to log it
-    if (Logger.level.index <= Level.info.index) {
+    // Only build the expensive data if we're actually going to log it. Release
+    // visible categories are exempt: the level check would skip them in release,
+    // which is exactly where they are wanted.
+    if (Logger.level.index <= Level.info.index ||
+        _releaseVisibleCategories.contains(category)) {
       final data = dataBuilder();
       structured(category, data);
     }


### PR DESCRIPTION
Checking logcat on the Play-delivered `1.0.3+12` install today turned up **53 log lines from the app, none of them from our own code**. `[API_KEYS_STATUS]` was absent.

## Why

`logging_service.dart:24` gates release logging at `Level.warning`, and `structured()` emits via `_logger.i` — info. So it never reaches logcat.

Worth noting what this *isn't*: `API_KEYS_STATUS` was never in `nonCriticalCategories`, so nothing was deliberately suppressing it. It was simply below the release level — which is why it looked like a deliberate design decision and wasn't.

## Why it matters

That line is the only way to answer **"did this build get its `--dart-define` secrets?"** for an install you can't attach a debugger to.

The keys are compile-time constants, and a build without them fails *silently* — airspace overlays and 3D maps come back empty, no error, nothing logged. That's precisely the failure this line exists to make visible, and it was invisible in the only build where it mattered.

## The change

A small `_releaseVisibleCategories` set, emitted at `warning` because that's the only level that survives the release gate. The level is a transport, not a severity claim — the comment says so, so nobody later "fixes" a warning that isn't a problem.

`structuredLazy` gets the same exemption: its `Logger.level` check would skip a release-visible category in release, which is exactly where it's wanted. Nothing uses that path today, but a half-working mechanism is a trap for whoever adds the next category.

Kept the set to one entry deliberately — every addition is noise in production logs.

## Verification

- `flutter analyze` clean, 113 tests pass
- Debug output unchanged: `[API_KEYS_STATUS] ffvl_configured=true | openaip_configured=true | cesium_configured=true | source=dart-define`

**The release path cannot be unit tested** — `kReleaseMode` is a const `false` under `flutter test`, so no test can exercise the branch that matters. It's confirmed only by installing the next release and checking logcat. I'd rather say that than imply the tests cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)