### PR TITLE
Stop background sessions moving branch state in the shared checkout

### DIFF
--- a/.claude/hooks/guard-shared-checkout.sh
+++ b/.claude/hooks/guard-shared-checkout.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# PreToolUse(Bash) guard: stop a BACKGROUND session from moving branch state in the
+# SHARED checkout while another session is working there.
+#
+# Why this exists, and why worktree.bgIsolation is not enough on its own:
+# bgIsolation blocks Edit/Write in the main checkout until a background job calls
+# EnterWorktree - but it does not gate Bash. On 2026-08-04 a background job that was
+# correctly isolated for its *edits* still ran git checkout/reset against the shared
+# checkout, switching the branch out from under another session mid-rebase. Nothing
+# was lost that time; nothing prevented it either.
+#
+# Scope, deliberately narrow:
+#   - interactive sessions are never gated - they own the checkout
+#   - a session already inside .claude/worktrees/ is never gated - that is the point
+#   - only commands that MOVE HEAD or rewrite refs are gated; read-only git
+#     (status/log/diff/show/fetch) passes untouched
+#
+# It asks rather than denies. A background job sometimes genuinely should pull or
+# check out in the shared checkout - when the user just told it to. Asking makes that
+# a decision instead of a silent collision.
+
+set -euo pipefail
+
+payload="$(cat)"
+cmd="$(jq -r '.tool_input.command // ""' <<<"$payload" 2>/dev/null || true)"
+[[ -n "$cmd" ]] || exit 0
+
+# Only background sessions are gated. CLAUDE_JOB_DIR is set for background jobs.
+[[ -n "${CLAUDE_JOB_DIR:-}" ]] || exit 0
+
+# Already isolated: nothing to protect.
+case "$PWD" in
+  */.claude/worktrees/*) exit 0 ;;
+esac
+
+# Ref-moving subcommands. Anchored to a `git` word so `git log --grep=reset` and
+# paths like ./scripts/reset.sh do not trip it.
+if ! grep -qE '(^|[;&|(]|&&|\|\|)[[:space:]]*git[[:space:]]+(-[^[:space:]]+[[:space:]]+)*(checkout|switch|reset|rebase|merge|pull|cherry-pick|stash|branch[[:space:]]+-[Dd])\b' <<<"$cmd"; then
+  exit 0
+fi
+
+reason="This is a background session working in the SHARED checkout ($PWD), not a worktree.
+Other Claude sessions and the user may be on this same checkout right now, and this
+command moves HEAD or rewrites refs - that is how a branch gets switched out from
+under someone else's rebase.
+
+If the user asked for this, approve it. Otherwise prefer EnterWorktree first."
+
+jq -n --arg r "$reason" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "ask",
+    permissionDecisionReason: $r
+  }
+}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,5 +20,23 @@
     ],
     "deny": [],
     "ask": []
+  },
+  "worktree": {
+    "bgIsolation": "worktree"
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "r=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; [ -n \"$r\" ] && [ -x \"$r/.claude/hooks/guard-shared-checkout.sh\" ] && exec bash \"$r/.claude/hooks/guard-shared-checkout.sh\"; exit 0",
+            "timeout": 10,
+            "statusMessage": "Checking shared-checkout safety"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -628,6 +628,21 @@ All API calls generate structured logs:
 Do feature and bugfix work in a git worktree, one per task, branched from `origin/main`.
 They live in `.claude/worktrees/` (gitignored) and are removed once the work merges.
 
+**Several Claude sessions often share this one checkout** - background jobs, plus whatever
+you have open interactively. Two guards keep them off each other:
+
+- `worktree.bgIsolation: "worktree"` (`.claude/settings.json`) blocks Edit/Write in the
+  shared checkout from a background session until it calls EnterWorktree.
+- `.claude/hooks/guard-shared-checkout.sh` covers what that misses. bgIsolation does not
+  gate **Bash**, and on 2026-08-04 a background job that was correctly isolated for its
+  edits still ran `git checkout`/`reset` against the shared checkout, switching the branch
+  out from under another session mid-rebase. The hook asks before a background session runs
+  a ref-moving git command outside a worktree. Interactive sessions are never gated, and
+  read-only git (`status`/`log`/`diff`/`fetch`) passes untouched.
+
+If you see that prompt, the honest question is whether the command belongs in a worktree
+instead. Approving is fine when you asked for it.
+
 A fresh worktree has none of the gitignored files. After creating one, from
 `the_paragliding_app/`:
 


### PR DESCRIPTION
Four Claude sessions currently share `/home/kmcisaac/Projects/the_paragliding_app` — background jobs plus interactive ones. None was in a worktree.

## What was actually broken

`worktree.bgIsolation` (already on by default) blocks **Edit/Write** in the shared checkout from a background session until it calls `EnterWorktree`. That part works — it refused an edit while this very change was being written.

It does **not** gate **Bash**. On 2026-08-04 a background job that was correctly isolated for its edits (`.claude/worktrees/fix+cesium-stale-provider-fallback`) still ran `git checkout` / `git reset` against the shared checkout, switching the branch out from under another session mid-rebase. Nothing was lost that time; nothing prevented it either.

So enabling `bgIsolation` alone would have been a no-op "fix" — it was already enabled and already bypassed.

## Change

- **`.claude/hooks/guard-shared-checkout.sh`** — PreToolUse(Bash) guard covering the gap.
- **`.claude/settings.json`** — wires the hook in; states `worktree.bgIsolation: "worktree"` explicitly rather than relying on the default.
- **`CLAUDE.md`** — documents both guards in the Worktrees section.

It **asks rather than denies**. A background job sometimes genuinely should pull or check out in the shared checkout — when the user just said so. Asking makes that a decision instead of a silent collision. (A hard deny would have blocked the `git pull` the user explicitly requested an hour ago.)

Deliberately narrow:
- interactive sessions are never gated — they own the checkout
- a session already under `.claude/worktrees/` is never gated
- only ref-moving subcommands are gated; read-only git passes untouched

## Verification

Hook payloads piped to the **exact command string from settings.json**, against a throwaway git repo with the guard installed:

| gated (`ask`) | passes |
|---|---|
| `git reset --hard origin/main` | `git status` |
| `git checkout main` | `git log --oneline -5` |
| `git switch -c foo` | `git diff` |
| `git pull --rebase` | `git fetch origin` |
| `git rebase main` | `git log --grep=reset` ← not a false positive |
| `cd /tmp && git checkout x` ← compound | `./scripts/reset.sh` ← not a false positive |
| `git stash`, `git branch -D old` | `flutter test`, `git commit -m x` |

Exemptions and robustness, all confirmed:

- no `CLAUDE_JOB_DIR` (interactive) → passes
- cwd under `.claude/worktrees/` → passes
- malformed JSON payload → exit 0, no crash
- non-git working directory → exit 0, no crash
- guard script absent (i.e. before this merges) → hook no-ops rather than erroring

`jq -e` confirms the hook resolves in settings.json; `bash -n` passes on the guard.

Note the hook is intentionally **not** given an `if: "Bash(git *)"` filter — that prefix match would miss compound commands like `cd /tmp && git checkout x`, which the regex does catch. Correctness over the small per-call cost.

## After merging

Settings changes are picked up per session. Existing sessions may need `/hooks` opened once, or a restart, before the guard is live for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)