### PR TITLE
chore: Bump build number to 1.0.4+15

### DIFF
--- a/the_paragliding_app/pubspec.yaml
+++ b/the_paragliding_app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.4+14
+version: 1.0.4+15
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
Ships the `LoggingService` filter fix (#295), which makes release and profile builds actually log.

Version code 14 is consumed by the release already on the internal track.

`versionName` stays **1.0.4** and the release notes are unchanged — the logging fix is invisible to users, and #289's hours correction is still what this release means to them.

After merge: tag `v1.0.4+15`, and verify on device by finding `[API_KEYS_STATUS]` in logcat. That line has never appeared in a release build; its presence is the whole point of #295, and its absence is what proved #288 didn't work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)