### PR TITLE
Seed the dev database from the 8 most recent flights

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,9 +26,12 @@ bin/dev_reload.sh R           # Hot restart (SIGUSR2) - needed for main()/initSt
 Hot reload also works with the standard `r` / `R` keys if you started it in a
 terminal; `bin/dev_reload.sh` is for when the app was started in the background.
 
-- **Test data**: drop ~10 real `.igc` files into `dev_data/igc/` (gitignored - real coordinates).
+- **Test data**: drop real `.igc` files into `dev_data/igc/` (gitignored - real coordinates).
   They import on first launch only; `--reset` starts over. Seeding is driven by
   `--dart-define=SEED_IGC_DIR=...` and handled by `lib/utils/dev_seed.dart` (never runs in release).
+  Only the **8 most recent** flights are imported, by the `YYMMDD` filename prefix - a full
+  archive is hundreds of files and takes minutes. Drop the whole archive in and raise the cap
+  when a task needs more: `SEED_IGC_LIMIT=20 bin/dev_run.sh --reset` (`0` seeds everything).
 - **App state** (database + IGC copies) lives in `dev_data/app_documents/`, redirected
   there via `XDG_DOCUMENTS_DIR`. It persists across runs — the seeder only imports when
   the flights table is empty, so relaunching keeps your data. Use `--reset` to start clean.

--- a/bin/dev_run.sh
+++ b/bin/dev_run.sh
@@ -22,6 +22,9 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 APP_DIR="$REPO_ROOT/the_paragliding_app"
 DEV_DATA="$REPO_ROOT/dev_data"
 SEED_IGC_DIR="${SEED_IGC_DIR:-$DEV_DATA/igc}"
+# Only the most recent flights are seeded - a full archive takes minutes to
+# import. Override with SEED_IGC_LIMIT=20, or 0 to seed everything.
+SEED_IGC_LIMIT="${SEED_IGC_LIMIT:-8}"
 APP_DOCUMENTS="$DEV_DATA/app_documents"
 # On desktop the app stores its database alongside its documents (see main.dart)
 DB_FILE="$APP_DOCUMENTS/FlightLog.db"
@@ -78,8 +81,10 @@ igc_count=$(find "$SEED_IGC_DIR" -maxdepth 1 -iname '*.igc' | wc -l)
 if [[ "$igc_count" -eq 0 ]]; then
   echo "WARNING: no .igc files in $SEED_IGC_DIR - the app will start with an empty log." >&2
   echo "         Copy ~10 real flights there to seed the database." >&2
+elif [[ "$SEED_IGC_LIMIT" -le 0 || "$SEED_IGC_LIMIT" -ge "$igc_count" ]]; then
+  echo "Seeding from all $igc_count IGC file(s) in $SEED_IGC_DIR (skipped if flights already exist)"
 else
-  echo "Seeding from $igc_count IGC file(s) in $SEED_IGC_DIR (skipped if flights already exist)"
+  echo "Seeding the $SEED_IGC_LIMIT most recent of $igc_count IGC file(s) in $SEED_IGC_DIR (skipped if flights already exist)"
 fi
 
 # path_provider_linux resolves getApplicationDocumentsDirectory() via xdg-user-dir,
@@ -107,5 +112,6 @@ exec flutter run -d "$device" \
   --pid-file "$PID_FILE" \
   ${env_file_args[@]+"${env_file_args[@]}"} \
   --dart-define=SEED_IGC_DIR="$SEED_IGC_DIR" \
+  --dart-define=SEED_IGC_LIMIT="$SEED_IGC_LIMIT" \
   ${mode_args[@]+"${mode_args[@]}"} \
   ${passthrough[@]+"${passthrough[@]}"}

--- a/the_paragliding_app/lib/utils/dev_seed.dart
+++ b/the_paragliding_app/lib/utils/dev_seed.dart
@@ -9,8 +9,26 @@ import '../services/logging_service.dart';
 /// Enabled with `--dart-define=SEED_IGC_DIR=/path/to/igc` (see bin/dev_run.sh).
 /// Never runs in release builds, and skips when the log already has flights, so
 /// it is safe to leave enabled across restarts.
+///
+/// Only the most recent [_seedLimit] flights are imported - a real IGC archive
+/// runs to hundreds of files and importing all of them takes minutes, while a
+/// handful exercises every screen. Raise it with
+/// `--dart-define=SEED_IGC_LIMIT=20`, or set it to 0 to import the lot.
 class DevSeed {
   static const _seedDir = String.fromEnvironment('SEED_IGC_DIR');
+  static const _seedLimit = int.fromEnvironment('SEED_IGC_LIMIT', defaultValue: 8);
+
+  /// The newest [limit] of [paths], returned oldest-first so imports still run
+  /// in chronological order.
+  ///
+  /// IGC files are named `YYMMDD_<pilot>_NN.igc`, so sorting by name is sorting
+  /// by flight date and the newest flights are the tail of the sorted list.
+  @visibleForTesting
+  static List<String> mostRecentPaths(List<String> paths, int limit) {
+    final sorted = [...paths]..sort();
+    if (limit <= 0 || sorted.length <= limit) return sorted;
+    return sorted.sublist(sorted.length - limit);
+  }
 
   /// Whether seeding is switched on for this build - lets the caller show a
   /// status before the first import starts
@@ -35,37 +53,40 @@ class DevSeed {
       return;
     }
 
-    final files = await directory
+    final found = await directory
         .list()
         .where((entity) =>
             entity is File && entity.path.toLowerCase().endsWith('.igc'))
-        .cast<File>()
+        .map((entity) => entity.path)
         .toList();
-    files.sort((a, b) => a.path.compareTo(b.path));
 
-    if (files.isEmpty) {
+    if (found.isEmpty) {
       LoggingService.warning('DevSeed: no IGC files found in $_seedDir');
       return;
     }
+
+    final paths = mostRecentPaths(found, _seedLimit);
 
     final stopwatch = Stopwatch()..start();
     int imported = 0;
     int failed = 0;
 
-    for (final file in files) {
-      onProgress?.call(imported + failed, files.length);
+    for (final path in paths) {
+      onProgress?.call(imported + failed, paths.length);
       try {
-        await IgcImportService.instance.importIgcFile(file.path);
+        await IgcImportService.instance.importIgcFile(path);
         imported++;
       } catch (e) {
         failed++;
-        LoggingService.warning('DevSeed: failed to import ${file.path}', e);
+        LoggingService.warning('DevSeed: failed to import $path', e);
       }
     }
 
     LoggingService.structured('DEV_SEED', {
       'directory': _seedDir,
-      'found': files.length,
+      'found': found.length,
+      'limit': _seedLimit,
+      'seeded': paths.length,
       'imported': imported,
       'failed': failed,
       'duration_ms': stopwatch.elapsedMilliseconds,

--- a/the_paragliding_app/test/dev_seed_selection_test.dart
+++ b/the_paragliding_app/test/dev_seed_selection_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:the_paragliding_app/utils/dev_seed.dart';
+
+/// DevSeed imports only the most recent flights so a full IGC archive does not
+/// take minutes to seed. The selection is pure - no disk, no database.
+void main() {
+  group('DevSeed.mostRecentPaths', () {
+    test('keeps the newest files, still oldest-first', () {
+      final paths = [
+        '/igc/160124_Kevin McIsaac_01.igc',
+        '/igc/260712_KMc_01.igc',
+        '/igc/230501_KMc_01.igc',
+        '/igc/260711_KMc_01.igc',
+      ];
+
+      expect(DevSeed.mostRecentPaths(paths, 2), [
+        '/igc/260711_KMc_01.igc',
+        '/igc/260712_KMc_01.igc',
+      ]);
+    });
+
+    test('returns everything when there are fewer files than the limit', () {
+      final paths = ['/igc/230501_KMc_01.igc', '/igc/160124_KMc_01.igc'];
+
+      expect(DevSeed.mostRecentPaths(paths, 8), [
+        '/igc/160124_KMc_01.igc',
+        '/igc/230501_KMc_01.igc',
+      ]);
+    });
+
+    test('returns everything when the count equals the limit', () {
+      final paths = ['/igc/230501_KMc_01.igc', '/igc/160124_KMc_01.igc'];
+
+      expect(DevSeed.mostRecentPaths(paths, 2).length, 2);
+    });
+
+    test('a non-positive limit means no cap', () {
+      final paths = List.generate(20, (i) => '/igc/2607${i.toString().padLeft(2, '0')}_KMc_01.igc');
+
+      expect(DevSeed.mostRecentPaths(paths, 0).length, 20);
+    });
+
+    test('picks the July 2026 tail out of a decade of flights', () {
+      final paths = <String>[
+        for (var year = 16; year <= 25; year++) '/igc/${year}0501_Kevin McIsaac_01.igc',
+        '/igc/260705_KMc_01.igc',
+        '/igc/260709_KMc_01.igc',
+        '/igc/260709_KMc_02.igc',
+        '/igc/260712_KMc_01.igc',
+      ];
+
+      final selected = DevSeed.mostRecentPaths(paths, 8);
+
+      expect(selected.length, 8);
+      expect(selected.where((p) => p.contains('/2607')).length, 4);
+      expect(selected.last, '/igc/260712_KMc_01.igc');
+    });
+
+    test('does not mutate the caller\'s list', () {
+      final paths = ['/igc/260712_KMc_01.igc', '/igc/160124_KMc_01.igc'];
+
+      DevSeed.mostRecentPaths(paths, 1);
+
+      expect(paths.first, '/igc/260712_KMc_01.igc');
+    });
+  });
+}


### PR DESCRIPTION
## Why

`DevSeed` imported **every** `.igc` file in `dev_data/igc` — 183 on my box — one at a time through the full parse → takeoff/landing detection → site match → insert path. That is the slow part of the first launch after `bin/dev_run.sh --reset`, and a handful of recent flights exercises every screen just as well.

## What

- **`lib/utils/dev_seed.dart`** — seed only the newest N files (default 8). Files are named `YYMMDD_<pilot>_NN.igc`, so the existing sort-by-name is already chronological and "most recent" is just its tail. The selection is extracted into a pure `mostRecentPaths(paths, limit)` helper so it can be unit-tested without disk or a database. The `DEV_SEED` structured log now reports `found`/`limit`/`seeded` so it is visible that the cap fired.
- **`bin/dev_run.sh`** — `SEED_IGC_LIMIT` (default 8) plumbed through as a dart-define; `0` seeds everything. The startup message states the cap instead of claiming all 183 will import.
- **`test/dev_seed_selection_test.dart`** — new, 6 cases: over/under/at the limit, non-positive limit, a decade-spanning list, and no mutation of the caller's list.
- **`CLAUDE.md`** — documents the cap and the override.

Nothing under `test/` needed capping: no test reads `dev_data/igc` or goes through `IgcImportService`. Tests run against an in-memory database and fabricate their own rows.

## Verification

- `flutter test` — 134 passed, 16 network-skipped
- `flutter analyze` — no issues
- Live run against a throwaway documents dir (so my real dev DB was untouched):
  ```
  [DEV_SEED] found=183 | limit=8 | seeded=8 | imported=8 | failed=0 | duration_ms=9332
  ```
  and the resulting database holds exactly the 8 newest flights, 2026-07-05 through 2026-07-12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)