### PR TITLE
Make LoggingService actually log in release and profile builds

### DIFF
--- a/the_paragliding_app/lib/services/logging_service.dart
+++ b/the_paragliding_app/lib/services/logging_service.dart
@@ -22,6 +22,19 @@ class LoggingService {
     // Profile builds are used for performance measurement, so they need the
     // same [P]/[D] output as debug - only release stays quiet
     level: kReleaseMode ? Level.warning : Level.debug,
+    // Without this the package default, DevelopmentFilter, applies - and it
+    // decides inside an assert():
+    //
+    //   var shouldLog = false;
+    //   assert(() { if (event.level >= level!) shouldLog = true; return true; }());
+    //   return shouldLog;
+    //
+    // Asserts are stripped in release, so it returns false for *every* event and
+    // the `level` above is never consulted. A release build emitted nothing at
+    // any severity - verified on 1.0.4+14, where logcat carried engine lines but
+    // not one line of ours. ProductionFilter is a plain `event.level >= level`,
+    // so the level gate does the filtering it looks like it does.
+    filter: ProductionFilter(),
     printer: ClaudeLogPrinter(), // Always use Claude-optimized format
   );
 


### PR DESCRIPTION
**#288 did not work.** It promoted `API_KEYS_STATUS` to warning level so it would survive release — and `1.0.4+14` on a real device emitted engine lines but **not one line of ours, at any severity**.

## Root cause — one line above the level gate

`Logger` was constructed with no `filter:`, so it got the package default, `DevelopmentFilter`:

```dart
bool shouldLog(LogEvent event) {
  var shouldLog = false;
  assert(() { if (event.level >= level!) shouldLog = true; return true; }());
  return shouldLog;              // asserts stripped → always false
}
```

Asserts are stripped outside debug, so it returns `false` for **every** event and the `level: kReleaseMode ? Level.warning : Level.debug` above it is never consulted. My #288 diagnosis — that the line was dropped for being *below* the release level — was wrong; nothing escapes at any level.

`ProductionFilter` is a plain `event.level >= level`, so the level gate now does the filtering it always looked like it was doing.

## This also fixes profile builds

The comment above that `Logger` says *"Profile builds are used for performance measurement, so they need the same `[P]`/`[D]` output as debug."* They didn't — asserts are stripped in profile too, so `bin/dev_run.sh --profile` has been silently emitting **nothing**. Performance measurement has been broken for as long as this code has existed.

## Verified, not reasoned about

Profile builds strip asserts exactly as release does, so this reproduces the phone's behaviour on the desktop:

| build | LoggingService lines |
|---|---|
| profile, `DevelopmentFilter` (current `main`) | **0** |
| profile, `ProductionFilter` (this PR) | **99** |

Same app, same mode, only the filter differs. Both runs confirmed fully started (VM Service up, DevTools available) — so the zero is silence, not a failed launch.

The first line of the fixed run is the one that was missing on the phone:

```
[I][+0.000s] [API_KEYS_STATUS] ffvl_configured=true | openaip_configured=true |
             cesium_configured=true | source=dart-define | at=api_keys.dart:42
```

That is also the first real evidence all three keys reach a shipped build. I had earlier argued that the *absence* of a missing-FFVL warning proved the key landed — unsound, since that warning couldn't fire either.

`flutter analyze` clean, **134 tests** pass.

## After merge

Needs `1.0.4+15` to verify on the phone. This time verification means seeing `[API_KEYS_STATUS]` in logcat, not reasoning about levels — which is how #288 shipped broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)