### PR TITLE
Bump to 1.0.4+16 and rewrite the release notes

### DIFF
--- a/distribution/whatsnew/whatsnew-en-GB
+++ b/distribution/whatsnew/whatsnew-en-GB
@@ -3,4 +3,4 @@
   detected and the map falls back to the standard imagery
 • Data Management re-checks your saved token when you open it, so a token
   that has stopped working no longer shows as validated
-• Fixed the map attribution link overflowing its line
+• Fixed the contact email being cut off on the About screen

--- a/distribution/whatsnew/whatsnew-en-GB
+++ b/distribution/whatsnew/whatsnew-en-GB
@@ -1,4 +1,6 @@
-• Flight durations now measure takeoff to landing instead of the full
-  recording, so your total hours are lower and more accurate
-• Statistics and Log Book totals now agree
-• Fixes to site data after a database reset
+• The 3D map no longer goes blank when a Cesium Ion token stops working.
+  A revoked token, or one without access to the map imagery, is now
+  detected and the map falls back to the standard imagery
+• Data Management re-checks your saved token when you open it, so a token
+  that has stopped working no longer shows as validated
+• Fixed the map attribution link overflowing its line

--- a/the_paragliding_app/pubspec.yaml
+++ b/the_paragliding_app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.4+15
+version: 1.0.4+16
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
Prepares the next Play internal-track release. Two files: the version and the notes that ship with it.

## Why

**The version code is spent.** `1.0.4+15` was published to the internal track on 2026-08-03 (run 30791718033, all three jobs green including the Play upload). Play rejects a reused version code, but only after the whole build has run and been uploaded — the `check-version` job catches a tag/pubspec mismatch in seconds, but not a code that has already shipped. `v1.0.4+16` is free locally and on the remote.

**The notes were two releases stale.** `distribution/whatsnew/whatsnew-en-GB` still described the 1.0.4 takeoff-to-landing duration change, untouched since #292 — that shipped in +13. The upload step attaches this directory to the Play release, so leaving it would have told users about work they were already told about, and said nothing about what changed here.

## What users actually get

19 commits since `v1.0.4+15`, but 16 are dev tooling (`dev_run.sh`, `dev_logs.sh`, worktree guards) that change nothing a user can see. The visible part:

- A revoked or wrongly-scoped Cesium Ion token no longer leaves the 3D map blank. `_handleRevokedUserToken` demotes it to the app token and reloads so the free providers come back (#306/#310)
- Data Management re-checks a saved token when the section is expanded, so one that has stopped working stops reading "Active"
- The contact email is no longer clipped on the About screen (7ad5f4b)

Each bullet was checked against the code it claims to describe, not against its commit subject. That caught one error, fixed in 259f2b0: the third bullet originally said *map* attribution, but `AppAttributionLink` is used in `about_screen.dart` and nowhere else — it would have pointed users at a screen the fix never touched.

The notes are 395 characters, under Play's 500 limit, and keep the existing bullet voice.

## Checks

- `flutter analyze` — no issues
- `flutter test` — 160 passed, 0 failed (16 network-tagged skipped)
- `flutter pub get` — pubspec still parses after the bump
- CI on this PR — both checks pass

Run against `main` at 95dcdc3, which this branch is identical to apart from these two files.

## Not in scope

`the_paragliding_app/android/release-notes/en-US/default.txt` exists but is referenced by nothing — not `build.yml`, not any script. It looks like dead scaffold predating `distribution/whatsnew`, and it is a second place for release notes to rot. Worth deleting separately.

## After merge

Tagging `v1.0.4+16` is what triggers the build and the Play upload — left to you deliberately, not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)