### PR TITLE
Note which Cesium Ion token to use when recovering keys

### DIFF
--- a/README_API_KEYS.md
+++ b/README_API_KEYS.md
@@ -121,6 +121,9 @@ re-requesting, and search Gmail for the confirmation message first (cheapest rec
 | `OPENAIP_API_KEY` | <https://www.openaip.net/> | Log in → user profile → API keys → regenerate or copy existing | 32-char lowercase hex |
 | `CESIUM_ION_TOKEN` | <https://ion.cesium.com/tokens> | Log in → Access Tokens → create a new token or copy the default | JWT, starts with `eyJ...` |
 
+For Cesium, log in with the GitHub account and use the **"The Paragliding App Default"**
+token — not the account's original default token, which has been rotated.
+
 ### Where keys live
 
 | Location | Purpose | Tracked in git? |


### PR DESCRIPTION
## Why

The Ion account is reached through the **GitHub login**, not an email/password pair, and the
account now holds more than one token. Neither fact is guessable from the recovery table,
and both cost time during the incident behind #300.

`"The Paragliding App Default"` is the live token. The account's original default was
rotated on 2026-08-04 after a stale copy of it — cached in a phone's SharedPreferences and
marked validated-forever — blanked the 3D map (#300).

## Change

One note under the Key Recovery table in `README_API_KEYS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)