### PR TITLE
chore: Bump build number to 1.0.4+14

### DIFF
--- a/the_paragliding_app/pubspec.yaml
+++ b/the_paragliding_app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.4+13
+version: 1.0.4+14
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
Version code **13 is already consumed**. Run [30771801193](https://github.com/Kevin-McIsaac/the_paragliding_app/actions/runs/30771801193) published it to the internal track (`Successfully committed 10108613990050427978`) before my cancellation took effect — the cancel only stopped the later `create-release` job, so the run's overall conclusion reads `cancelled` while the Play upload had already succeeded. I reported it as "nothing published"; that was wrong.

Play now rejects any reuse of 13, which is why the re-tagged release failed with `Version code 13 has already been used`. Everything else in that run passed — signing, both assertions, artifacts.

That already-published build **predates the `whatsNewDirectory` wiring** (#292), so `13 (1.0.4)` is live with no release notes — on the release where every user's total hours drop ~11% (#289).

`versionName` stays **1.0.4**: same release, re-cut so CI attaches the notes users need to understand the change.

After merge: tag `v1.0.4+14`, approve, and confirm the notes appear alongside release `14 (1.0.4)` in Play Console. This is also the first real exercise of the notes path — it has never run successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)