### PR TITLE
Stop dev_logs.sh reading whichever device adb lists first

### DIFF
--- a/bin/dev_logs.sh
+++ b/bin/dev_logs.sh
@@ -10,10 +10,15 @@
 #   bin/dev_logs.sh -g cesium        # search the whole buffer, any tag (case-sensitive)
 #   bin/dev_logs.sh --raw            # unfiltered logcat (all tags)
 #   bin/dev_logs.sh -c               # clear the buffer, then exit
+#   bin/dev_logs.sh -s <id>          # pick a device when more than one is online
 #
-# Connection is handled here: an already-online device is used as-is, otherwise the
+# Connection is handled here: a single online device is used as-is, otherwise the
 # known phone IPs are tried on the fixed tcpip port. `adb tcpip 5555` resets on phone
 # reboot - if every candidate fails, re-run it over USB (see the run-app skill).
+#
+# With more than one device online the script refuses to guess and asks for -s (or
+# ANDROID_SERIAL). Reading the wrong phone's logs is the exact failure this script
+# exists to prevent - it would answer confidently about the install you did not mean.
 #
 # What a release install actually logs: LoggingService gates release builds at
 # Level.warning, so info/debug from our own code is absent by design. What survives is
@@ -26,8 +31,10 @@
 
 set -euo pipefail
 
-# Pixel 9 (tokay). .99 is the current lease, .135 was an earlier one.
-CANDIDATE_IPS=("192.168.86.99" "192.168.86.135")
+# Fallback IPs, tried only when no device is already online. Pixel 9 (tokay); .99 is
+# the current lease, .135 an earlier one. Not portable between developers - override
+# with DEV_LOGS_IPS="192.168.1.20 192.168.1.21", or just edit this line.
+read -r -a CANDIDATE_IPS <<<"${DEV_LOGS_IPS:-192.168.86.99 192.168.86.135}"
 ADB_PORT=5555
 
 lines=300
@@ -35,14 +42,17 @@ follow=false
 raw=false
 clear_first=false
 pattern=""
+requested=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -n|--lines)
       # ${2-} not $2: under `set -u` a bare `-n` would otherwise die with an
-      # unbound-variable trace instead of saying what was wrong.
+      # unbound-variable trace instead of saying what was wrong. Reject 0 along with
+      # non-numerics: `tail -n 0` prints nothing, which reads as an empty buffer.
       lines="${2-}"
-      [[ -n "$lines" ]] || { echo "$1 needs a line count (try --help)" >&2; exit 1; }
+      [[ "$lines" =~ ^[1-9][0-9]*$ ]] ||
+        { echo "$1 needs a positive line count, got '$lines' (try --help)" >&2; exit 1; }
       shift 2
       ;;
     -f|--follow)
@@ -69,8 +79,16 @@ while [[ $# -gt 0 ]]; do
       clear_first=true
       shift
       ;;
+    -s|--serial)
+      requested="${2-}"
+      [[ -n "$requested" ]] || { echo "$1 needs a device id (try --help)" >&2; exit 1; }
+      shift 2
+      ;;
     -h|--help)
-      sed -n '2,25p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      # Print the header comment block - from after the shebang to the first
+      # non-comment line - rather than a fixed line range, which silently truncated
+      # or picked up code whenever a header line was added.
+      awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
       exit 0
       ;;
     *)
@@ -81,22 +99,30 @@ while [[ $# -gt 0 ]]; do
 done
 
 # An online device is good enough however it got connected - the guid-based TLS
-# transport from `adb pair` reconnects by itself and needs no `adb connect`.
-online_device() {
-  adb devices | awk '$2 == "device" { print $1; exit }'
+# transport from `adb pair` reconnects by itself and needs no `adb connect`. Every
+# online id is listed, not just the first: picking the first silently read whichever
+# device adb happened to list first whenever a second phone or an emulator was up.
+online_devices() {
+  adb devices | awk '$2 == "device" { print $1 }'
 }
 
-device="$(online_device || true)"
-if [[ -z "$device" ]]; then
+# -s wins over ANDROID_SERIAL; adb's own env var is honoured so this behaves like adb.
+requested="${requested:-${ANDROID_SERIAL-}}"
+
+mapfile -t devices < <(online_devices || true)
+
+# Only reconnect when nothing at all is online - an explicit -s for a device that is
+# already up must not drag the candidate IPs in.
+if [[ ${#devices[@]} -eq 0 ]]; then
   for ip in "${CANDIDATE_IPS[@]}"; do
     echo "connecting to $ip:$ADB_PORT ..." >&2
     timeout 10 adb connect "$ip:$ADB_PORT" >/dev/null 2>&1 || true
-    device="$(online_device || true)"
-    [[ -n "$device" ]] && break
+    mapfile -t devices < <(online_devices || true)
+    [[ ${#devices[@]} -gt 0 ]] && break
   done
 fi
 
-if [[ -z "$device" ]]; then
+if [[ ${#devices[@]} -eq 0 ]]; then
   cat >&2 <<'EOF'
 No device. Either the phone is off the network, or `adb tcpip 5555` has not been run
 since its last reboot. Plug in over USB and:
@@ -107,6 +133,26 @@ then unplug and re-run this script. Wireless Debugging pairing (a random port, n
 re-pairing) is the fallback - see the run-app skill.
 EOF
   exit 1
+fi
+
+if [[ -n "$requested" ]]; then
+  device=""
+  for d in "${devices[@]}"; do
+    [[ "$d" == "$requested" ]] && device="$d" && break
+  done
+  if [[ -z "$device" ]]; then
+    echo "device '$requested' is not online. Online now:" >&2
+    printf '  %s\n' "${devices[@]}" >&2
+    exit 1
+  fi
+elif [[ ${#devices[@]} -gt 1 ]]; then
+  # Refusing beats guessing: these logs get read as evidence about one specific
+  # install, so the wrong device is worse than no output at all.
+  echo "more than one device online - pick one with -s <id> (or ANDROID_SERIAL):" >&2
+  printf '  %s\n' "${devices[@]}" >&2
+  exit 1
+else
+  device="${devices[0]}"
 fi
 
 echo "device: $device" >&2

--- a/bin/dev_run.sh
+++ b/bin/dev_run.sh
@@ -66,7 +66,10 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     -h|--help)
-      sed -n '2,22p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'
+      # Print the header comment block - from after the shebang to the first
+      # non-comment line - rather than a fixed line range, which silently truncated
+      # or picked up code whenever a header line was added.
+      awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
       exit 0
       ;;
     *)


### PR DESCRIPTION
Closes #307 — all four findings from the #301 review.

## 1. Device selection no longer guesses

`online_device()` took the *first* `adb devices` line in state `device`. With a second phone or an emulator attached, the script read whichever adb happened to list first, signalled only by `device: <id>` on stderr — easy to miss, gone entirely when stdout is piped.

It now lists every online device, and:

| online | `-s` / `ANDROID_SERIAL` | behaviour |
|---|---|---|
| 0 | — | candidate-IP connect loop, then the existing "No device" message (unchanged) |
| 1 | unset | use it (unchanged) |
| ≥2 | unset | **exit 1**, listing the ids |
| any | set | use it if online, else exit 1 listing what *is* online |

`-s` follows adb's own convention (and `adb -s "$DEV"` in the run-app skill); `dev_run.sh`'s `-d` is a *flutter* device id, a different id space, so the two deliberately differ. The connect loop still runs only when nothing is online, so an explicit `-s` for an already-up device doesn't drag the candidate IPs in.

## 2–4. The papercuts

- `-n` validated as a positive integer. `0` is rejected too: `tail -n 0` prints nothing, which reads as an empty buffer — the same confident-wrong-conclusion class as item 1.
- `--help` prints the header comment block up to the first non-comment line instead of a fixed range. Portable awk, no GNU-sed `Q`. Same fix in `dev_run.sh`, which had the same pattern.
- Candidate IPs take a `DEV_LOGS_IPS` override, following the `SEED_IGC_DIR` precedent in `dev_run.sh`.

## Verification

No shell test harness exists, so every guard was deliberately failed by hand. Two-device cases use a stubbed `adb` on `PATH` reporting `pixel9` + `emulator-5554` online plus an `offline` and an `unauthorized` device; single-device cases ran against the real Pixel 9.

**The old script, same two-device stub** — the bug, reproduced:

```
$ git show HEAD:bin/dev_logs.sh | bash -s -- -n 5
device: pixel9
LOGCAT-FROM:pixel9
exit=0          <-- emulator never mentioned

$ ... -n abc
tail: invalid number of lines: 'abc'
```

**New script, same stub:**

```
$ bin/dev_logs.sh -n 5
more than one device online - pick one with -s <id> (or ANDROID_SERIAL):
  pixel9
  emulator-5554
exit=1

$ bin/dev_logs.sh -s emulator-5554 -n 5      # the one NOT listed first
device: emulator-5554
LOGCAT-FROM:emulator-5554

$ ANDROID_SERIAL=emulator-5554 bin/dev_logs.sh -s pixel9 -n 5   # -s wins
device: pixel9

$ bin/dev_logs.sh -s brokenphone -n 5        # offline is not selectable
device 'brokenphone' is not online. Online now:
  pixel9
  emulator-5554
exit=1
```

**`-n` guards** — all exit 1 with the script's own message:

```
-n abc     -> exit=1 | -n needs a positive line count, got 'abc' (try --help)
-n 0       -> exit=1 | -n needs a positive line count, got '0' (try --help)
-n -5      -> exit=1 | -n needs a positive line count, got '-5' (try --help)
-n         -> exit=1 | -n needs a positive line count, got '' (try --help)
```

**`--help`** — `dev_run.sh --help` is byte-identical before/after (21 lines). `dev_logs.sh --help` differs by exactly the intended header additions — and the old `sed -n '2,25p'` would now have dropped 5 real header lines (26-30), including the WebView/chromium note. The header block spans lines 2-30, so `--help` prints 29 lines.

**IP override** — with nothing online, `DEV_LOGS_IPS="10.0.0.1 10.0.0.2"` tries those instead of the hardcoded pair; unset still tries `192.168.86.99` then `.135`; the "No device" message is unchanged.

**Single real device, unregressed** — bare, `-s <real id>`, `ANDROID_SERIAL=<real id>`, `--raw` (500 lines) and `-g` all behave as before. `-c` was not exercised: it clears the buffer.

No Dart changed, so `flutter analyze` / `flutter test` don't apply. `shellcheck` isn't installed here; `bash -n` passes on both scripts. Adding shellcheck to CI or a bats harness was considered and left out of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)