### PR TITLE
Follow OpenAIP's airspace export bucket to its new home

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -530,6 +530,42 @@ flight data.
 
 The Paragliding App integrates with OpenAIP Core API for aviation data overlays including airspaces, airports, navigation aids, and reporting points.
 
+### Two different data paths — do not confuse them
+
+**Airspace overlays do not use the API and need no API key.** They are bulk-downloaded per
+country from OpenAIP's public daily export bucket by `AirspaceCountryService`, stored in the
+local database, and read back by bounding box. That is what makes airspace work offline,
+which matters because launch sites usually have no signal.
+
+```
+https://storage.openaip.net/openaip-system-exports/<cc>_asp.geojson   # e.g. au_asp.geojson
+```
+
+The API below is used for the *other* layers (airports, navaids, reporting points) and for
+OpenAIP tile URLs — those do need the key.
+
+This distinction cost real debugging time: airspace was failing while the base map rendered
+fine, which looked like an API-key problem and is not one. When airspace breaks, check the
+bucket, not the key.
+
+**The bucket moved in July 2026.** The old Google Cloud Storage bucket
+(`storage.googleapis.com/29f98e10-...`) was switched to *Requester Pays* on ~2026-07-23 after
+OpenAIP was billed four-figure egress costs, and now returns `HTTP 400 UserProjectMissing` to
+every anonymous request — see openAIP/openaip#468 and #469. The S3 endpoint above is the
+sanctioned replacement, rate limited to 20 req/s.
+
+Two consequences worth keeping:
+
+- **Do not fetch airspace per viewport.** A viewport query is ~250 KiB and fires on every
+  pan/zoom; that is the usage pattern that got the previous bucket locked down. One country
+  is one request.
+- The endpoint returns `content-encoding: utf-8`, which is a charset, not an encoding. Dart
+  ignores it (only gzip is auto-uncompressed) so the app is fine, but `curl --compressed`
+  fails on it — use plain `curl` when reproducing by hand.
+
+`test/airspace_country_source_test.dart` guards both the URL and, under the `network` tag,
+that the bucket still serves usable GeoJSON.
+
 ### API Endpoints & Authentication
 
 ```

--- a/the_paragliding_app/dart_test.yaml
+++ b/the_paragliding_app/dart_test.yaml
@@ -12,4 +12,7 @@
 # line instead; see .github/workflows/ci.yml.
 tags:
   network:
-    skip: "Hits the live ParaglidingEarth API; run with --tags network --run-skipped"
+    # Deliberately names no single service - more than one is covered now
+    # (ParaglidingEarth, the OpenAIP export bucket), and a message naming only
+    # one reads as "this test hits ParaglidingEarth" when it does not.
+    skip: "Hits a live third-party service; run with --tags network --run-skipped"

--- a/the_paragliding_app/lib/services/airspace_country_service.dart
+++ b/the_paragliding_app/lib/services/airspace_country_service.dart
@@ -14,12 +14,41 @@ class AirspaceCountryService {
 
   AirspaceCountryService._();
 
-  // Google Storage configuration
-  static const String _storageBaseUrl = 'https://storage.googleapis.com/29f98e10-a489-4c82-ae5e-489dbcd4912f';
+  // OpenAIP's public daily export bucket.
+  //
+  // This is NOT the old Google Cloud Storage bucket
+  // (storage.googleapis.com/29f98e10-...), and must not be "corrected" back to
+  // it. OpenAIP switched that bucket to Requester Pays around 2026-07-23, so
+  // every anonymous request now fails with HTTP 400 UserProjectMissing and no
+  // country can be downloaded. It was deliberate - they were being billed
+  // four-figure egress costs - and announced in openAIP/openaip#468. The
+  // replacement S3 endpoint below is the sanctioned bulk channel (#469), rate
+  // limited to 20 req/s. Downloading a whole country is one request against
+  // that budget; fetching per-viewport instead would be the very usage pattern
+  // that got the last bucket locked down.
+  //
+  // The endpoint returns `content-encoding: utf-8`, which is a charset, not an
+  // encoding. It is wrong but harmless here: dart:io only auto-uncompresses
+  // gzip, so an unknown value is passed through untouched. Verified against
+  // this exact code path. Tools that trust the header - `curl --compressed` -
+  // do fail on it, which is worth knowing when reproducing by hand.
+  static const String _storageBaseUrl = 'https://storage.openaip.net/openaip-system-exports';
   static const Duration _requestTimeout = Duration(minutes: 2); // Longer timeout for large files
 
   // Preferences keys
   static const String _selectedCountriesKey = 'airspace_selected_countries';
+
+  /// Where the ETag / Last-Modified / download time for one country are kept.
+  static String _fetchInfoKey(String countryCode) =>
+      'airspace_fetch_info_${countryCode.toUpperCase()}';
+
+  /// URL of the daily airspace export for [countryCode], e.g. `au_asp.geojson`.
+  ///
+  /// Public so a test can assert the app points at a URL that actually serves
+  /// data. That is the only thing that would have caught this file's last
+  /// outage: the code was correct, the host was not.
+  static String countryDataUrl(String countryCode) =>
+      '$_storageBaseUrl/${countryCode.toLowerCase()}_asp.geojson';
 
   // Cache references
   final AirspaceMetadataCache _metadataCache = AirspaceMetadataCache.instance;
@@ -90,12 +119,17 @@ class AirspaceCountryService {
 
         // Only include countries that actually have data
         if (stats['has_data'] == true) {
+          final fetchInfo = await _getFetchInfo(countryCode);
+
           metadata[countryCode] = CountryMetadata(
             countryCode: countryCode,
             airspaceCount: stats['airspace_count'] ?? 0,
-            downloadTime: DateTime.now(), // TODO: Store real download time
-            etag: null,
-            lastModified: null,
+            // Falls back to "now" only for data downloaded before the fetch
+            // info was recorded. That reads as freshly downloaded, which is the
+            // safe direction: it delays an update rather than discarding data.
+            downloadTime: fetchInfo.downloadedAt ?? DateTime.now(),
+            etag: fetchInfo.etag,
+            lastModified: fetchInfo.lastModified,
             version: 1,
           );
         }
@@ -120,7 +154,7 @@ class AirspaceCountryService {
       LoggingService.info('Starting download for country: $countryCode');
 
       // Build URL for country GeoJSON
-      final url = '$_storageBaseUrl/${countryCode.toLowerCase()}_asp.geojson';
+      final url = countryDataUrl(countryCode);
 
       LoggingService.structured('COUNTRY_DOWNLOAD_START', {
         'country': countryCode,
@@ -132,7 +166,31 @@ class AirspaceCountryService {
       final streamedResponse = await request.send().timeout(_requestTimeout);
 
       if (streamedResponse.statusCode != 200) {
-        throw Exception('Failed to download country data: HTTP ${streamedResponse.statusCode}');
+        // Read the body before throwing. When the old bucket switched to
+        // Requester Pays this threw a bare "HTTP 400", while the server was
+        // spelling out exactly what was wrong in a body nobody looked at:
+        //   <Error><Code>UserProjectMissing</Code>...
+        // That cost far more to diagnose than it should have.
+        var detail = '';
+        try {
+          final body = await streamedResponse.stream.bytesToString();
+          detail = body.trim().replaceAll(RegExp(r'\s+'), ' ');
+          if (detail.length > 300) detail = '${detail.substring(0, 300)}...';
+        } catch (_) {
+          // Body unreadable - the status code is still worth reporting.
+        }
+
+        LoggingService.structured('COUNTRY_DOWNLOAD_FAILED', {
+          'country': countryCode,
+          'status': streamedResponse.statusCode,
+          'url': url,
+          'body': detail,
+        });
+
+        throw Exception(
+          'Failed to download country data: HTTP ${streamedResponse.statusCode}'
+          '${detail.isEmpty ? '' : ' - $detail'}',
+        );
       }
 
       // Get content length for progress tracking
@@ -215,14 +273,32 @@ class AirspaceCountryService {
       features: features.cast<Map<String, dynamic>>(),
     );
 
-    // Country metadata is automatically stored by _metadataCache.putCountryAirspaces()
+    // Country metadata is automatically stored by _metadataCache.putCountryAirspaces(),
+    // but not the HTTP validators - so record them here. They used to be passed
+    // in and dropped on the floor, which left checkForUpdate() with nothing to
+    // compare and getCountryMetadata() reporting etag/lastModified as null.
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _fetchInfoKey(countryCode),
+      jsonEncode({
+        'etag': etag,
+        'lastModified': lastModified,
+        'downloadedAt': DateTime.now().toIso8601String(),
+      }),
+    );
 
     stopwatch.stop();
 
     LoggingService.debug('Completed storing country $countryCode in ${stopwatch.elapsedMilliseconds}ms');
   }
 
-  /// Check if country data needs updating
+  /// Check if country data needs updating.
+  ///
+  /// Asks the server with a HEAD request and compares HTTP validators instead
+  /// of guessing from age. The exports are rebuilt daily but the airspace in
+  /// them changes rarely, so an age rule gets it wrong in both directions: it
+  /// re-downloads ~13 MB that is already current, or sits on stale safety data
+  /// for a month. A HEAD is a few hundred bytes.
   Future<bool> checkForUpdate(String countryCode) async {
     try {
       final metadata = await getCountryMetadata();
@@ -232,13 +308,70 @@ class AirspaceCountryService {
         return true; // No data, needs download
       }
 
-      // Check age (update if > 30 days old)
-      final age = DateTime.now().difference(currentData.downloadTime);
-      return age.inDays > 30;
+      final stored = await _getFetchInfo(countryCode);
+      final ageInDays =
+          DateTime.now().difference(currentData.downloadTime).inDays;
 
+      // Data downloaded before validators were recorded has nothing to compare.
+      if (stored.etag == null && stored.lastModified == null) {
+        return ageInDays > 30;
+      }
+
+      final response = await http
+          .head(Uri.parse(countryDataUrl(countryCode)))
+          .timeout(const Duration(seconds: 30));
+
+      if (response.statusCode != 200) {
+        LoggingService.structured('COUNTRY_UPDATE_CHECK_FAILED', {
+          'country': countryCode,
+          'status': response.statusCode,
+        });
+        // Can't tell. Say no rather than pushing a large download that may be
+        // pointless - the user can still re-download by hand.
+        return false;
+      }
+
+      final remoteEtag = response.headers['etag'];
+      final remoteLastModified = response.headers['last-modified'];
+
+      final bool changed;
+      if (remoteEtag != null && stored.etag != null) {
+        changed = remoteEtag != stored.etag;
+      } else if (remoteLastModified != null && stored.lastModified != null) {
+        changed = remoteLastModified != stored.lastModified;
+      } else {
+        changed = ageInDays > 30; // No comparable validator - fall back to age
+      }
+
+      LoggingService.structured('COUNTRY_UPDATE_CHECK', {
+        'country': countryCode,
+        'update_available': changed,
+        'age_days': ageInDays,
+      });
+
+      return changed;
     } catch (e) {
       LoggingService.error('Failed to check for update for $countryCode', e);
       return false; // On error, assume up to date
+    }
+  }
+
+  /// Read the stored ETag / Last-Modified / download time for a country.
+  Future<_FetchInfo> _getFetchInfo(String countryCode) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(_fetchInfoKey(countryCode));
+      if (raw == null) return const _FetchInfo();
+
+      final map = jsonDecode(raw) as Map<String, dynamic>;
+      return _FetchInfo(
+        etag: map['etag'] as String?,
+        lastModified: map['lastModified'] as String?,
+        downloadedAt: DateTime.tryParse(map['downloadedAt'] as String? ?? ''),
+      );
+    } catch (e) {
+      LoggingService.error('Failed to read fetch info for $countryCode', e);
+      return const _FetchInfo();
     }
   }
 
@@ -253,6 +386,10 @@ class AirspaceCountryService {
     final selected = await getSelectedCountries();
     selected.remove(countryCode);
     await setSelectedCountries(selected);
+
+    // And the stored validators, so a re-download is not told it is current.
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_fetchInfoKey(countryCode));
 
     LoggingService.info('Successfully deleted country data for $countryCode');
   }
@@ -271,8 +408,23 @@ class AirspaceCountryService {
     await _geometryCache.clearAllCache();
 
     final prefs = await SharedPreferences.getInstance();
+    // Drop the stored validators too, or a later re-download would compare
+    // against an ETag whose data is gone and report "up to date".
+    for (final code in availableCountries.keys) {
+      await prefs.remove(_fetchInfoKey(code));
+    }
     await prefs.remove(_selectedCountriesKey);
 
     LoggingService.info('Successfully cleared all country airspace data');
   }
+}
+
+/// Stored HTTP validators for one country's export file, used to answer
+/// "has this changed?" with a HEAD request instead of a 13 MB download.
+class _FetchInfo {
+  final String? etag;
+  final String? lastModified;
+  final DateTime? downloadedAt;
+
+  const _FetchInfo({this.etag, this.lastModified, this.downloadedAt});
 }

--- a/the_paragliding_app/lib/services/airspace_country_service.dart
+++ b/the_paragliding_app/lib/services/airspace_country_service.dart
@@ -10,7 +10,8 @@ import '../data/models/airspace_country_models.dart';
 /// Service for managing country-based airspace data
 class AirspaceCountryService {
   static AirspaceCountryService? _instance;
-  static AirspaceCountryService get instance => _instance ??= AirspaceCountryService._();
+  static AirspaceCountryService get instance =>
+      _instance ??= AirspaceCountryService._();
 
   AirspaceCountryService._();
 
@@ -32,8 +33,11 @@ class AirspaceCountryService {
   // gzip, so an unknown value is passed through untouched. Verified against
   // this exact code path. Tools that trust the header - `curl --compressed` -
   // do fail on it, which is worth knowing when reproducing by hand.
-  static const String _storageBaseUrl = 'https://storage.openaip.net/openaip-system-exports';
-  static const Duration _requestTimeout = Duration(minutes: 2); // Longer timeout for large files
+  static const String _storageBaseUrl =
+      'https://storage.openaip.net/openaip-system-exports';
+  static const Duration _requestTimeout = Duration(
+    minutes: 2,
+  ); // Longer timeout for large files
 
   // Preferences keys
   static const String _selectedCountriesKey = 'airspace_selected_countries';
@@ -103,7 +107,9 @@ class AirspaceCountryService {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setStringList(_selectedCountriesKey, countryCodes);
 
-    LoggingService.info('Updated selected countries: ${countryCodes.join(", ")}');
+    LoggingService.info(
+      'Updated selected countries: ${countryCodes.join(", ")}',
+    );
   }
 
   /// Get metadata for all countries with real database statistics
@@ -141,7 +147,6 @@ class AirspaceCountryService {
       return {};
     }
   }
-
 
   /// Download country airspace data
   Future<DownloadResult> downloadCountryData(
@@ -224,7 +229,7 @@ class AirspaceCountryService {
       final durationSec = stopwatch.elapsedMilliseconds / 1000;
 
       LoggingService.info(
-        'Downloaded $countryName: ${features.length} airspaces (${sizeMB.toStringAsFixed(1)} MB) in ${durationSec.toStringAsFixed(1)}s'
+        'Downloaded $countryName: ${features.length} airspaces (${sizeMB.toStringAsFixed(1)} MB) in ${durationSec.toStringAsFixed(1)}s',
       );
 
       // Get etag and last-modified from response headers
@@ -243,7 +248,6 @@ class AirspaceCountryService {
         sizeMB: bytes.length / 1024 / 1024,
         durationMs: stopwatch.elapsedMilliseconds,
       );
-
     } catch (e, stack) {
       LoggingService.error('Failed to download country $countryCode', e, stack);
 
@@ -265,7 +269,9 @@ class AirspaceCountryService {
   ) async {
     final stopwatch = Stopwatch()..start();
 
-    LoggingService.debug('Storing ${features.length} features for country $countryCode');
+    LoggingService.debug(
+      'Storing ${features.length} features for country $countryCode',
+    );
 
     // Store all features for this country
     await _metadataCache.putCountryAirspaces(
@@ -289,7 +295,32 @@ class AirspaceCountryService {
 
     stopwatch.stop();
 
-    LoggingService.debug('Completed storing country $countryCode in ${stopwatch.elapsedMilliseconds}ms');
+    LoggingService.debug(
+      'Completed storing country $countryCode in ${stopwatch.elapsedMilliseconds}ms',
+    );
+  }
+
+  /// Decide whether the server's copy differs from the one already stored.
+  ///
+  /// Prefers ETag, falls back to Last-Modified, and only falls back to age when
+  /// neither side offers a comparable validator. Separated from the HTTP call
+  /// so the branches can be tested directly - it is the intricate part, and
+  /// getting it wrong either re-downloads 13 MB needlessly or leaves stale
+  /// safety data in place.
+  static bool isRemoteNewer({
+    required String? storedEtag,
+    required String? storedLastModified,
+    required String? remoteEtag,
+    required String? remoteLastModified,
+    required int ageInDays,
+  }) {
+    if (remoteEtag != null && storedEtag != null) {
+      return remoteEtag != storedEtag;
+    }
+    if (remoteLastModified != null && storedLastModified != null) {
+      return remoteLastModified != storedLastModified;
+    }
+    return ageInDays > 30;
   }
 
   /// Check if country data needs updating.
@@ -309,8 +340,9 @@ class AirspaceCountryService {
       }
 
       final stored = await _getFetchInfo(countryCode);
-      final ageInDays =
-          DateTime.now().difference(currentData.downloadTime).inDays;
+      final ageInDays = DateTime.now()
+          .difference(currentData.downloadTime)
+          .inDays;
 
       // Data downloaded before validators were recorded has nothing to compare.
       if (stored.etag == null && stored.lastModified == null) {
@@ -331,17 +363,13 @@ class AirspaceCountryService {
         return false;
       }
 
-      final remoteEtag = response.headers['etag'];
-      final remoteLastModified = response.headers['last-modified'];
-
-      final bool changed;
-      if (remoteEtag != null && stored.etag != null) {
-        changed = remoteEtag != stored.etag;
-      } else if (remoteLastModified != null && stored.lastModified != null) {
-        changed = remoteLastModified != stored.lastModified;
-      } else {
-        changed = ageInDays > 30; // No comparable validator - fall back to age
-      }
+      final changed = isRemoteNewer(
+        storedEtag: stored.etag,
+        storedLastModified: stored.lastModified,
+        remoteEtag: response.headers['etag'],
+        remoteLastModified: response.headers['last-modified'],
+        ageInDays: ageInDays,
+      );
 
       LoggingService.structured('COUNTRY_UPDATE_CHECK', {
         'country': countryCode,

--- a/the_paragliding_app/test/airspace_country_source_test.dart
+++ b/the_paragliding_app/test/airspace_country_source_test.dart
@@ -1,0 +1,90 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:the_paragliding_app/services/airspace_country_service.dart';
+
+/// Airspace loading broke because OpenAIP moved their public export bucket, not
+/// because any app code was wrong. The old GCS bucket was switched to Requester
+/// Pays (openAIP/openaip#468) and every anonymous download started returning
+/// HTTP 400 UserProjectMissing, so no country could be downloaded and the map
+/// showed no airspace.
+///
+/// Two tests, deliberately split:
+///
+///  * the offline one guards against the URL being reverted or "tidied" back to
+///    the dead bucket, and runs in the default suite;
+///  * the network one is the only kind of test that can catch the bucket moving
+///    *again* - the code stays correct while the host stops serving. It is
+///    tagged `network` and skipped by default:
+///        flutter test --tags network --run-skipped
+void main() {
+  group('airspace country export URL', () {
+    test('is built from the live OpenAIP export bucket', () {
+      final url = AirspaceCountryService.countryDataUrl('AU');
+
+      expect(url, 'https://storage.openaip.net/openaip-system-exports/au_asp.geojson');
+
+      // The specific failure this file exists to prevent. The old bucket still
+      // resolves and still answers - with HTTP 400 for everyone - so pointing
+      // back at it fails at runtime, not at build time.
+      expect(
+        url,
+        isNot(contains('storage.googleapis.com')),
+        reason: 'The GCS export bucket is Requester Pays since 2026-07-23 and '
+            'returns 400 UserProjectMissing to anonymous clients.',
+      );
+    });
+
+    test('lower-cases the country code to match the published filenames', () {
+      // availableCountries keys are upper case ('AU'); the files are not.
+      expect(AirspaceCountryService.countryDataUrl('NZ'), endsWith('/nz_asp.geojson'));
+      expect(AirspaceCountryService.countryDataUrl('gb'), endsWith('/gb_asp.geojson'));
+    });
+  });
+
+  group('airspace country export bucket', () {
+    test(
+      'serves parseable GeoJSON in the shape the overlay expects',
+      () async {
+        // NZ is the smallest of the supported countries (~1.7 MB).
+        final url = AirspaceCountryService.countryDataUrl('NZ');
+        final response =
+            await http.get(Uri.parse(url)).timeout(const Duration(minutes: 2));
+
+        expect(
+          response.statusCode,
+          200,
+          reason: 'Export bucket did not serve $url. If this is 400 with '
+              'UserProjectMissing, the bucket has been locked down again - see '
+              'openAIP/openaip#468 and #469.',
+        );
+
+        final decoded = jsonDecode(response.body) as Map<String, dynamic>;
+        expect(decoded['type'], 'FeatureCollection');
+
+        final features = decoded['features'] as List<dynamic>;
+        expect(features, isNotEmpty);
+
+        // The fields the airspace overlay actually reads. A file that parses
+        // but has lost these would render nothing, which looks identical to
+        // the outage this test is guarding against.
+        final properties =
+            (features.first as Map<String, dynamic>)['properties']
+                as Map<String, dynamic>;
+        expect(
+          properties.keys,
+          containsAll(
+            <String>['name', 'type', 'icaoClass', 'upperLimit', 'lowerLimit'],
+          ),
+        );
+
+        final geometry = (features.first as Map<String, dynamic>)['geometry']
+            as Map<String, dynamic>;
+        expect(geometry['type'], 'Polygon');
+      },
+      tags: ['network'],
+      timeout: const Timeout(Duration(minutes: 3)),
+    );
+  });
+}

--- a/the_paragliding_app/test/airspace_country_source_test.dart
+++ b/the_paragliding_app/test/airspace_country_source_test.dart
@@ -23,7 +23,10 @@ void main() {
     test('is built from the live OpenAIP export bucket', () {
       final url = AirspaceCountryService.countryDataUrl('AU');
 
-      expect(url, 'https://storage.openaip.net/openaip-system-exports/au_asp.geojson');
+      expect(
+        url,
+        'https://storage.openaip.net/openaip-system-exports/au_asp.geojson',
+      );
 
       // The specific failure this file exists to prevent. The old bucket still
       // resolves and still answers - with HTTP 400 for everyone - so pointing
@@ -31,15 +34,94 @@ void main() {
       expect(
         url,
         isNot(contains('storage.googleapis.com')),
-        reason: 'The GCS export bucket is Requester Pays since 2026-07-23 and '
+        reason:
+            'The GCS export bucket is Requester Pays since 2026-07-23 and '
             'returns 400 UserProjectMissing to anonymous clients.',
       );
     });
 
     test('lower-cases the country code to match the published filenames', () {
       // availableCountries keys are upper case ('AU'); the files are not.
-      expect(AirspaceCountryService.countryDataUrl('NZ'), endsWith('/nz_asp.geojson'));
-      expect(AirspaceCountryService.countryDataUrl('gb'), endsWith('/gb_asp.geojson'));
+      expect(
+        AirspaceCountryService.countryDataUrl('NZ'),
+        endsWith('/nz_asp.geojson'),
+      );
+      expect(
+        AirspaceCountryService.countryDataUrl('gb'),
+        endsWith('/gb_asp.geojson'),
+      );
+    });
+  });
+
+  // The refresh check exists so a country that has not changed is not
+  // re-downloaded - 13 MB for Australia. Getting this wrong is quiet in both
+  // directions: too eager burns the user's data and OpenAIP's egress budget,
+  // too lazy leaves stale airspace on the map, which is safety data.
+  group('isRemoteNewer', () {
+    const anEtag = '"fd64da8f00b7dea96f5b16640be501f8"';
+    const anotherEtag = '"514b4f4cfb4d511f9a7f86874061ee94-3"';
+    const aDate = 'Thu, 06 Aug 2026 01:09:06 GMT';
+    const laterDate = 'Fri, 07 Aug 2026 02:11:00 GMT';
+
+    bool check({
+      String? storedEtag,
+      String? storedLastModified,
+      String? remoteEtag,
+      String? remoteLastModified,
+      int ageInDays = 0,
+    }) => AirspaceCountryService.isRemoteNewer(
+      storedEtag: storedEtag,
+      storedLastModified: storedLastModified,
+      remoteEtag: remoteEtag,
+      remoteLastModified: remoteLastModified,
+      ageInDays: ageInDays,
+    );
+
+    test('matching ETag means no update', () {
+      expect(check(storedEtag: anEtag, remoteEtag: anEtag), isFalse);
+    });
+
+    test('different ETag means an update', () {
+      expect(check(storedEtag: anEtag, remoteEtag: anotherEtag), isTrue);
+    });
+
+    test('ETag wins over Last-Modified when both are available', () {
+      // The daily rebuild moves Last-Modified even when the airspace is
+      // byte-identical, so trusting the date would re-download every day.
+      expect(
+        check(
+          storedEtag: anEtag,
+          remoteEtag: anEtag,
+          storedLastModified: aDate,
+          remoteLastModified: laterDate,
+        ),
+        isFalse,
+      );
+    });
+
+    test('falls back to Last-Modified when no ETag is comparable', () {
+      expect(
+        check(storedLastModified: aDate, remoteLastModified: aDate),
+        isFalse,
+      );
+      expect(
+        check(storedLastModified: aDate, remoteLastModified: laterDate),
+        isTrue,
+      );
+    });
+
+    test('falls back to age when neither validator is comparable', () {
+      // Data stored before validators were recorded, or a server that stops
+      // sending them.
+      expect(check(ageInDays: 3), isFalse);
+      expect(check(ageInDays: 31), isTrue);
+    });
+
+    test('a validator on only one side is not treated as a match', () {
+      // Comparing something against nothing must not silently mean "unchanged".
+      expect(check(remoteEtag: anEtag, ageInDays: 31), isTrue);
+      expect(check(storedEtag: anEtag, ageInDays: 31), isTrue);
+      expect(check(remoteEtag: anEtag, ageInDays: 1), isFalse);
     });
   });
 
@@ -49,13 +131,15 @@ void main() {
       () async {
         // NZ is the smallest of the supported countries (~1.7 MB).
         final url = AirspaceCountryService.countryDataUrl('NZ');
-        final response =
-            await http.get(Uri.parse(url)).timeout(const Duration(minutes: 2));
+        final response = await http
+            .get(Uri.parse(url))
+            .timeout(const Duration(minutes: 2));
 
         expect(
           response.statusCode,
           200,
-          reason: 'Export bucket did not serve $url. If this is 400 with '
+          reason:
+              'Export bucket did not serve $url. If this is 400 with '
               'UserProjectMissing, the bucket has been locked down again - see '
               'openAIP/openaip#468 and #469.',
         );
@@ -74,13 +158,18 @@ void main() {
                 as Map<String, dynamic>;
         expect(
           properties.keys,
-          containsAll(
-            <String>['name', 'type', 'icaoClass', 'upperLimit', 'lowerLimit'],
-          ),
+          containsAll(<String>[
+            'name',
+            'type',
+            'icaoClass',
+            'upperLimit',
+            'lowerLimit',
+          ]),
         );
 
-        final geometry = (features.first as Map<String, dynamic>)['geometry']
-            as Map<String, dynamic>;
+        final geometry =
+            (features.first as Map<String, dynamic>)['geometry']
+                as Map<String, dynamic>;
         expect(geometry['type'], 'Polygon');
       },
       tags: ['network'],


### PR DESCRIPTION
Airspace stopped loading in **every released version** of the app. Nothing in the code was
wrong — OpenAIP moved their public data export bucket and we were still pointing at the old
one.

## Root cause

`airspace_country_service.dart` downloaded country files from a Google Cloud Storage bucket.
Every request now returns:

```
HTTP 400  <Code>UserProjectMissing</Code>
"Bucket is a requester pays bucket but no user project provided."
```

`downloadCountryData()` throws on any non-200, so no country could be downloaded, the local
airspace DB stayed empty, and the map drew nothing.

This was **deliberate and announced upstream**, not a fault on our side:

- **openAIP/openaip#468** (2026-07-25) — maintainer: *"The current lock-down to 'Requester
  Pays' mode was a deliberate action… until we can provide a better way to distribute the
  data without risking getting billed additional 4-figure costs for storage egress by
  irresponsible usage patterns."*
- **openAIP/openaip#469** (2026-08-01) — XCSoar broke the same way. Closing comment: *"The new
  storage is available… The current rate limits are 20 req/s and bursts up to 50."*

The replacement is an S3 endpoint, which XCSoar has already migrated to — that's how it was
found. Verified against the exact files this app requests:

| file | old bucket | new bucket | features |
|---|---|---|---|
| `au_asp.geojson` | 400 | **200**, 12,933,430 B | 1,819 |
| `nz_asp.geojson` | 400 | **200**, 1,724,312 B | 413 |
| `gb_asp.geojson` | 400 | **200**, 5,027,790 B | 1,185 |

Same `FeatureCollection`, same `Polygon` geometry, same property keys, `last-modified` today.
So the parser, local DB, overlay and country selector are all untouched.

## Why whole-country downloads stay, rather than per-viewport fetching

1. **Offline is the point.** Launch sites have no signal and airspace is safety data.
   Per-viewport means no airspace exactly where it matters most.
2. **Per-viewport is the pattern that caused this outage.** A measured viewport query is
   ~250 KiB and fires on every pan/zoom. One country is *one* request against OpenAIP's
   20 req/s budget.
3. It is also the smallest change — the existing architecture was already right.

The REST API works and returns matching counts (AU 1819, NZ 413); it stays a fallback if the
bucket moves again, but it would cost offline support.

## Also fixed, because this was far harder to diagnose than it should have been

- **The error body is now logged.** The server was explaining itself in XML the whole time
  while the code threw a bare `HTTP 400`. This outage would have been self-diagnosing.
- **`checkForUpdate()` now actually works.** It compared against `getCountryMetadata()`, which
  hardcoded `downloadTime: DateTime.now()` — so the age test was always 0 days and it could
  never return true. It now sends a `HEAD` and compares `ETag`/`Last-Modified`: a few hundred
  bytes instead of re-downloading 13 MB. `_storeCountryData()` was already being handed
  `etag` and `lastModified` and silently discarding both; persisting them is what made this
  possible.
- **`CLAUDE.md` corrected.** It documented airspace as coming from `/api/airspaces`. It does
  not, and needs no API key. That mismatch sent this investigation at the API key first —
  while the base map rendering fine appeared to rule the key out. Both misleading, since base
  tiles are OpenStreetMap. The doc now states the two data paths plainly.
- **`dart_test.yaml`** — the `network` skip message named ParaglidingEarth specifically, which
  is now wrong for a second live service.

## Verification

**Both new tests were confirmed to fail against the old URL before being committed** — per the
repo's "prove a regression test fails without the fix" rule:

```
offline: Expected: '...storage.openaip.net/openaip-system-exports/au_asp.geojson'
           Actual: '...storage.googleapis.com/29f98e10-.../au_asp.geojson'

network: Expected: <200>  Actual: <400>
         Export bucket did not serve ... If this is 400 with UserProjectMissing,
         the bucket has been locked down again - see openAIP/openaip#468 and #469.
```

With the fix: offline tests pass in the default suite, and the `network` test downloads the
real NZ file (413 features, correct property keys) in 16s.

- `flutter analyze` — no issues
- `flutter test --concurrency=1` — **162 passed, 17 skipped**
- The malformed `content-encoding: utf-8` the endpoint sends was checked first against the
  real production code path (`http.Request().send()`): Dart only auto-uncompresses gzip, so it
  passes through untouched and **no client change was needed**. Noted in the code, since
  `curl --compressed` *does* fail on it when reproducing by hand.

**Not covered here:** downloading a country through the UI and seeing polygons render — worth
doing on the device before release. The `network` test covers the fetch and parse end of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
