### PR TITLE
Close the gaps between what the release pipeline claims and what it does

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,10 @@ jobs:
             echo "::error::$notes is missing or empty - Play rejects the upload and the GitHub release would have no notes"
             exit 1
           fi
-          chars=$(wc -c < "$notes")
+          # wc -m, not -c. Play's limit is 500 characters; the bullets already in
+          # this file are U+2022, three bytes each, so a byte count reads high and
+          # would reject notes that are legitimately under the limit.
+          chars=$(LC_ALL=C.UTF-8 wc -m < "$notes")
           echo "release notes: $chars characters"
           if [ "$chars" -gt 500 ]; then
             echo "::error::$notes is $chars characters - Play's limit is 500"
@@ -134,6 +137,9 @@ jobs:
   # green one, and no ruleset required the checks to pass before merging either.
   # Repeating the suite here costs ~2 minutes against a ~15 minute build, and
   # makes the gate part of the release rather than adjacent to it.
+  #
+  # Deliberately a near-copy of analyze-and-test in ci.yml: the release must not
+  # depend on ci.yml having run. Change one and change the other.
   test:
     name: Analyze and test
     runs-on: ubuntu-latest
@@ -181,10 +187,12 @@ jobs:
     # without a human checkpoint. Add required reviewers under Settings ->
     # Environments -> play-internal if that is wanted.
     environment: play-internal
+    # Nothing beyond reading the code. Provenance is attested in its own job so
+    # that id-token/attestations write access is never held by the job carrying
+    # the upload keystore and the Play service account JSON - Actions permissions
+    # are job-scoped, not step-scoped, so separating them is the only way.
     permissions:
       contents: read
-      id-token: write # sign the provenance attestation
-      attestations: write # record it against the repository
 
     steps:
       - name: Checkout repository
@@ -341,21 +349,6 @@ jobs:
 
           echo "OK: AAB and APK are both signed with the upload key, neither contains .env"
 
-      # Lets anyone check that a downloaded APK really came from this workflow, at
-      # this commit, rather than from someone's laptop:
-      #   gh attestation verify app-release.apk --repo Kevin-McIsaac/the_paragliding_app
-      #
-      # Deliberately not gated to tags. Everything downstream of here that only
-      # runs on a tag is untestable by workflow_dispatch, and a signing step that
-      # has never executed is exactly the kind of guard this project has been
-      # bitten by. Attesting a dry-run build costs nothing and keeps it exercised.
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
-        with:
-          subject-path: |
-            the_paragliding_app/build/app/outputs/flutter-apk/app-release.apk
-            the_paragliding_app/build/app/outputs/bundle/release/app-release.aab
-
       - name: Upload APK artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -406,6 +399,40 @@ jobs:
           # `track` must go rather than stay as a belt-and-braces fallback.
           tracks: internal
           status: completed
+
+  # Lets anyone check that a downloaded APK really came from this workflow, at this
+  # commit, rather than from someone's laptop:
+  #   gh attestation verify app-release.apk --repo Kevin-McIsaac/the_paragliding_app
+  #
+  # Its own job purely to keep these two write grants away from the job holding the
+  # signing key and the Play credentials. It re-downloads the artifacts rather than
+  # building its own, so it attests the exact bytes that get published.
+  #
+  # Deliberately not gated to tags: everything that only runs on a tag is
+  # untestable by workflow_dispatch, and a step that has never executed is exactly
+  # the kind of guard this project has been bitten by. A dry run exercises it, and
+  # exercises the download-artifact pin at the same time.
+  attest:
+    name: Attest build provenance
+    needs: [release-android]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # mint the signing token
+      attestations: write # record the attestation against the repository
+
+    steps:
+      - name: Download built artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+
+      - name: Attest
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+        with:
+          subject-path: |
+            artifacts/app-release-apk/app-release.apk
+            artifacts/app-release-bundle/app-release.aab
 
   # No iOS job: the app ships Android-only, ios/ is not signed or configured for
   # distribution, and nothing consumed the unsigned artifact it produced. It was

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,11 @@ on:
 
 # Two tags pushed close together would otherwise build and upload at the same
 # time. The loser reaches Play second and fails with "version code has already
-# been used", which reads as a versioning mistake rather than a race. Queue them.
+# been used", which reads as a versioning mistake rather than a race. So every tag
+# run shares one queue. Dry runs get a group per branch instead, or testing a
+# pipeline change would park a real release behind a ~15 minute build.
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ startsWith(github.ref, 'refs/tags/') && 'release' || github.ref }}
   cancel-in-progress: false
 
 # The repository default for GITHUB_TOKEN is already read-only, but that is a
@@ -67,7 +69,15 @@ jobs:
         run: |
           cd the_paragliding_app
           version=$(grep '^version:' pubspec.yaml | awk '{print $2}')
-          code="${version##*+}"
+          # Parsed the same way as the tags below, so a malformed pubspec version
+          # says so rather than reaching `[ -le ]` as "integer expression expected".
+          case "$version" in
+            *+*) code="${version##*+}" ;;
+            *) echo "::error::pubspec version '$version' has no +versionCode suffix"; exit 1 ;;
+          esac
+          case "$code" in
+            ''|*[!0-9]*) echo "::error::pubspec versionCode '$code' is not a number"; exit 1 ;;
+          esac
           highest=0
           highest_tag="(none)"
           for t in $(git tag -l 'v*'); do

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,24 +1,50 @@
 name: Build and Release
 
+# Actions below are pinned to commit SHAs, with the release they came from in a
+# trailing comment. A tag like `v1` is a movable ref - whoever controls the action
+# repository can repoint it at new code, and it would run here on the next release
+# with no change to this file. That matters more than usual: release-android holds
+# the upload keystore and its passwords, and hands the Play service account JSON to
+# a third-party action. Bump a pin by editing the SHA and the comment together.
+
 on:
   push:
     tags:
       - 'v*' # Trigger on version tags
   workflow_dispatch: # Manual trigger - builds and verifies, does not publish
 
+# Two tags pushed close together would otherwise build and upload at the same
+# time. The loser reaches Play second and fails with "version code has already
+# been used", which reads as a versioning mistake rather than a race. Queue them.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+# The repository default for GITHUB_TOKEN is already read-only, but that is a
+# repository setting anyone can flip, silently widening every job here. Declaring
+# it means a job gaining write access has to be a visible edit to this file -
+# create-release and release-android each grant themselves only what they need.
+permissions:
+  contents: read
+
 env:
   # Must ship Dart >= 3.8.1 to satisfy the pubspec SDK constraint
   FLUTTER_VERSION: "3.41.6"
 
 jobs:
+  # Everything that can be decided in seconds, before a ~15 minute build.
   check-version:
-    name: Check tag matches pubspec
+    name: Validate tag
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Needs every v* tag for the versionCode check, and enough history to
+          # answer whether the tagged commit is on main.
+          fetch-depth: 0
 
       # Play rejects a reused versionCode, but only after the whole build has run
       # and been uploaded. Catching a tag that disagrees with pubspec costs seconds.
@@ -33,26 +59,133 @@ jobs:
             exit 1
           fi
 
-  release-android:
-    name: Build signed Android release
+      # "Version code N has already been used" is the most common way a release
+      # fails, and Play only says so after the AAB has been built and uploaded.
+      # Every code that has shipped is recorded as a v* tag, so the answer is
+      # already in the repository - ask it here instead.
+      - name: Check versionCode is higher than every released tag
+        run: |
+          cd the_paragliding_app
+          version=$(grep '^version:' pubspec.yaml | awk '{print $2}')
+          code="${version##*+}"
+          highest=0
+          highest_tag="(none)"
+          for t in $(git tag -l 'v*'); do
+            # The tag being released is already pushed by the time this runs.
+            if [ "$t" = "$GITHUB_REF_NAME" ]; then continue; fi
+            case "$t" in
+              *+*) c="${t##*+}" ;;
+              *) continue ;;
+            esac
+            case "$c" in
+              ''|*[!0-9]*) continue ;;
+            esac
+            if [ "$c" -gt "$highest" ]; then
+              highest="$c"
+              highest_tag="$t"
+            fi
+          done
+          echo "this versionCode=$code, highest already released=$highest ($highest_tag)"
+          if [ "$code" -le "$highest" ]; then
+            echo "::error::versionCode $code was already released as $highest_tag - Play will reject it. Bump pubspec.yaml."
+            exit 1
+          fi
+
+      # Both the Play upload and the GitHub release read this file, and neither
+      # job runs until after the build. A missing locale file fails the Play
+      # upload outright; checking it here costs nothing.
+      - name: Check release notes exist
+        run: |
+          notes=distribution/whatsnew/whatsnew-en-GB
+          if [ ! -s "$notes" ]; then
+            echo "::error::$notes is missing or empty - Play rejects the upload and the GitHub release would have no notes"
+            exit 1
+          fi
+          chars=$(wc -c < "$notes")
+          echo "release notes: $chars characters"
+          if [ "$chars" -gt 500 ]; then
+            echo "::error::$notes is $chars characters - Play's limit is 500"
+            exit 1
+          fi
+
+      # A tag can point at any commit: an unmerged branch, a commit whose CI went
+      # red, or an arbitrary SHA. No repository ruleset prevents that, so assert
+      # it where it matters.
+      - name: Check the tagged commit is on main
+        run: |
+          git fetch --no-tags --quiet origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" FETCH_HEAD; then
+            echo "::error::Tag $GITHUB_REF_NAME points at $GITHUB_SHA, which is not an ancestor of main - releases must be cut from merged code"
+            exit 1
+          fi
+
+  # ci.yml covers pushes to main and pull requests, but nothing connected it to
+  # the release path: a tag on a red commit built and published exactly like a
+  # green one, and no ruleset required the checks to pass before merging either.
+  # Repeating the suite here costs ~2 minutes against a ~15 minute build, and
+  # makes the gate part of the release rather than adjacent to it.
+  test:
+    name: Analyze and test
     runs-on: ubuntu-latest
-    needs: [check-version]
-    # check-version is skipped on workflow_dispatch; without this the whole job
-    # would be skipped with it.
-    if: always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped')
-    # Gates on a required reviewer, and scopes the signing and Play secrets to this
-    # environment instead of the whole repository.
-    environment: play-internal
+
+    defaults:
+      run:
+        working-directory: the_paragliding_app
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
+          cache: true
+
+      - name: Get dependencies
+        run: flutter pub get
+
+      - name: Analyze
+        run: flutter analyze
+
+      # --concurrency=1 mirrors ci.yml; see the comment there for why.
+      - name: Test
+        run: flutter test --concurrency=1
+
+      - name: Test date ranges in a DST timezone
+        env:
+          TZ: America/New_York
+        run: flutter test --concurrency=1 test/date_range_test.dart
+
+  release-android:
+    name: Build signed Android release
+    runs-on: ubuntu-latest
+    needs: [check-version, test]
+    # check-version is skipped on workflow_dispatch; without always() the whole
+    # job would be skipped with it. test runs either way, so it must have passed.
+    if: always() && needs.test.result == 'success' && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped')
+    # Scopes the signing and Play secrets to this environment instead of the whole
+    # repository, so no other workflow can read them. Note that it gates nothing on
+    # its own: the environment has no protection rules, so a pushed tag publishes
+    # without a human checkpoint. Add required reviewers under Settings ->
+    # Environments -> play-internal if that is wanted.
+    environment: play-internal
+    permissions:
+      contents: read
+      id-token: write # sign the provenance attestation
+      attestations: write # record it against the repository
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
 
       # Fail in seconds rather than after a ~15 minute build that cannot publish.
       - name: Check Play credentials are present
@@ -101,57 +234,126 @@ jobs:
           cd the_paragliding_app
           flutter pub get
 
+      # The keys go through env rather than straight into the run: block. A
+      # ${{ secrets.X }} expression is pasted into the script as literal text
+      # before bash sees it, so a key containing a quote or a backtick changes
+      # what gets executed; "$VAR" is just a value.
       - name: Build APK and App Bundle
+        env:
+          FFVL_API_KEY: ${{ secrets.FFVL_API_KEY }}
+          OPENAIP_API_KEY: ${{ secrets.OPENAIP_API_KEY }}
+          CESIUM_ION_TOKEN: ${{ secrets.CESIUM_ION_TOKEN }}
         run: |
           cd the_paragliding_app
           flutter build apk --release \
-            --dart-define=FFVL_API_KEY=${{ secrets.FFVL_API_KEY }} \
-            --dart-define=OPENAIP_API_KEY=${{ secrets.OPENAIP_API_KEY }} \
-            --dart-define=CESIUM_ION_TOKEN=${{ secrets.CESIUM_ION_TOKEN }}
+            --dart-define=FFVL_API_KEY="$FFVL_API_KEY" \
+            --dart-define=OPENAIP_API_KEY="$OPENAIP_API_KEY" \
+            --dart-define=CESIUM_ION_TOKEN="$CESIUM_ION_TOKEN"
           flutter build appbundle --release \
-            --dart-define=FFVL_API_KEY=${{ secrets.FFVL_API_KEY }} \
-            --dart-define=OPENAIP_API_KEY=${{ secrets.OPENAIP_API_KEY }} \
-            --dart-define=CESIUM_ION_TOKEN=${{ secrets.CESIUM_ION_TOKEN }}
+            --dart-define=FFVL_API_KEY="$FFVL_API_KEY" \
+            --dart-define=OPENAIP_API_KEY="$OPENAIP_API_KEY" \
+            --dart-define=CESIUM_ION_TOKEN="$CESIUM_ION_TOKEN"
 
-      # These two assertions are the point of this job. A debug-signed bundle and a
-      # bundle with .env baked in both build cleanly and look completely normal:
-      # the first is rejected by Play, the second shipped API keys in plaintext to
-      # every user (#284). Neither was detectable from build output.
+      # These assertions are the point of this job. A debug-signed artifact and one
+      # with .env baked in both build cleanly and look completely normal: the first
+      # is rejected by Play, the second shipped API keys in plaintext to every user
+      # (#284). Neither was detectable from build output.
+      #
+      # Both artifacts are checked, not just the AAB. Play re-signs and validates
+      # the AAB anyway; the APK is the one attached to the GitHub release and
+      # sideloaded directly, so it is the copy that reaches users unexamined.
+      #
+      # shell: bash rather than the default `bash -e {0}`, which has no pipefail.
+      # Every fingerprint below is read through a pipe, and without pipefail a
+      # failing keytool would leave an empty string to compare instead of failing.
       - name: Verify signing and bundle contents
+        shell: bash
         env:
           EXPECTED_SHA256: ${{ vars.UPLOAD_CERT_SHA256 }}
         run: |
           cd the_paragliding_app
           aab=build/app/outputs/bundle/release/app-release.aab
+          apk=build/app/outputs/flutter-apk/app-release.apk
 
           if [ -z "$EXPECTED_SHA256" ]; then
             echo "::error::vars.UPLOAD_CERT_SHA256 is not set - cannot prove this was signed with the upload key"
             exit 1
           fi
 
-          actual=$(keytool -printcert -jarfile "$aab" | awk '/SHA256:/{print $2; exit}')
-          echo "signing SHA256: $actual"
-          if [ "$actual" != "$EXPECTED_SHA256" ]; then
-            echo "::error::AAB is not signed with the upload key (expected $EXPECTED_SHA256)"
+          for f in "$aab" "$apk"; do
+            if [ ! -f "$f" ]; then
+              echo "::error::$f was not produced - there is nothing to verify"
+              exit 1
+            fi
+          done
+
+          # keytool prints AA:BB:.., apksigner prints unseparated lowercase hex.
+          norm() { tr -d ':' | tr '[:lower:]' '[:upper:]'; }
+          expected=$(printf '%s' "$EXPECTED_SHA256" | norm)
+
+          # The AAB is jar-signed, so keytool can read it. The APK may carry only
+          # an APK Signature Scheme v2/v3 block, which keytool cannot see at all -
+          # it would report "not a signed jar file" on a correctly signed APK.
+          aab_sha=$(keytool -printcert -jarfile "$aab" | awk '/SHA256:/{print $2; exit}' | norm)
+
+          apksigner=$(ls -1 "$ANDROID_HOME"/build-tools/*/apksigner 2>/dev/null | sort -V | tail -1 || true)
+          if [ -z "$apksigner" ]; then
+            echo "::error::apksigner not found under $ANDROID_HOME/build-tools - cannot verify the APK signature"
+            exit 1
+          fi
+          apk_sha=$("$apksigner" verify --print-certs "$apk" | awk '/certificate SHA-256 digest:/{print $NF; exit}' | norm)
+
+          echo "expected: $expected"
+          echo "aab:      $aab_sha"
+          echo "apk:      $apk_sha"
+
+          if [ "$aab_sha" != "$expected" ]; then
+            echo "::error::AAB is not signed with the upload key"
             keytool -printcert -jarfile "$aab" | grep -E 'Owner:|SHA256:' || true
             exit 1
           fi
-
-          if unzip -l "$aab" | grep -q 'flutter_assets/\.env'; then
-            echo "::error::.env is bundled as an asset - API keys would ship in plaintext (regression of #284)"
+          if [ "$apk_sha" != "$expected" ]; then
+            echo "::error::APK is not signed with the upload key - it must not be attached to a release"
+            "$apksigner" verify --print-certs "$apk" || true
             exit 1
           fi
 
-          echo "OK: signed with the upload key, no .env in the bundle"
+          # Listed into a variable first. `unzip -l "$f" | grep -q` inside an if
+          # swallows a failing unzip: grep reads nothing, returns 1, and the check
+          # reports success on an archive it never managed to read.
+          for f in "$aab" "$apk"; do
+            listing=$(unzip -l "$f")
+            if printf '%s\n' "$listing" | grep -q 'flutter_assets/\.env'; then
+              echo "::error::.env is bundled in $f - API keys would ship in plaintext (regression of #284)"
+              exit 1
+            fi
+          done
+
+          echo "OK: AAB and APK are both signed with the upload key, neither contains .env"
+
+      # Lets anyone check that a downloaded APK really came from this workflow, at
+      # this commit, rather than from someone's laptop:
+      #   gh attestation verify app-release.apk --repo Kevin-McIsaac/the_paragliding_app
+      #
+      # Deliberately not gated to tags. Everything downstream of here that only
+      # runs on a tag is untestable by workflow_dispatch, and a signing step that
+      # has never executed is exactly the kind of guard this project has been
+      # bitten by. Attesting a dry-run build costs nothing and keeps it exercised.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+        with:
+          subject-path: |
+            the_paragliding_app/build/app/outputs/flutter-apk/app-release.apk
+            the_paragliding_app/build/app/outputs/bundle/release/app-release.aab
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: app-release-apk
           path: the_paragliding_app/build/app/outputs/flutter-apk/app-release.apk
 
       - name: Upload App Bundle artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: app-release-bundle
           path: the_paragliding_app/build/app/outputs/bundle/release/app-release.aab
@@ -178,7 +380,7 @@ jobs:
       # loss. The locale MUST exist in the Play listing or the upload is rejected.
       - name: Publish to Play internal track
         if: startsWith(github.ref, 'refs/tags/')
-        uses: r0adkll/upload-google-play@v1
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
           packageName: com.theparaglidingapp
@@ -213,17 +415,27 @@ jobs:
       contents: write
 
     steps:
+      # Only for the release notes file below.
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - name: Download APK artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: app-release-apk
 
       # Only the APK is attached now: an .aab is not installable by end users, and
       # Play is the distribution path for it.
+      #
+      # body_path is the same file Play testers see, so the two release notes stop
+      # diverging - GitHub used to show only a list of commit subjects, which is
+      # the worse summary of the two. generate_release_notes still appends the
+      # generated changelog underneath, so nothing is lost.
       - name: Create Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: app-release.apk
+          body_path: distribution/whatsnew/whatsnew-en-GB
           generate_release_notes: true
           draft: false
           prerelease: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -415,6 +415,12 @@ jobs:
   attest:
     name: Attest build provenance
     needs: [release-android]
+    # Same shape as release-android's guard, and for the same reason. A skipped job
+    # propagates down the whole needs chain: on workflow_dispatch check-version is
+    # skipped, and without this that skip reaches here *through* release-android
+    # even though release-android ran and succeeded. Caught by a dry run reporting
+    # success with this job silently skipped.
+    if: always() && needs.release-android.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,23 @@
 name: CI
 
+# Actions are pinned to commit SHAs, with the release they came from in a trailing
+# comment. See the note at the top of build.yml for why.
+
 on:
   push:
     branches:
       - main
   pull_request:
+
+# Superseded pushes to a PR branch have nothing left to prove; let the newest win.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Declared rather than inherited, so a job gaining write access has to be a
+# visible edit here. Nothing in this workflow writes to the repository.
+permissions:
+  contents: read
 
 env:
   FLUTTER_VERSION: "3.41.6"
@@ -20,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ env:
   FLUTTER_VERSION: "3.41.6"
 
 jobs:
+  # build.yml carries a near-copy of this job, because the release path must not
+  # depend on this workflow having run. Change one and change the other.
   analyze-and-test:
     name: Analyze and test
     runs-on: ubuntu-latest

--- a/GOOGLE_PLAY_DEPLOYMENT.md
+++ b/GOOGLE_PLAY_DEPLOYMENT.md
@@ -77,6 +77,12 @@ publish** — use it to test pipeline changes, against a branch:
 gh workflow run build.yml --ref my-branch
 ```
 
+**What the dry run does not cover.** Anything gated on a tag ref: the four checks in the table
+above, the Play upload, and the GitHub release. Those first run for real on the next tag. If you
+need to prove one of the tag checks without publishing, tag an *unmerged* commit — the
+ancestor-of-`main` check fails, so nothing is built and nothing is uploaded. Delete the throwaway
+tag afterwards, and confirm with `git ls-remote --tags origin`.
+
 ## What CI verifies
 
 Two failure modes that produce a perfectly normal-looking build, both hard errors:

--- a/GOOGLE_PLAY_DEPLOYMENT.md
+++ b/GOOGLE_PLAY_DEPLOYMENT.md
@@ -9,14 +9,19 @@ track.
 ```bash
 # 1. bump the build number (versionCode) - Play rejects a reused one
 $EDITOR the_paragliding_app/pubspec.yaml     # version: 1.0.4+13
-git commit -am "chore: Bump build number to 1.0.4+13"
 
 # 2. write the release notes users will see
 $EDITOR distribution/whatsnew/whatsnew-en-GB
 
-# 3. tag and push
-git tag v1.0.4+13 && git push origin main --tags
+# 3. get both onto main the usual way (PR, review, merge)
+
+# 4. tag the merged commit and push the tag
+git switch main && git pull
+git tag -a v1.0.4+13 -m "Release 1.0.4+13" && git push origin v1.0.4+13
 ```
+
+Tag a commit that is already on `main` — CI refuses to release from anything else, so tagging a
+branch and pushing both at once is no longer a shortcut that works.
 
 ### Release notes
 
@@ -31,34 +36,71 @@ Notes are worth writing whenever a release changes something users can see. 1.0.
 user's total hours by about 11% by measuring takeoff-to-landing instead of the whole recording;
 shipped without explanation, that reads as data loss rather than a correction.
 
-The tag must agree with `pubspec.yaml` — the `check-version` job fails fast otherwise, rather
-than letting Play reject the upload after a full build.
+## What happens when you push the tag
 
-Then **approve the deployment**: the `release-android` job targets the `play-internal`
-environment, which has a required reviewer, so it waits in the Actions tab until approved. That
-is the last point at which a mistaken tag can be stopped.
+**There is no approval step.** The `play-internal` environment scopes the signing and Play
+credentials to this one job so no other workflow can read them, but it carries no protection
+rules — a pushed tag publishes without waiting for anyone. This file used to claim a required
+reviewer; there has never been one. Add required reviewers under Settings → Environments →
+`play-internal` if a human checkpoint is wanted. Until then the tag push *is* the decision.
 
-After approval, CI:
+Four cheap checks run first, all within seconds, so a bad tag fails long before a ~15 minute
+build:
+
+| check | fails when |
+|---|---|
+| tag matches `pubspec.yaml` | tagged without bumping |
+| `versionCode` exceeds every existing `v*` tag | the `+N` suffix was reused — Play otherwise only says so *after* the upload |
+| tagged commit is an ancestor of `main` | the tag points at an unmerged branch or an arbitrary commit |
+| `whatsnew-en-GB` exists and is ≤500 characters | notes were forgotten, or overrun Play's limit |
+
+`flutter analyze` and the full test suite run alongside them, and the build does not start
+unless they pass. That gate lives here rather than relying on `ci.yml` because nothing requires
+`ci.yml` to be green before merging or tagging — a tag on a red commit used to build and publish
+exactly like a green one.
+
+Then CI:
 
 1. Restores the upload keystore and writes `android/key.properties`
 2. Builds APK + AAB with the API keys injected via `--dart-define`
-3. **Verifies** the bundle (see below) — hard failure, not a warning
-4. Publishes the AAB to the internal track with `mapping.txt`
-5. Attaches the APK to a GitHub Release
+3. **Verifies both artifacts** (see below) — hard failure, not a warning
+4. Records a build provenance attestation for each
+5. Publishes the AAB to the internal track with `mapping.txt`
+6. Attaches the APK to a GitHub Release, carrying the same notes Play testers see
 
 Internal testing has no review delay; testers see it within minutes.
 
-`workflow_dispatch` runs the same build and verification but **does not publish** — use it to
-test pipeline changes.
+`workflow_dispatch` runs the same tests, build, verification and attestation but **does not
+publish** — use it to test pipeline changes, against a branch:
+
+```bash
+gh workflow run build.yml --ref my-branch
+```
 
 ## What CI verifies
 
-Two failure modes that produce a perfectly normal-looking build, both now hard errors:
+Two failure modes that produce a perfectly normal-looking build, both hard errors:
 
 | check | why |
 |---|---|
-| AAB signing cert == `vars.UPLOAD_CERT_SHA256` | Without `key.properties`, `build.gradle.kts` falls back to the **debug** key and only `println`s a warning. Play rejects the upload, and before this check GitHub Releases were being published debug-signed. |
-| no `flutter_assets/.env` in the bundle | `.env` was once declared as an asset, shipping API keys in plaintext to every user (#284). This stops that regressing. |
+| signing cert == `vars.UPLOAD_CERT_SHA256` | Without `key.properties`, `build.gradle.kts` falls back to the **debug** key and only `println`s a warning. Play rejects the upload, and before this check GitHub Releases were being published debug-signed. |
+| no `flutter_assets/.env` in the artifact | `.env` was once declared as an asset, shipping API keys in plaintext to every user (#284). This stops that regressing. |
+
+Both run against **the APK as well as the AAB**. They used to cover only the AAB, which is the
+artifact Play re-signs and independently validates anyway; the APK is the one attached to the
+GitHub release and sideloaded directly, so it was the copy reaching users unexamined.
+
+The two need different tools. An AAB is jar-signed, so `keytool -printcert -jarfile` reads it.
+An APK may carry only an APK Signature Scheme v2/v3 block, which `keytool` cannot see at all —
+it reports "not a signed jar file" on a perfectly good APK — so the APK is read with
+`apksigner verify --print-certs` and the two fingerprints are normalised before comparing.
+
+Beyond verification, each artifact gets a **build provenance attestation**, which lets anyone
+check that a downloaded APK came from this workflow at this commit:
+
+```bash
+gh attestation verify app-release.apk --repo Kevin-McIsaac/the_paragliding_app
+```
 
 The expected fingerprint is a repository **variable**, not a secret — it is a public certificate
 fingerprint:
@@ -71,8 +113,8 @@ UPLOAD_CERT_SHA256 = 1F:05:AD:55:3A:CB:78:8C:38:CB:13:7D:61:06:B6:D6:EC:3C:04:0D
 
 ### Environment `play-internal` (already created)
 
-Required reviewer: repository owner. Signing and Play credentials are scoped to this
-environment rather than the whole repository, so no other workflow can read them.
+No protection rules — see above. Its purpose is scoping: signing and Play credentials live here
+rather than on the whole repository, so no other workflow can read them.
 
 **Environment secrets** (set from the local keystore):
 
@@ -114,6 +156,24 @@ the ability to update the listing, and this pipeline would be a bad idea.
 Keep a backup of the keystore **and** `key.properties` regardless; the passwords are useless
 without the keystore and vice versa.
 
+## Pinned actions
+
+Every `uses:` in `build.yml` and `ci.yml` names a commit SHA with its release in a trailing
+comment, not a tag. `@v1` is a movable ref: whoever controls the action repository can repoint it
+at new code, and it would run here on the next release with nothing changing in this repo. That
+matters more than usual because `release-android` holds the upload keystore and its passwords,
+and hands the Play service account JSON to a third-party action (`r0adkll/upload-google-play`).
+
+The cost is that pins go stale silently — a pinned action is never told about its own security
+fixes. To update one:
+
+```bash
+gh api repos/actions/checkout/commits/v7 -q .sha   # resolve the tag to a commit
+```
+
+then edit the SHA **and** the version comment together, and prove it with
+`gh workflow run build.yml --ref <branch>`.
+
 ## Version management
 
 `pubspec.yaml` is the single source of truth for all three numbers Play shows, which are easy to
@@ -140,9 +200,13 @@ run-number scheme would desynchronise from what is already published.
 | Error | Cause | Fix |
 |---|---|---|
 | `Tag vX does not match pubspec version` | Tagged without bumping | Bump `pubspec.yaml`, retag |
+| `versionCode N was already released as vX` | The `+N` suffix was reused | Bump it; this is the local form of Play's `Version code N has already been used` |
+| `... is not an ancestor of main` | Tag points at an unmerged or arbitrary commit | Merge first, then tag the merge commit |
+| `whatsnew-en-GB is missing or empty` | Release notes not written | Write them; step 2 of Releasing |
 | `AAB is not signed with the upload key` | Keystore secret missing or wrong | Check the `play-internal` environment secrets |
-| `.env is bundled as an asset` | Someone re-added `.env` to `assets:` | Remove it; keys come from `--dart-define` (see README_API_KEYS.md) |
-| `Version code N has already been used` | `versionCode` not bumped | Bump the `+N` suffix |
+| `APK is not signed with the upload key` | Same cause; the APK is checked separately with `apksigner` | As above |
+| `.env is bundled in ...` | Someone re-added `.env` to `assets:` | Remove it; keys come from `--dart-define` (see README_API_KEYS.md) |
+| `Version code N has already been used` | Reached Play despite the check above — e.g. a build uploaded manually | Bump the `+N` suffix |
 | `The caller does not have permission` | Service account lacks Play access | Re-check the grant in Play Console → API access |
 | `Invalid JWT` | Malformed service account JSON secret | Re-set it from the original file with `gh secret set ... <` |
 

--- a/the_paragliding_app/android/app/build.gradle.kts
+++ b/the_paragliding_app/android/app/build.gradle.kts
@@ -5,37 +5,30 @@ plugins {
     id("dev.flutter.flutter-gradle-plugin")
 }
 
-import java.io.ByteArrayOutputStream
 import java.io.FileInputStream
 import java.util.Properties
 
-// Function to get git commit hash
-fun getGitCommitHash(): String {
+// Runs a command and returns its stdout, or `fallback` if it fails at all.
+//
+// providers.exec, not Project.exec: the latter is deprecated in Gradle 8 and gone
+// in Gradle 9, so this build would stop working on that upgrade. It is also the
+// configuration-cache-safe form - Project.exec at configuration time is one of the
+// things that makes a build cache-incompatible.
+fun gitOutput(vararg command: String, fallback: String): String {
     return try {
-        val stdout = ByteArrayOutputStream()
-        exec {
-            commandLine("git", "rev-parse", "--short", "HEAD")
-            standardOutput = stdout
-        }
-        stdout.toString().trim()
+        providers.exec {
+            commandLine(*command)
+        }.standardOutput.asText.get().trim()
     } catch (e: Exception) {
-        "unknown"
+        fallback
     }
 }
 
+// Function to get git commit hash
+fun getGitCommitHash(): String = gitOutput("git", "rev-parse", "--short", "HEAD", fallback = "unknown")
+
 // Function to get git branch name
-fun getGitBranchName(): String {
-    return try {
-        val stdout = ByteArrayOutputStream()
-        exec {
-            commandLine("git", "rev-parse", "--abbrev-ref", "HEAD")
-            standardOutput = stdout
-        }
-        stdout.toString().trim()
-    } catch (e: Exception) {
-        "main"
-    }
-}
+fun getGitBranchName(): String = gitOutput("git", "rev-parse", "--abbrev-ref", "HEAD", fallback = "main")
 
 // Load keystore properties from file
 fun getKeystoreProperties(): Properties? {


### PR DESCRIPTION
Follow-up to a review of the build and deploy pipeline. Each item below was a gap
between what the pipeline claimed and what it did.

## The approval gate did not exist

`build.yml` said the `play-internal` environment *"Gates on a required reviewer"*.
`GOOGLE_PLAY_DEPLOYMENT.md` said *"Required reviewer: repository owner"*. The API says:

```
play-internal | protection_rules=NONE
```

And it showed: the `v1.0.4+16` run went straight from `check-version` into building and
publishing to Play without ever pausing for approval.

Both claims are deleted. The environment does something real — it scopes the signing and
Play credentials so no other workflow can read them — and that is now all it says it does,
plus a pointer to Settings → Environments for anyone who wants the gate added.

## The APK reaching users was never verified

Both assertions ran against `app-release.aab` only. Play re-signs and independently
validates the bundle; the **APK** is what gets attached to the GitHub release and
sideloaded directly, and it passed through unchecked — including the `.env` guard that
exists because #284 shipped API keys in plaintext to every user.

Now both artifacts are checked. They need different tools: an AAB is jar-signed so
`keytool -printcert -jarfile` reads it, but an APK may carry only an APK Signature Scheme
v2/v3 block, which `keytool` cannot see at all — it reports "not a signed jar file" on a
perfectly good APK. The APK goes through `apksigner verify --print-certs` and the two
fingerprint formats are normalised before comparing.

## Nothing required the tagged commit to be green, or on main

`ci.yml` ran on pushes to main and on PRs, but nothing connected it to the release path,
and the `main` ruleset has only `deletion` and `non_fast_forward` — no required checks, no
required PR. A tag on a red commit built and published exactly like a green one, and a tag
could point at any commit at all.

`release-android` now needs an `Analyze and test` job, and `check-version` asserts the
tagged commit is an ancestor of `main`. ~2 minutes against a ~15 minute build.

## versionCode reuse is caught locally

"Version code N has already been used" is the most common way a release fails, and Play
only says so after a full build and upload. Every shipped code is recorded as a `v*` tag,
so the answer was already in the repo. Same reasoning for `whatsnew-en-GB`, which both the
Play upload and the GitHub release read but neither reaches until after the build.

Exercised against the real tag list before committing:

```
version=1.0.5+17    tag=v1.0.5+17        -> accept (highest=16 v1.0.4+16)
version=1.0.4+16    tag=v1.0.4+16-retry  -> REJECT (highest=16 v1.0.4+16)
version=1.0.4+13    tag=v1.0.4+13b       -> REJECT (highest=16 v1.0.4+16)
version=1.0.4+16    tag=v1.0.4+16        -> accept (own tag excluded, so 15 is the max)
```

## A guard that could pass without looking

```bash
if unzip -l "$aab" | grep -q 'flutter_assets/\.env'; then
```

The default shell for a `run:` step is `bash -e {0}` — **no** `pipefail`. If `unzip` fails,
`grep` reads empty input, returns 1, and the check reports success on an archive it never
managed to read. Latent today only because the signing step above would fail first.

Fixed by capturing the listing into a variable first, so a failing `unzip` fails the step.
Proved both directions rather than assuming:

```
old form, unreadable archive:  reported OK, step exit=0   <-- the bug
new form, unreadable archive:  step exit=9                <-- fails, correct
new form, archive with .env:   detected                   <-- still works
```

Note `shell: bash` alone would **not** have fixed this — `pipefail` sets the pipeline's
status, but `if` consumes it either way. The restructure is the fix.

## Supply chain

Every `uses:` is pinned to a commit SHA with its release in a trailing comment. `@v1` is a
movable ref: whoever controls the action repo can repoint it at new code and it runs here
on the next release with nothing changing in this repository. `release-android` holds the
upload keystore and its passwords and hands the Play service account JSON to a third-party
action, so this is worth the maintenance cost. `GOOGLE_PLAY_DEPLOYMENT.md` documents how to
bump one.

Both artifacts also get a build provenance attestation:

```bash
gh attestation verify app-release.apk --repo Kevin-McIsaac/the_paragliding_app
```

Deliberately **not** gated to tags. Everything downstream that only runs on a tag is
untestable by `workflow_dispatch`, and a step that has never executed is exactly the kind
of guard this project has been bitten by.

## Smaller

- Top-level `permissions: contents: read` in both workflows. The repo default is already
  read-only, but that is a setting anyone can flip, silently widening every job.
- `concurrency` on `build.yml` so two tags queue instead of racing to Play; on `ci.yml` so
  superseded PR pushes cancel.
- API keys passed via `env:` rather than `${{ secrets.X }}` interpolated into the shell
  script, where a value containing a quote or backtick changes what executes.
- `cache: true` on the release build's Flutter setup, matching `ci.yml`.
- The GitHub release now carries the same notes Play testers see (`body_path`), with the
  generated changelog appended below, instead of only a list of commit subjects.
- `android/app/build.gradle.kts` moves off `Project.exec`, deprecated in Gradle 8 and
  **removed in Gradle 9** — the build would break on that upgrade. `providers.exec` is also
  configuration-cache safe.

## Verification

`actionlint 1.7.7` clean on both workflows. Beyond that, three things were run rather than
reasoned about.

**Dry run** — `gh workflow run build.yml --ref ci/harden-release-pipeline`
([run 31056808440](https://github.com/Kevin-McIsaac/the_paragliding_app/actions/runs/31056808440)),
completed **success**, 0 annotations. Every step green including `Build APK and App Bundle`
(so `providers.exec` works), `Verify signing and bundle contents`, and `Attest build
provenance`; `Publish to Play internal track` correctly skipped. The verification step's own
output, rather than its exit status:

```
expected: 1F05AD553ACB788C38CB137D6106B6D6EC3C040D9089AAA80014706E637A7EF2
aab:      1F05AD553ACB788C38CB137D6106B6D6EC3C040D9089AAA80014706E637A7EF2
apk:      1F05AD553ACB788C38CB137D6106B6D6EC3C040D9089AAA80014706E637A7EF2
OK: AAB and APK are both signed with the upload key, neither contains .env
...
Attestation created for 2 subjects
```

The APK fingerprint is a real `apksigner` read, not an empty string comparing equal to
another empty string — `expected` is non-empty, so an empty result would have failed.

**Probe tag** — the new `check-version` guards are skipped by `workflow_dispatch`, so they
were exercised for real by pushing a throwaway annotated tag at an *unmerged* commit, in the
spirit of the release assertions that were deliberately failed once on a throwaway branch:

```
job Validate tag: failure
  3. Compare tag with pubspec version:                  success
  4. Check versionCode is higher than every released tag: success
  5. Check release notes exist:                          success
  6. Check the tagged commit is on main:                 failure   <-- the guard firing
job Build signed Android release: skipped
job Create GitHub Release:        skipped
```

Nothing was built and nothing was published. The tag has been deleted; `git ls-remote --tags`
confirms the list is back to `v1.0.2+11 … v1.0.4+16`. That run also exercised the two
review fixes below, since it used the updated workflow.

**Local** — the versionCode logic against the real tag list (results above), and the `.env`
guard in both forms against an unreadable archive (old: exit 0; new: exit 9), plus
fingerprint normalisation against real `keytool` and `apksigner` output including a
debug-key sample that must *not* match.

Still unexercised: `create-release` is gated to tags, so `body_path` and the pinned
`download-artifact` / `action-gh-release` are first exercised on the next real release.

## Review fixes applied

First pass:

- The pubspec versionCode is now parsed with the same `case` guards as the tags, so a
  version missing its `+N` reports an `::error::` instead of bash's "integer expression
  expected".
- `concurrency` is scoped so only tag runs share a queue. Grouping on the workflow alone
  meant a ~15 minute dry run would park a real release tag behind it.

Second pass:

- **The release-notes check counted bytes against a character limit.** Reproduced on the
  file this repo ships: `wc -c` reads 395, `wc -m` reads 389 — the bullets are U+2022, three
  bytes each. It fails closed rather than open, but it would reject notes legitimately under
  Play's 500 characters. Now `LC_ALL=C.UTF-8 wc -m`.
- **Attestation moved to its own job.** Actions permissions are job-scoped, not step-scoped,
  so `id-token: write` and `attestations: write` were available to every step of the job
  holding the upload keystore and the Play service account JSON — including the third-party
  upload action. This was the one place the change's stated least-privilege goal and the
  actual grant disagreed. It re-downloads the artifacts rather than rebuilding, so it still
  attests the exact published bytes, and it now exercises the `download-artifact` pin on
  every dry run.
- The duplicated `analyze-and-test` job says so in both files.
- `GOOGLE_PLAY_DEPLOYMENT.md` documents what a dry run cannot reach, and the unmerged-tag
  trick for proving a tag check without publishing.

## The split introduced a bug, which the dry run caught

Moving attestation into its own job left it never running — and the run still reported
**success**. A skipped job propagates down the entire `needs` chain: on `workflow_dispatch`,
`check-version` is skipped, and that skip reached `attest` *through* `release-android`, even
though `release-android` ran and succeeded. Its `always()` guard covers itself, not what
comes after it.

Only visible by reading the job list, not the conclusion — the failure mode this repo's
CLAUDE.md is about:

```
job Build signed Android release: success
job Attest build provenance:      skipped     <-- run conclusion: success
```

Fixed in aa73f17 with the same explicit guard, and re-verified
([run 31058518623](https://github.com/Kevin-McIsaac/the_paragliding_app/actions/runs/31058518623)):

```
job Attest build provenance: success
  2. Download built artifacts: success
  3. Attest: success

- app-release-bundle (Expected Digest: sha256:ec391a84...b937)
- app-release-apk    (Expected Digest: sha256:997d4f2b...5476)
SHA256 digest of downloaded artifact is ec391a84...b937
SHA256 digest of downloaded artifact is 997d4f2b...5476
Attestation created for 2 subjects
Attestation signed using certificate from Public Good Sigstore instance
Attestation signature uploaded to Rekor transparency log
```

Both digests were verified on download — `download-artifact@v8` defaults
`digest-mismatch: error`, which is the behaviour that motivated taking the full major bump
in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
