### PR TITLE
Stamp an exit marker into flutter.log when the session dies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,35 @@ The Paragliding App is a free, Android-first, cross-platform application for log
 
 Both are per-checkout, so worktrees do not fight over them.
 
+`flutter.log` ends with an explicit marker when the session dies:
+
+```
+--- flutter exited 2026-08-04 10:52:42 - log ends here; the app may still be running on the device ---
+```
+
+Without it, a log that stopped because `flutter run` died is indistinguishable from one with
+nothing to report — a dropped session was once read as "the app was never touched", and the
+wrong conclusion drawn from it. **On a device the app usually keeps running after flutter
+detaches**, so the marker means the log stopped, not the app. Switch to `bin/dev_logs.sh`
+from there: logcat is written by the app itself and survives a dropped `flutter run`.
+
+### Reading logs from a device
+
+`bin/dev_logs.sh` reads logcat over adb — the only option for a Play Store install, where
+there is no `flutter run` at all. There is no logcat on Linux desktop, so `flutter.log`
+remains the only log there, and it is also the only place build and compile errors appear.
+
+```bash
+bin/dev_logs.sh --keys       # just the [API_KEYS_STATUS] line
+bin/dev_logs.sh -g cesium    # search the whole buffer
+bin/dev_logs.sh -f           # follow live
+```
+
+The phone's logcat ring buffer holds only a couple of minutes — `adbd` retries a USB bind it
+can never complete when no cable is attached, and floods it. Follow live rather than expecting
+history to be there. The phone also dozes when idle, which kills `flutter run`; Developer
+options → **"Stay awake"** avoids it.
+
 ### Claude-Specific Patterns
 
 ```dart

--- a/bin/dev_run.sh
+++ b/bin/dev_run.sh
@@ -194,11 +194,28 @@ launcher=$!
 #
 # On a device the app usually keeps running after flutter detaches, so the marker says
 # where the log stops, not that the app stopped - use bin/dev_logs.sh from there.
+#
+# The guards below exist for races that are awkward to hit by hand. To re-verify after
+# changing this, extract the watcher body and drive it against fake pid/log files:
+#
+#   awk "/^setsid bash -c '\$/{f=1;next} f&&/^' _ /{f=0} f" bin/dev_run.sh >/tmp/w.sh
+#   sleep 60 & echo $! >/tmp/t.pid; echo one >/tmp/t.log
+#   bash /tmp/w.sh /tmp/t.pid /tmp/t.log 10 $! &
+#
+# then kill the sleep to see the marker land; or leave a stale pid file and truncate
+# the log first to confirm it stays quiet. Strip the guard lines to watch it fail.
 setsid bash -c '
-  pid_file=$1 log_file=$2 wait_ready=$3
+  pid_file=$1 log_file=$2 wait_ready=$3 launcher=$4
   deadline=$((SECONDS + wait_ready))
   while (( SECONDS < deadline )); do
     [[ -s "$pid_file" ]] && break
+    # Give up with the launcher, mirroring the readiness loop below. Without this a
+    # failed build left this watcher polling for the whole ready timeout; a fix-and-
+    # retry inside that window would arm it against the *new* session, running
+    # alongside the watcher that session spawned, and both would stamp the marker.
+    #
+    # No apostrophes in here - this whole block is inside a single-quoted bash -c.
+    kill -0 "$launcher" 2>/dev/null || exit 0
     sleep 1
   done
   # Never became ready - the launcher reports that case itself, so stay quiet.
@@ -221,7 +238,7 @@ setsid bash -c '
 
   printf -- "--- flutter exited %s - log ends here; the app may still be running on the device ---\n" \
     "$(date "+%Y-%m-%d %H:%M:%S")" >>"$log_file"
-' _ "$PID_FILE" "$LOG_FILE" "$ready_timeout" >/dev/null 2>&1 </dev/null &
+' _ "$PID_FILE" "$LOG_FILE" "$ready_timeout" "$launcher" >/dev/null 2>&1 </dev/null &
 
 echo "Starting on '$device' in the background; log: $LOG_FILE"
 deadline=$((SECONDS + ready_timeout))

--- a/bin/dev_run.sh
+++ b/bin/dev_run.sh
@@ -196,14 +196,29 @@ launcher=$!
 # where the log stops, not that the app stopped - use bin/dev_logs.sh from there.
 setsid bash -c '
   pid_file=$1 log_file=$2 wait_ready=$3
-  for ((i = 0; i < wait_ready; i++)); do
+  deadline=$((SECONDS + wait_ready))
+  while (( SECONDS < deadline )); do
     [[ -s "$pid_file" ]] && break
     sleep 1
   done
   # Never became ready - the launcher reports that case itself, so stay quiet.
   [[ -s "$pid_file" ]] || exit 0
   pid=$(cat "$pid_file")
+  # Size at arm time, to detect a later run truncating the log out from under us.
+  armed_size=$(stat -c %s "$log_file" 2>/dev/null || echo 0)
+
   while kill -0 "$pid" 2>/dev/null; do sleep 2; done
+
+  # A crash that skips flutter cleanup leaves a stale pid file, so a restart within
+  # the poll interval gets past the already-running guard, truncates this log and
+  # claims it. Stamping "exited" then would brand a live session dead - the same
+  # confusion this marker exists to prevent, only inverted. Two ways to spot it:
+  # the pid file now names a different process, or the log shrank.
+  now_pid=$(cat "$pid_file" 2>/dev/null || true)
+  [[ -n "$now_pid" && "$now_pid" != "$pid" ]] && exit 0
+  now_size=$(stat -c %s "$log_file" 2>/dev/null || echo 0)
+  (( now_size < armed_size )) && exit 0
+
   printf -- "--- flutter exited %s - log ends here; the app may still be running on the device ---\n" \
     "$(date "+%Y-%m-%d %H:%M:%S")" >>"$log_file"
 ' _ "$PID_FILE" "$LOG_FILE" "$ready_timeout" >/dev/null 2>&1 </dev/null &

--- a/bin/dev_run.sh
+++ b/bin/dev_run.sh
@@ -187,6 +187,27 @@ fi
 setsid flutter "${run_args[@]}" >"$LOG_FILE" 2>&1 </dev/null &
 launcher=$!
 
+# A log that stops silently looks exactly like a log with nothing to report - that is
+# how a dead session got read as "the app was never touched". Flutter removes the pid
+# file on exit, but that signal lives in a different file from the log being read, so
+# stamp the end into the log itself. Detached, so it outlives this script.
+#
+# On a device the app usually keeps running after flutter detaches, so the marker says
+# where the log stops, not that the app stopped - use bin/dev_logs.sh from there.
+setsid bash -c '
+  pid_file=$1 log_file=$2 wait_ready=$3
+  for ((i = 0; i < wait_ready; i++)); do
+    [[ -s "$pid_file" ]] && break
+    sleep 1
+  done
+  # Never became ready - the launcher reports that case itself, so stay quiet.
+  [[ -s "$pid_file" ]] || exit 0
+  pid=$(cat "$pid_file")
+  while kill -0 "$pid" 2>/dev/null; do sleep 2; done
+  printf -- "--- flutter exited %s - log ends here; the app may still be running on the device ---\n" \
+    "$(date "+%Y-%m-%d %H:%M:%S")" >>"$log_file"
+' _ "$PID_FILE" "$LOG_FILE" "$ready_timeout" >/dev/null 2>&1 </dev/null &
+
 echo "Starting on '$device' in the background; log: $LOG_FILE"
 deadline=$((SECONDS + ready_timeout))
 while :; do


### PR DESCRIPTION
## Why

A log that stops silently is indistinguishable from a log with nothing to report.

When `flutter run` dropped mid-test today, `flutter.log` just stopped. I read it, saw no new
lines, and concluded the app under test had never been touched — telling the user they had
opened the wrong one of the two installs. They hadn't. The session had died and the evidence
was in logcat instead.

The signal already existed: `flutter run --pid-file` removes `flutter.pid` on exit, and
CLAUDE.md documents its presence as *the* readiness check. But it lives in a **different file
from the artifact being read**, which is precisely the trap the repo's
"check the artifact, not the status" section warns about. So put it in the log.

## Change

`--background` detaches a watcher that appends, once the flutter pid goes away:

```
--- flutter exited 2026-08-04 10:52:42 - log ends here; the app may still be running on the device ---
```

It waits for the pid file to appear before arming (bounded by the same `ready_timeout`) and
stays quiet if the app never started — the launcher already reports that case itself, and a
marker there would be noise.

Only the `--background` path needs it. Foreground `flutter | tee` keeps the terminal attached,
so its exit is already visible.

**The marker means the log stopped, not the app.** On a device the app normally keeps running
after flutter detaches. CLAUDE.md now says so and points at `bin/dev_logs.sh`, which reads
logcat and survives a dropped session.

## Docs

CLAUDE.md also gains a short section on `bin/dev_logs.sh` (#301) and the two device gotchas
this session turned up:

- The logcat ring buffer holds only a couple of minutes, because `adbd` floods it retrying a
  USB bind it can never complete while no cable is attached (`Usb:0`). Follow live rather than
  expecting history.
- The phone dozes when idle, which is what kills `flutter run`. Developer options →
  "Stay awake" avoids it. A note claiming `wifi_sleep_policy` prevented this was wrong — that
  setting is legacy and inert on Android 17.

It also records why `flutter.log` is **not** redundant now that `dev_logs.sh` exists: there is
no logcat on Linux desktop, which is the default dev loop, and build and compile errors appear
only in `flutter.log` — logcat is silent when a build fails.

## Testing

Launched with `--background`, confirmed ready, killed the flutter pid, and watched the marker
land after `Lost connection to device`:

```
Lost connection to device.
--- flutter exited 2026-08-04 10:52:42 - log ends here; the app may still be running on the device ---
```

Shell only — no Dart touched, so the analyze/test job exercises nothing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)