### PR TITLE
Stop the empty Cesium token field from looking like it holds a key

### DIFF
--- a/the_paragliding_app/lib/presentation/screens/data_management_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/data_management_screen.dart
@@ -689,7 +689,9 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
                   controller: controller,
                   decoration: const InputDecoration(
                     labelText: 'Access Token',
-                    hintText: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+                    // No sample-token hint here: a JWT-shaped placeholder reads
+                    // as a key that is already filled in. The line above the
+                    // field says what to paste.
                     border: OutlineInputBorder(),
                   ),
                   maxLines: 3,


### PR DESCRIPTION
Data management → Free Premium Maps → Add Token showed a JWT-shaped placeholder (`eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...`) as the field's `hintText`. Tapping into the empty field looked like a key was already there.

Removed the hint. The dialog already says "Paste your Cesium Ion access token below:" directly above the field, and the label reads "Access Token", so the placeholder added nothing but confusion.

`flutter analyze` on the changed file: no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
