### PR TITLE
chore: Move statusLine to user settings, allowlist read-only commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,13 +2,19 @@
   "permissions": {
     "allow": [
       "Bash(flutter_controller_enhanced:*)",
-      "Update"
+      "Update",
+      "Bash(flutter test)",
+      "Bash(flutter test *)",
+      "Bash(flutter analyze)",
+      "Bash(flutter analyze *)",
+      "Bash(adb devices*)",
+      "Bash(unzip -l *)",
+      "Bash(gh secret list *)",
+      "Bash(gh variable list *)",
+      "Bash(keytool -printcert *)",
+      "Bash(openssl x509 *)"
     ],
     "deny": [],
     "ask": []
-  },
-  "statusLine": {
-    "type": "command",
-    "command": ".claude/statusline.sh"
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,33 @@ genhtml coverage/lcov.info -o coverage/html/
 - Measure performance before optimizing
 - Default to emulator for testing
 
+### Verifying work: check the artifact, not the status
+
+Summaries in this project lie in both directions. Every one of these cost real time:
+
+| what it reported | what was true |
+|---|---|
+| CI run conclusion `cancelled` | its Play upload step had **succeeded** - the build was published |
+| `flutter_controller_enhanced status` → `CRASHED` / `ERROR` | app running fine; the *tooling* had disconnected, or the log merely contained an `[E]` line |
+| a passing test | passed identically against the **unfixed** code |
+| a green signing assertion | had never once been observed failing |
+
+So:
+
+- **A failing run can still have shipped.** Check the step, not the run: a cancel that
+  lands after approval stops later jobs while the publish already went through. This is how
+  version code 13 was burned.
+- **Prove a regression test fails without the fix.** Revert the fix, run it, watch it go red.
+  A test that passes either way is worse than none - it reads as coverage.
+- **Assert against the underlying state, not the service reporting it.** Query `sqlite_master`
+  rather than asking the service whether its tables exist.
+- **Drive production code paths.** Recomputing an expected value in the test proves the test
+  agrees with itself. `test/statistics_match_log_book_test.dart` calls the same
+  `getYearlyStatistics()` / `getAllFlights()` the two screens call - that is what would have
+  caught the duration bug.
+- **A guard that has only been seen passing is unverified.** Both release assertions in
+  `build.yml` were deliberately made to fail once, on a throwaway branch, to prove they work.
+
 ## ✅❌ Code Patterns & Anti-Patterns
 
 ### Logging (ALWAYS use LoggingService)


### PR DESCRIPTION
Two Claude Code config changes.

**statusLine removed from project settings.** It pointed at `.claude/statusline.sh` with a *relative* path, which only resolves when Claude is launched from the repo root — start it from anywhere else and the status line silently disappears. It now lives in `~/.claude/settings.json` with an absolute path, so it works in every directory including worktrees. Removing it here leaves one config and one script rather than two copies that can drift.

**Read-only command allowlist**, from the commands that actually recurred this session:

| pattern | count |
|---|---|
| `flutter test` / `flutter test *` | 151 |
| `flutter analyze` / `flutter analyze *` | 85 |
| `adb devices*` | 19 |
| `unzip -l *` | 18 |
| `gh secret list *` | 12 |
| `keytool -printcert *` | 11 |
| `openssl x509 *` | 11 |
| `gh variable list *` | 7 |

**Deliberately excluded despite high usage:** `python3` (93) and `sqlite3` (47) — arbitrary code execution, and `sqlite3` can `UPDATE`/`DELETE` the flight log. `adb shell` (23) runs arbitrary commands on the device. `flutter build` (29) and `flutter pub get` (15) mutate and fetch. `gh workflow run` triggers CI.

Nothing added to `deny` or `ask`; existing entries preserved.

Note `.claude/statusline.sh` is now unreferenced by this repo but still tracked — left in place rather than deleting a tracked file unprompted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)