### PR TITLE
Release 1.0.5+17

### DIFF
--- a/distribution/whatsnew/whatsnew-en-GB
+++ b/distribution/whatsnew/whatsnew-en-GB
@@ -1,6 +1,2 @@
-• The 3D map no longer goes blank when a Cesium Ion token stops working.
-  A revoked token, or one without access to the map imagery, is now
-  detected and the map falls back to the standard imagery
-• Data Management re-checks your saved token when you open it, so a token
-  that has stopped working no longer shows as validated
-• Fixed the contact email being cut off on the About screen
+• When you add a Cesium Ion access token, the box no longer shows greyed-out
+  sample text that looked like a key had already been entered

--- a/the_paragliding_app/pubspec.yaml
+++ b/the_paragliding_app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.4+16
+version: 1.0.5+17
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
Version bump and release notes for the next Play internal-track release.

## What ships

One user-visible change since `v1.0.4+16`:

- **34f5452** — the Cesium Ion token field used a JWT-shaped string as its `hintText`, so
  tapping into an empty field showed what read as an already-entered key. The dialog above
  already says what to paste, so the placeholder is gone.

Everything else on `main` since that tag is release-pipeline work (#313, #315) and does not
change the app.

## Version

`1.0.4+16` → `1.0.5+17`.

- `versionCode` **17** because 16 is published and Play never allows reuse.
- `versionName` **1.0.5** rather than a fourth `1.0.4` build, because the release carries a
  user-visible change. That is the rule in `GOOGLE_PLAY_DEPLOYMENT.md`, and the reason it
  exists: builds 5 through 11 all shipped as `1.0.2`, leaving users unable to tell a
  months-old build from a current one.

## Release notes

```
• When you add a Cesium Ion access token, the box no longer shows greyed-out
  sample text that looked like a key had already been entered
```

139 characters, against Play's 500.

## First release through the hardened pipeline

This is the first tag since #315, so it exercises the parts a `workflow_dispatch` dry run
cannot reach: the four `check-version` gates, the Play upload, and `create-release`.

Already verified before merge — `check-version` against a throwaway tag on an unmerged
commit (all four steps ran; the ancestor gate fired and nothing was built), and the build,
APK/AAB signature verification and attestation across three dispatch runs.

Genuinely first-run here: `body_path` on the GitHub release, and `action-gh-release@v3`.
Both live in `create-release`, which runs *after* the Play upload — so if either misbehaves
the app is still published and only the GitHub release needs redoing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
