### PR TITLE
Stop a revoked Cesium Ion user token from blanking the 3D map

### DIFF
--- a/the_paragliding_app/lib/presentation/screens/cesium_settings_demo_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/cesium_settings_demo_screen.dart
@@ -39,7 +39,7 @@ class _CesiumSettingsDemoScreenState extends State<CesiumSettingsDemoScreen> {
             ),
             const SizedBox(height: 8),
             const Text(
-              'To unlock free access to premium Bing Maps you need to provide your own Cesium ION acess token.\n'
+              'To unlock free access to premium Google Maps imagery you need to provide your own Cesium ION access token.\n'
               'Registering with Cesium is free, quick and easy',
               style: TextStyle(fontSize: 16),
             ),

--- a/the_paragliding_app/lib/presentation/screens/data_management_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/data_management_screen.dart
@@ -526,12 +526,12 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
           ),
         );
         
-        if (isValid) {
-          await PreferencesHelper.setCesiumTokenValidated(true);
-          setState(() {
-            _isCesiumTokenValidated = true;
-          });
-        }
+        // Record the failure too. Only writing the success case left a revoked
+        // token reading "Active" and still being used for every map load.
+        await PreferencesHelper.setCesiumTokenValidated(isValid);
+        setState(() {
+          _isCesiumTokenValidated = isValid;
+        });
       }
     } catch (e, stackTrace) {
       LoggingService.structured('CESIUM_TOKEN_TEST_ERROR', {
@@ -1872,7 +1872,7 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
                       },
                       children: [
                       const Text(
-                        'To unlock free access to premium Bing Maps you need to provide your own Cesium ION access token. '
+                        'To unlock free access to premium Google Maps imagery you need to provide your own Cesium ION access token. '
                         'Registering with Cesium is free, quick and easy.',
                         style: TextStyle(fontSize: 14, color: Colors.grey),
                       ),
@@ -1901,7 +1901,7 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
                       Text(
                         _cesiumToken != null && _isCesiumTokenValidated
                           ? 'You now have access to the Premium maps.'
-                          : 'To access premium Bing maps for free follow these 4 steps:',
+                          : 'To access premium Google maps for free follow these 4 steps:',
                         style: TextStyle(
                           fontSize: 14,
                           fontWeight: FontWeight.w500,

--- a/the_paragliding_app/lib/presentation/widgets/cesium_3d_map_inappwebview.dart
+++ b/the_paragliding_app/lib/presentation/widgets/cesium_3d_map_inappwebview.dart
@@ -11,6 +11,22 @@ import '../../utils/preferences_helper.dart';
 import '../../config/cesium_config.dart';
 import '../screens/data_management_screen.dart';
 
+/// Whether a URL belongs to Cesium, and so whether a 401 from it can be blamed on
+/// the Ion token. Covers api.cesium.com and the assets.ion.cesium.com tile hosts.
+///
+/// The suffix check keeps the leading dot deliberately: a bare
+/// `endsWith('cesium.com')` would also accept `notcesium.com`, handing an
+/// unrelated host the power to discard the user's token.
+///
+/// Takes a plain [Uri] rather than a `WebUri` - `WebUri implements Uri`, so call
+/// sites pass `request.url` unchanged, and tests need no WebView plugin.
+@visibleForTesting
+bool isCesiumHost(Uri? url) {
+  final host = url?.host.toLowerCase();
+  if (host == null || host.isEmpty) return false;
+  return host == 'cesium.com' || host.endsWith('.cesium.com');
+}
+
 class Cesium3DMapInAppWebView extends StatefulWidget {
   /// flutter_inappwebview only ships Android and iOS implementations, so the
   /// 3D map cannot render on desktop (used for the Linux dev loop).
@@ -635,7 +651,7 @@ class _Cesium3DMapInAppWebViewState extends State<Cesium3DMapInAppWebView>
             // perfectly good token.
             if (response.statusCode == 401 &&
                 _hasValidUserToken &&
-                _isCesiumHost(request.url)) {
+                isCesiumHost(request.url)) {
               _handleRevokedUserToken();
             }
           },
@@ -1495,16 +1511,6 @@ class _Cesium3DMapInAppWebViewState extends State<Cesium3DMapInAppWebView>
         _errorMessage = 'No internet connection available.\nThe 3D map requires an active internet connection.';
       });
     }
-  }
-
-  /// Whether a URL belongs to Cesium, and so whether a 401 from it can be blamed
-  /// on the Ion token. Covers api.cesium.com and the assets.ion.cesium.com tile
-  /// hosts; the suffix check with a leading dot avoids matching a lookalike
-  /// domain that merely ends in the same letters.
-  static bool _isCesiumHost(WebUri? url) {
-    final host = url?.host.toLowerCase();
-    if (host == null) return false;
-    return host == 'cesium.com' || host.endsWith('.cesium.com');
   }
 
   /// Demote a user token that Ion has started rejecting, then reload on the app

--- a/the_paragliding_app/lib/presentation/widgets/cesium_3d_map_inappwebview.dart
+++ b/the_paragliding_app/lib/presentation/widgets/cesium_3d_map_inappwebview.dart
@@ -70,7 +70,7 @@ class _Cesium3DMapInAppWebViewState extends State<Cesium3DMapInAppWebView>
   
   // Saved preferences with defaults
   String _savedSceneMode = '3D';
-  String _savedBaseMap = 'Bing Maps Aerial';
+  String _savedBaseMap = 'OpenStreetMap';
   bool _savedTerrainEnabled = true;
   bool _savedNavigationHelpDialogOpen = false;
   bool _savedFlyThroughMode = false;
@@ -81,6 +81,8 @@ class _Cesium3DMapInAppWebViewState extends State<Cesium3DMapInAppWebView>
   // User token for premium maps
   String? _userToken;
   bool _hasValidUserToken = false;
+  // Set once per widget so the fallback chain's repeated 401s trigger one reload
+  bool _userTokenRevoked = false;
   
   @override
   void initState() {
@@ -128,7 +130,7 @@ class _Cesium3DMapInAppWebViewState extends State<Cesium3DMapInAppWebView>
   Future<void> _loadPreferences() async {
     try {
       final sceneMode = await PreferencesHelper.getCesiumSceneMode() ?? '3D';
-      final baseMap = await PreferencesHelper.getCesiumBaseMap() ?? 'Bing Maps Aerial';
+      final baseMap = await PreferencesHelper.getCesiumBaseMap() ?? 'OpenStreetMap';
       final terrainEnabled = await PreferencesHelper.getCesiumTerrainEnabled() ?? true;
       final navigationHelpDialogOpen = await PreferencesHelper.getCesiumNavigationHelpDialog() ?? false;
       final flyThroughMode = await PreferencesHelper.getCesiumFlyThroughMode() ?? false;
@@ -616,8 +618,15 @@ class _Cesium3DMapInAppWebViewState extends State<Cesium3DMapInAppWebView>
               return;
             }
             
-            LoggingService.error('Cesium3D InAppWebView', 
+            LoggingService.error('Cesium3D InAppWebView',
               'HTTP error: ${response.statusCode} - ${response.reasonPhrase}');
+
+            // Ion rejects every asset request once the user's token is revoked or
+            // expired. Nothing re-checks a token after its first validation, so
+            // without this the map stays blank on every future launch.
+            if (response.statusCode == 401 && _hasValidUserToken) {
+              _handleRevokedUserToken();
+            }
           },
           onJsAlert: (controller, jsAlertRequest) async {
             LoggingService.debug('Cesium3D JS Alert: ${jsAlertRequest.message}');
@@ -818,7 +827,10 @@ class _Cesium3DMapInAppWebViewState extends State<Cesium3DMapInAppWebView>
         .replaceAll('{{LON}}', lon.toString())
         .replaceAll('{{ALTITUDE}}', altitude.toString())
         .replaceAll('{{DEBUG}}', isDebugMode.toString())
-        .replaceAll('{{TOKEN}}', _userToken ?? CesiumConfig.ionAccessToken)
+        // Only a *validated* user token may shadow the app token. A stored token
+        // that failed validation used to be sent anyway, so every Ion asset 401'd
+        // and the map came up blank with no way back short of removing it by hand.
+        .replaceAll('{{TOKEN}}', (_hasValidUserToken ? _userToken : null) ?? CesiumConfig.ionAccessToken)
         .replaceAll('window.cesiumConfig = {lat:', '''window.cesiumConfig = {
             trackPoints: $trackPointsJs,
             savedSceneMode: "$_savedSceneMode",
@@ -1471,6 +1483,35 @@ class _Cesium3DMapInAppWebViewState extends State<Cesium3DMapInAppWebView>
         _showErrorMessage = true;
         _errorMessage = 'No internet connection available.\nThe 3D map requires an active internet connection.';
       });
+    }
+  }
+
+  /// Demote a user token that Ion has started rejecting, then reload on the app
+  /// token so the free providers come back instead of a blank globe.
+  ///
+  /// The token itself is kept - only the validated flag is cleared - so the user
+  /// can see it in Settings and re-test it once they have fixed it at Ion's end.
+  Future<void> _handleRevokedUserToken() async {
+    // A failed load produces one 401 per provider in the fallback chain; only the
+    // first should trigger a reload.
+    if (_userTokenRevoked || _isDisposed) return;
+    _userTokenRevoked = true;
+
+    LoggingService.structured('CESIUM_USER_TOKEN_REVOKED', {
+      'action': 'falling back to app token',
+    });
+
+    await PreferencesHelper.setCesiumTokenValidated(false);
+    if (!mounted || _isDisposed) return;
+    setState(() => _hasValidUserToken = false);
+
+    if (webViewController != null) {
+      await webViewController!.loadData(
+        data: _buildCesiumHtml(),
+        baseUrl: WebUri("https://localhost/"),
+        mimeType: "text/html",
+        encoding: "utf-8",
+      );
     }
   }
   

--- a/the_paragliding_app/lib/presentation/widgets/cesium_3d_map_inappwebview.dart
+++ b/the_paragliding_app/lib/presentation/widgets/cesium_3d_map_inappwebview.dart
@@ -157,6 +157,10 @@ class _Cesium3DMapInAppWebViewState extends State<Cesium3DMapInAppWebView>
           _savedChaseZoomFactor = chaseZoomFactor;
           _userToken = userToken;
           _hasValidUserToken = hasValidToken;
+          // Returning from Settings with a working token reuses this widget, so
+          // the one-shot guard has to clear or a later revocation would not
+          // self-heal for the rest of the widget's life.
+          if (hasValidToken) _userTokenRevoked = false;
         });
         
         LoggingService.debug('Cesium3D: Loaded preferences - Scene: $sceneMode, BaseMap: $baseMap, Terrain: $terrainEnabled, NavDialog: $navigationHelpDialogOpen, FlyThrough: $flyThroughMode, Trail: ${trailDuration}s, Quality: $quality, UserToken: ${userToken != null ? 'present' : 'none'}, TokenValid: $hasValidToken');
@@ -624,7 +628,14 @@ class _Cesium3DMapInAppWebViewState extends State<Cesium3DMapInAppWebView>
             // Ion rejects every asset request once the user's token is revoked or
             // expired. Nothing re-checks a token after its first validation, so
             // without this the map stays blank on every future launch.
-            if (response.statusCode == 401 && _hasValidUserToken) {
+            //
+            // Only Cesium's own hosts count. This callback fires for every
+            // subresource the WebView loads, and a 401 from anywhere else says
+            // nothing about the user's Ion token - demoting on one would discard a
+            // perfectly good token.
+            if (response.statusCode == 401 &&
+                _hasValidUserToken &&
+                _isCesiumHost(request.url)) {
               _handleRevokedUserToken();
             }
           },
@@ -1484,6 +1495,16 @@ class _Cesium3DMapInAppWebViewState extends State<Cesium3DMapInAppWebView>
         _errorMessage = 'No internet connection available.\nThe 3D map requires an active internet connection.';
       });
     }
+  }
+
+  /// Whether a URL belongs to Cesium, and so whether a 401 from it can be blamed
+  /// on the Ion token. Covers api.cesium.com and the assets.ion.cesium.com tile
+  /// hosts; the suffix check with a leading dot avoids matching a lookalike
+  /// domain that merely ends in the same letters.
+  static bool _isCesiumHost(WebUri? url) {
+    final host = url?.host.toLowerCase();
+    if (host == null) return false;
+    return host == 'cesium.com' || host.endsWith('.cesium.com');
   }
 
   /// Demote a user token that Ion has started rejecting, then reload on the app

--- a/the_paragliding_app/lib/presentation/widgets/cesium_token_manager.dart
+++ b/the_paragliding_app/lib/presentation/widgets/cesium_token_manager.dart
@@ -184,12 +184,11 @@ class _CesiumTokenManagerState extends State<CesiumTokenManager> {
           ),
         );
         
-        if (isValid) {
-          await PreferencesHelper.setCesiumTokenValidated(true);
-          setState(() {
-            _isTokenValidated = true;
-            });
-        }
+        // Record the failure too - see the note in DataManagementScreen.
+        await PreferencesHelper.setCesiumTokenValidated(isValid);
+        setState(() {
+          _isTokenValidated = isValid;
+        });
       }
     } catch (e) {
       if (mounted) {
@@ -373,7 +372,7 @@ class _CesiumTokenManagerState extends State<CesiumTokenManager> {
             Text(
               _currentToken != null && _isTokenValidated 
                 ? 'You now have access to the Premium maps.'
-                : 'To access premium Bing maps for free follow these 4 steps:',
+                : 'To access premium Google maps for free follow these 4 steps:',
               style: TextStyle(
                 fontSize: 14, 
                 fontWeight: FontWeight.w500,

--- a/the_paragliding_app/lib/utils/preferences_helper.dart
+++ b/the_paragliding_app/lib/utils/preferences_helper.dart
@@ -210,7 +210,15 @@ class PreferencesHelper {
   static Future<void> setCesiumTokenValidated(bool value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(cesiumTokenValidatedKey, value);
-    await prefs.setString(cesiumTokenValidationDateKey, DateTime.now().toIso8601String());
+    // The date means "last validated successfully". Failures now reach this method
+    // too, and stamping the current time onto one would leave a token that just
+    // failed looking freshly validated - which is what any future re-validation
+    // logic would key off.
+    if (value) {
+      await prefs.setString(cesiumTokenValidationDateKey, DateTime.now().toIso8601String());
+    } else {
+      await prefs.remove(cesiumTokenValidationDateKey);
+    }
   }
   
   static Future<DateTime?> getCesiumTokenValidationDate() async {

--- a/the_paragliding_app/test/cesium_token_recovery_test.dart
+++ b/the_paragliding_app/test/cesium_token_recovery_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:the_paragliding_app/presentation/widgets/cesium_3d_map_inappwebview.dart'
+    show isCesiumHost;
+import 'package:the_paragliding_app/utils/preferences_helper.dart';
+
+/// A user's own Ion token shadows the app's build-time token. When Ion starts
+/// rejecting it, the 3D map used to go blank permanently: the validated flag was
+/// only ever written `true`, so a dead token kept reading "Active" and kept being
+/// sent (#300).
+///
+/// Two pieces of that recovery are unit-testable without a WebView.
+void main() {
+  group('isCesiumHost', () {
+    test('accepts the hosts that serve Ion assets', () {
+      expect(isCesiumHost(Uri.parse('https://api.cesium.com/v1/assets/3954')), isTrue);
+      expect(isCesiumHost(Uri.parse('https://assets.ion.cesium.com/3954/tile.png')), isTrue);
+      expect(isCesiumHost(Uri.parse('https://cesium.com/downloads/Cesium.js')), isTrue);
+    });
+
+    test('is case-insensitive about the host', () {
+      expect(isCesiumHost(Uri.parse('https://API.Cesium.COM/v1/me')), isTrue);
+    });
+
+    test('rejects a lookalike domain that merely ends in the same letters', () {
+      // The reason the suffix check keeps its leading dot. A bare
+      // endsWith('cesium.com') would let this host discard the user's token.
+      expect(isCesiumHost(Uri.parse('https://notcesium.com/tile.png')), isFalse);
+      expect(isCesiumHost(Uri.parse('https://evilcesium.com/tile.png')), isFalse);
+    });
+
+    test('rejects unrelated hosts and URLs with no host', () {
+      expect(isCesiumHost(Uri.parse('https://tile.openstreetmap.org/1/2/3.png')), isFalse);
+      expect(isCesiumHost(Uri.parse('https://api.core.openaip.net/api/airspaces')), isFalse);
+      expect(isCesiumHost(Uri.parse('about:blank')), isFalse);
+      expect(isCesiumHost(null), isFalse);
+    });
+  });
+
+  group('setCesiumTokenValidated', () {
+    setUp(() => SharedPreferences.setMockInitialValues({}));
+
+    test('records a date when validation succeeds', () async {
+      await PreferencesHelper.setCesiumTokenValidated(true);
+
+      expect(await PreferencesHelper.getCesiumTokenValidated(), isTrue);
+      expect(await PreferencesHelper.getCesiumTokenValidationDate(), isNotNull);
+    });
+
+    test('clears the date when validation fails', () async {
+      // The date means "last validated successfully". Failures reach this method
+      // too, and stamping the current time onto one would leave a token that just
+      // failed looking freshly validated.
+      await PreferencesHelper.setCesiumTokenValidated(true);
+      expect(await PreferencesHelper.getCesiumTokenValidationDate(), isNotNull);
+
+      await PreferencesHelper.setCesiumTokenValidated(false);
+
+      expect(await PreferencesHelper.getCesiumTokenValidated(), isFalse);
+      expect(await PreferencesHelper.getCesiumTokenValidationDate(), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Problem

A user's own Ion token is stored in SharedPreferences to unlock the premium Google
imagery layers, and it takes precedence over the app's build-time token. Once Ion
revokes or expires that token, every asset request 401s — and because
`_createImageryProviders` **swaps the free providers out** when a user token is present
(`cesium.js:1139-1146`), no selectable layer works. The map comes up blank while the
flythrough keeps running on local track data.

Observed in the field on a Play install:

```
[API_KEYS_STATUS] cesium_configured=true | source=dart-define   <- build token was fine
[PROVIDER_ERROR] Google Maps 2D Satellite failed
HTTP error: 401
[PROVIDER_FALLBACK_ERROR] Sentinel-2 fallback failed
```

The build token was valid throughout (verified 200 against assets 3954 / 3830183 / 1).
The dead credential was the cached user token.

## Why nothing recovered

- `_buildCesiumHtml` sent `_userToken` whenever it was non-null, ignoring whether
  validation had ever succeeded.
- The token was validated once and trusted forever — *"no expiry check - once validated,
  remains valid indefinitely"*. The only writer of the validated flag set it to `true`, so
  a failed **Test Connection** left the token reading "Active" and still in use.
- The in-map banner linking to token settings renders only when `!_hasValidUserToken`, so
  it was hidden in exactly the state where it was needed.

Net effect: manually removing the token was the only way out.

## Changes

1. Only a **validated** token may shadow the app token.
2. A **401 during load demotes the token and reloads** on the app token, so the free
   providers come back by themselves. The token string is kept so the user can re-test it
   after fixing it at Ion's end. A `_userTokenRevoked` guard means the fallback chain's
   repeated 401s trigger one reload, not three.
3. **Test Connection records failure as well as success** (`setCesiumTokenValidated(isValid)`),
   in both the settings screen and `CesiumTokenManager`.

Also drops stale user-facing copy: the premium layers have been Google Maps (assets
3830183/3830184) since Bing imagery was retired from Ion. The default base map name
`'Bing Maps Aerial'` matched no provider and silently fell through to
`imageryProviders[0]` — it now names that provider directly.

## Testing

`flutter analyze` clean, 134 tests pass. Verified on a debug build on a Pixel 9 that a
valid user token still validates and loads the premium layers:

```
Cesium Token Validation: Token is valid for user ID 330274
[PROVIDER_SUCCESS] Google Maps 2D Satellite provider created successfully
```

**Verified on-device** (debug build, Pixel 9), staging the real failure by entering a
valid Ion token, deleting it at Ion, then reopening the map:

```
Dynamic lighting disabled for Google Maps 2D Satellite   <- premium layer, dead token
HTTP error: 401
[CESIUM_USER_TOKEN_REVOKED] action=falling back to app token
Using app token - free providers only to eliminate quota usage
Available providers: OpenStreetMap, Sentinel-2
```

Recovered in ~700ms. One 401, one demotion - the guard collapses the fallback chain's
repeated 401s into a single reload.

After a full process restart, with the demoted token still stored:

```
Loaded preferences - ... UserToken: present, TokenValid: false
Using app token - free providers only
```

No 401 at all on that launch - the unvalidated token was never sent, which exercises the
first fix directly and confirms the third persisted to disk.

Not exercised: the cesium.com host gating (unit-tested only - it needs a 401 from a
non-Cesium origin) and the guard reset on re-entering a working token.

**Tests** (`test/cesium_token_recovery_test.dart`) cover the two unit-testable pieces.
Both assertions were watched failing against the unfixed code before being committed:

```
rejects a lookalike domain   Expected: false   Actual: <true>
clears date on failure       Expected: null    Actual: DateTime<...>
```

`isCesiumHost` moved to a top-level `@visibleForTesting` function taking `Uri` rather than
`WebUri` - `WebUri implements Uri`, so the call site is unchanged and the test needs no
WebView plugin.

The 401 -> demote -> reload orchestration itself has no automated cover: it lives in an
`InAppWebView` callback and would need the widget pumped against a mocked WebView, which is
a lot of scaffolding for a codebase with no widget tests. Verified manually instead, above.

## Follow-up worth considering

`validateToken` hits the profile endpoint, not an asset, so "Active" does not mean "will
render maps". A scoped-down token passes validation and then fails at tile load. The 401
handler now rescues that, but validating against an asset endpoint would reject it up front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
