### PR TITLE
Fix attribution link overflow by letting the text flex

### DIFF
--- a/the_paragliding_app/lib/presentation/widgets/common/app_attribution_link.dart
+++ b/the_paragliding_app/lib/presentation/widgets/common/app_attribution_link.dart
@@ -29,7 +29,6 @@ class AppAttributionLink extends StatelessWidget {
   final String text;
   final double iconSize;
   final EdgeInsets padding;
-  final bool useExpanded;
 
   const AppAttributionLink({
     super.key,
@@ -38,7 +37,6 @@ class AppAttributionLink extends StatelessWidget {
     required this.text,
     this.iconSize = 20,
     this.padding = EdgeInsets.zero,
-    this.useExpanded = false,
   });
 
   /// Standard attribution link with larger icon (20px) for primary links.
@@ -54,7 +52,6 @@ class AppAttributionLink extends StatelessWidget {
       text: text,
       iconSize: 20,
       padding: EdgeInsets.zero,
-      useExpanded: false,
     );
   }
 
@@ -71,7 +68,6 @@ class AppAttributionLink extends StatelessWidget {
       text: text,
       iconSize: 18,
       padding: const EdgeInsets.only(bottom: 8),
-      useExpanded: true,
     );
   }
 
@@ -98,24 +94,15 @@ class AppAttributionLink extends StatelessWidget {
               color: Theme.of(context).colorScheme.primary,
             ),
             const SizedBox(width: 8),
-            if (useExpanded)
-              Expanded(
-                child: Text(
-                  text,
-                  style: TextStyle(
-                    color: Theme.of(context).colorScheme.primary,
-                    decoration: TextDecoration.underline,
-                  ),
-                ),
-              )
-            else
-              Text(
+            Flexible(
+              child: Text(
                 text,
                 style: TextStyle(
                   color: Theme.of(context).colorScheme.primary,
                   decoration: TextDecoration.underline,
                 ),
               ),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
## What was wrong

`A RenderFlex overflowed by 12 pixels on the right`, thrown from the `Row` at `app_attribution_link.dart:93` while the About screen laid out. Caught on a Pixel 9 (1080x2424). The offender is the longest link on that screen — the contact email `kevin.mcisaac+the.paragliding.app@gmail.com`, which wants ~383px in a 371.4px row.

The cause was the `useExpanded` flag. `AppAttributionLink.standard()` set it `false`, so the `Text` went into the `Row` unconstrained with no way to give way; only `.compact()` opted into `Expanded`. The flag made the two factories diverge on layout behaviour that neither caller had asked about.

## The fix

Both branches collapse to a single `Flexible`. Short links still hug their text, long ones now wrap instead of being clipped, and the widget has one layout path rather than two. The field, its constructor parameter and both factory arguments are gone — a net deletion.

## Verified on a wireless Pixel 9

The About screen reports its own provenance, so this is unambiguously the fixed build rather than a stale install:

```
Build: 7ad5f4b
Branch: fix/attribution-link-overflow
```

On that build, rendering the same screen that overflowed this morning:

- `RenderFlex overflowed` count in the log: **0** (was 12px)
- `EXCEPTION CAUGHT` count: **0**
- No yellow/black striped overflow banner on the email row

That is a before/after pair on the same screen and the same device, not an absence-of-evidence claim.

`flutter analyze` clean.

## Known cosmetic follow-up (deliberately not addressed here)

The email now wraps mid-word, leaving a lone `m` on the second line:

```
kevin.mcisaac+the.paragliding.app@gmail.co
m
```

This is `Flexible` behaving correctly — the string contains no spaces, so Flutter breaks at the character level. It is a strict improvement on the previous behaviour (the text was clipped and partly unreadable; now all of it is visible and tappable), but it is not pretty.

Fixing it properly means changing what the screen *says* — e.g. displaying "Email the developer" over the `mailto:` URL — which is a product decision rather than a layout one, so it is left out of this PR. Ellipsizing was rejected: it would re-hide part of the address, which is the problem this fixes.

No regression test is included, by request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)