### PR TITLE
Settle cesium_base_map on one vocabulary: Cesium provider names

### DIFF
--- a/the_paragliding_app/lib/presentation/screens/preferences_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/preferences_screen.dart
@@ -14,7 +14,6 @@ class PreferencesScreen extends StatefulWidget {
 class _PreferencesScreenState extends State<PreferencesScreen> {
   // 3D Visualization preferences
   String? _cesiumSceneMode;
-  String? _cesiumBaseMap;
   bool? _cesiumTerrainEnabled;
   int? _cesiumTrailDuration;
   double? _cesiumQuality;
@@ -53,7 +52,6 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
     try {
       // Load 3D Visualization preferences
       final sceneMode = await PreferencesHelper.getCesiumSceneMode();
-      final baseMap = await PreferencesHelper.getCesiumBaseMap();
       final terrainEnabled = await PreferencesHelper.getCesiumTerrainEnabled();
       final trailDuration = await PreferencesHelper.getCesiumTrailDuration();
       final quality = await PreferencesHelper.getCesiumQuality();
@@ -71,7 +69,6 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
       if (mounted) {
         setState(() {
           _cesiumSceneMode = sceneMode;
-          _cesiumBaseMap = baseMap ?? 'satellite';
           _cesiumTerrainEnabled = terrainEnabled;
           _cesiumTrailDuration = trailDuration;
           _cesiumQuality = quality;
@@ -105,11 +102,6 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
         UiUtils.showErrorMessage(context, 'Failed to load preferences: $e');
       }
     }
-  }
-
-  bool _isValidBaseMap(String? value) {
-    const validMaps = ['openstreetmap', 'satellite', 'hybrid'];
-    return value != null && validMaps.contains(value);
   }
 
   bool _isValidSceneMode(String? value) {
@@ -329,24 +321,10 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
                     }
                   },
                 ),
-                _buildDropdownRow<String>(
-                  'Base Map',
-                  'The background imagery to display',
-                  _isValidBaseMap(_cesiumBaseMap) ? _cesiumBaseMap : null,
-                  [
-                    const DropdownMenuItem(value: 'openstreetmap', child: Text('OpenStreetMap')),
-                    const DropdownMenuItem(value: 'satellite', child: Text('Satellite')),
-                    const DropdownMenuItem(value: 'hybrid', child: Text('Hybrid')),
-                  ],
-                  (value) {
-                    if (value != null) {
-                      setState(() {
-                        _cesiumBaseMap = value;
-                      });
-                      _savePreference('base map', value, PreferencesHelper.setCesiumBaseMap);
-                    }
-                  },
-                ),
+                // Base map is chosen in the 3D map's own layer picker, which is the
+                // single source of truth: the available imagery providers differ
+                // depending on whether the user has their own Cesium Ion token, so a
+                // fixed dropdown here cannot be right for both. Issue #302.
                 _buildDropdownRow<int>(
                   'Trail Duration',
                   'How long the flight trail remains visible',

--- a/the_paragliding_app/lib/presentation/widgets/cesium_3d_map_inappwebview.dart
+++ b/the_paragliding_app/lib/presentation/widgets/cesium_3d_map_inappwebview.dart
@@ -86,7 +86,9 @@ class _Cesium3DMapInAppWebViewState extends State<Cesium3DMapInAppWebView>
   
   // Saved preferences with defaults
   String _savedSceneMode = '3D';
-  String _savedBaseMap = 'OpenStreetMap';
+  // Null means "no saved choice" - cesium.js then picks the first provider of
+  // whichever list is live (free or premium), which is the only correct default.
+  String? _savedBaseMap;
   bool _savedTerrainEnabled = true;
   bool _savedNavigationHelpDialogOpen = false;
   bool _savedFlyThroughMode = false;
@@ -146,7 +148,7 @@ class _Cesium3DMapInAppWebViewState extends State<Cesium3DMapInAppWebView>
   Future<void> _loadPreferences() async {
     try {
       final sceneMode = await PreferencesHelper.getCesiumSceneMode() ?? '3D';
-      final baseMap = await PreferencesHelper.getCesiumBaseMap() ?? 'OpenStreetMap';
+      final baseMap = await PreferencesHelper.getCesiumBaseMap();
       final terrainEnabled = await PreferencesHelper.getCesiumTerrainEnabled() ?? true;
       final navigationHelpDialogOpen = await PreferencesHelper.getCesiumNavigationHelpDialog() ?? false;
       final flyThroughMode = await PreferencesHelper.getCesiumFlyThroughMode() ?? false;
@@ -861,7 +863,7 @@ class _Cesium3DMapInAppWebViewState extends State<Cesium3DMapInAppWebView>
         .replaceAll('window.cesiumConfig = {lat:', '''window.cesiumConfig = {
             trackPoints: $trackPointsJs,
             savedSceneMode: "$_savedSceneMode",
-            savedBaseMap: "$_savedBaseMap",
+            savedBaseMap: "${_savedBaseMap ?? ''}",
             savedTerrainEnabled: $_savedTerrainEnabled,
             savedNavigationHelpDialogOpen: $_savedNavigationHelpDialogOpen,
             savedFlyThroughMode: $_savedFlyThroughMode,

--- a/the_paragliding_app/lib/utils/preferences_helper.dart
+++ b/the_paragliding_app/lib/utils/preferences_helper.dart
@@ -1,5 +1,6 @@
 import 'package:shared_preferences/shared_preferences.dart';
 import '../data/models/weather_model.dart';
+import '../services/logging_service.dart';
 
 /// Helper class for managing app preferences using SharedPreferences
 /// Uses the stable legacy API for reliable persistence
@@ -84,17 +85,42 @@ class PreferencesHelper {
     await prefs.setString(cesiumSceneModeKey, value);
   }
   
+  /// Slugs written by the old Preferences dropdown and the old first-run default.
+  /// None was ever a Cesium provider name, so the map silently fell back to its
+  /// first provider. Dropped on read - see [getCesiumBaseMap]. Issue #302.
+  static const Set<String> _legacyCesiumBaseMaps = {
+    'openstreetmap',
+    'satellite',
+    'hybrid',
+  };
+
+  /// The Cesium imagery provider *display name* last chosen in the map's own layer
+  /// picker (e.g. 'OpenStreetMap', 'Sentinel-2', 'Google Maps 2D Satellite').
+  ///
+  /// Returns null when unset, meaning "let Cesium pick its first available
+  /// provider". Unlike its siblings this deliberately does **not** seed a default:
+  /// the provider list depends on whether the user has their own Ion token
+  /// (assets/cesium/cesium.js), so no single name is correct for both states.
   static Future<String?> getCesiumBaseMap() async {
     final prefs = await SharedPreferences.getInstance();
-    // Check if the preference has been set before
-    if (!prefs.containsKey(cesiumBaseMapKey)) {
-      // First time - set default to satellite
-      await prefs.setString(cesiumBaseMapKey, 'satellite');
-      return 'satellite';
+    final value = prefs.getString(cesiumBaseMapKey);
+
+    if (value != null && _legacyCesiumBaseMaps.contains(value)) {
+      await prefs.remove(cesiumBaseMapKey);
+      LoggingService.structured('PREFS_MIGRATION', {
+        'key': cesiumBaseMapKey,
+        'legacy_value': value,
+        'action': 'removed',
+        'issue': 302,
+      });
+      return null;
     }
-    return prefs.getString(cesiumBaseMapKey);
+
+    return value;
   }
-  
+
+  /// Stores a Cesium imagery provider display name. The map's layer picker is the
+  /// only writer - see `onImageryProviderChanged` in cesium_3d_map_inappwebview.dart.
   static Future<void> setCesiumBaseMap(String value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(cesiumBaseMapKey, value);

--- a/the_paragliding_app/test/preferences_helper_test.dart
+++ b/the_paragliding_app/test/preferences_helper_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:the_paragliding_app/utils/preferences_helper.dart';
+
+/// Covers the `cesium_base_map` vocabulary fix (#302).
+///
+/// The key is read by `assets/cesium/cesium.js`, which matches it against a
+/// Cesium imagery provider *display name* and silently falls back to the first
+/// available provider on no match. The old slugs (`satellite`, `openstreetmap`,
+/// `hybrid`) matched nothing, so they are dropped on read - which reproduces the
+/// fallback users have been getting all along, in both token modes.
+void main() {
+  group('PreferencesHelper.getCesiumBaseMap', () {
+    test('returns null and stores nothing when unset', () async {
+      SharedPreferences.setMockInitialValues({});
+
+      expect(await PreferencesHelper.getCesiumBaseMap(), isNull);
+
+      // No lazy-seeded default: an unset key must stay unset so Cesium picks its
+      // own first provider, which differs between the free and premium lists.
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.reload();
+      expect(prefs.containsKey(PreferencesHelper.cesiumBaseMapKey), isFalse);
+    });
+
+    test('drops a legacy slug and removes the key', () async {
+      for (final legacy in ['satellite', 'openstreetmap', 'hybrid']) {
+        SharedPreferences.setMockInitialValues({
+          PreferencesHelper.cesiumBaseMapKey: legacy,
+        });
+
+        expect(
+          await PreferencesHelper.getCesiumBaseMap(),
+          isNull,
+          reason: '$legacy matches no Cesium provider name',
+        );
+
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.reload();
+        expect(
+          prefs.containsKey(PreferencesHelper.cesiumBaseMapKey),
+          isFalse,
+          reason: '$legacy should be migrated away, not re-read every launch',
+        );
+      }
+    });
+
+    test('returns a real provider name untouched', () async {
+      SharedPreferences.setMockInitialValues({
+        PreferencesHelper.cesiumBaseMapKey: 'Sentinel-2',
+      });
+
+      expect(await PreferencesHelper.getCesiumBaseMap(), 'Sentinel-2');
+
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.reload();
+      expect(prefs.getString(PreferencesHelper.cesiumBaseMapKey), 'Sentinel-2');
+    });
+
+    test('round-trips a value written by the in-map picker', () async {
+      SharedPreferences.setMockInitialValues({});
+
+      await PreferencesHelper.setCesiumBaseMap('Google Maps 2D Satellite');
+
+      expect(
+        await PreferencesHelper.getCesiumBaseMap(),
+        'Google Maps 2D Satellite',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Fixes #302.

## The bug

`cesium_base_map` had three writers using two incompatible vocabularies. The reader, `assets/cesium/cesium.js:884-897`, matches the stored string against a Cesium `ProviderViewModel.name` — a *display name* — and silently falls back to `imageryProviders[0]` when nothing matches:

```js
selectedProvider = imageryProviders.find(vm => vm.name === config.savedBaseMap);
if (!selectedProvider) selectedProvider = imageryProviders[0];   // silent
```

Only the in-map layer picker ever wrote those names:

| Writer | Values | Matched? |
|---|---|---|
| First-run default, `preferences_helper.dart:92` | `satellite` | no |
| Preferences dropdown, `preferences_screen.dart:337-339` | `openstreetmap`, `satellite`, `hybrid` | no |
| In-map picker, `cesium_3d_map_inappwebview.dart:372` | `OpenStreetMap`, `Sentinel-2`, `Google Maps 2D Satellite`, `Google Maps 2D Roadmap` | **yes** |

So the "default to satellite" intent never once applied, the Preferences dropdown was inert, and it rendered blank after any in-map choice because `_isValidBaseMap` rejected real provider names.

## The approach

The map's own layer picker becomes the single source of truth; the Preferences row is **deleted rather than repaired**. `cesium.js:1136-1147` *replaces* the free provider list with the premium one when the user has their own Ion token — the two sets are disjoint — so any fixed list of names in Dart is wrong in one of the two states.

For the same reason this stores **no default name at all**. `cesium.js:888` already treats a falsy `savedBaseMap` as "use the first available provider", which is correct in both token modes, so `getCesiumBaseMap()` returns `null` when unset and deliberately skips the lazy-seed pattern its siblings use (commented, so it doesn't read as an oversight).

Legacy values are dropped on read with a `PREFS_MIGRATION` audit log. Removing is behaviour-preserving: those users have been getting `imageryProviders[0]` all along and `null` reproduces that. Mapping `satellite → Sentinel-2` would instead *change* what they see and start billing the shared Ion token, and `hybrid` has no equivalent to map to.

## Verification

Both new test cases were run against the **unfixed** code first and observed to fail:

```
00:00 +0 -1: returns null and stores nothing when unset [E]
  Expected: null
    Actual: 'satellite'
00:00 +0 -2: drops a legacy slug and removes the key [E]
  Expected: null
    Actual: 'satellite'
```

After the fix: `flutter analyze` clean, `flutter test` 144 passed.

Then on a Pixel 9 debug build that held the real legacy value from the issue:

| Check | Result |
|---|---|
| Migration on real data | fired on the actual stored `satellite` |
| One-shot | `PREFS_MIGRATION` count = 1 for the whole session |
| Default | `BaseMap: null` → resolved to first available provider |
| Round-trip | picked Roadmap, then Satellite; reopen read back `Google Maps 2D Satellite` |
| Preferences UI | Base Map row gone; Terrain / Scene Mode / Trail Duration / Quality still save |
| Exceptions | 0 |

That device has a validated Ion token, so its provider list is `Google Maps 2D Satellite, Google Maps 2D Roadmap` with **no OpenStreetMap** — which confirms that #300's `?? 'OpenStreetMap'` fallback would have matched nothing there, and is the concrete argument for storing no default name.

## Follow-ups (not in this PR)

Two stale-name bugs in `cesium.js`, separate from the preference mismatch:

- `_updateLightingForProvider` (`:1199-1207`) lists `'Stamen Terrain'`, a provider no longer constructed.
- The tile-failure fallback (`:1318`, `:1355`) searches for `'OpenStreetMap'` by name, which can never succeed in premium mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)