### PR TITLE
Make map tile caching explicit and disk-cache aware

### DIFF
--- a/the_paragliding_app/lib/presentation/screens/data_management_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/data_management_screen.dart
@@ -2229,6 +2229,9 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
                       setState(() {
                         _expansionManager.setState('map_cache', expanded);
                       });
+                      // This tab is kept alive by IndexedStack, so stats loaded once in
+                      // initState() go stale after browsing maps on another tab.
+                      if (expanded) _loadMapCacheStats();
                     },
                     children: [
                       const Text(

--- a/the_paragliding_app/lib/presentation/screens/data_management_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/data_management_screen.dart
@@ -66,6 +66,10 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
   // Airspace refresh key to force widget recreation
   int _airspaceRefreshKey = 0;
 
+  // Map tile cache stats (disk-backed, shared by every map screen)
+  int? _mapCacheTileCount;
+  int? _mapCacheSizeBytes;
+
   // Scroll controller and keys for Premium Maps highlighting
   final ScrollController _scrollController = ScrollController();
   final GlobalKey _premiumMapsKey = GlobalKey();
@@ -115,6 +119,7 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
     _loadBackupDiagnostics();
     _loadCesiumToken();
     _loadPgeSitesStats();
+    _loadMapCacheStats();
     _listenToDownloadProgress();
   }
 
@@ -1091,13 +1096,22 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
   }
 
 
+  Future<void> _loadMapCacheStats() async {
+    final stats = await CacheUtils.getDiskCacheStats();
+    if (!mounted) return;
+    setState(() {
+      _mapCacheTileCount = stats.tileCount;
+      _mapCacheSizeBytes = stats.sizeBytes;
+    });
+  }
+
   Future<void> _clearMapCache() async {
-    final initialTiles = CacheUtils.getCurrentCacheCount();
-    final initialSize = CacheUtils.getCurrentCacheSize();
-    
+    final initialTiles = _mapCacheTileCount ?? 0;
+    final initialSize = _mapCacheSizeBytes ?? 0;
+
     final confirmed = await _showConfirmationDialog(
       'Clear Map Cache',
-      'This will clear all cached map tiles.\n\n'
+      'This will clear all cached map tiles for every map screen.\n\n'
       'Maps will need to re-download tiles when viewed.',
     );
 
@@ -1112,27 +1126,16 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
     });
     final stopwatch = Stopwatch()..start();
 
-    CacheUtils.clearMapCache();
+    await CacheUtils.clearDiskTileCache();
+    await _loadMapCacheStats();
 
-    // Give the system a moment to update cache stats
-    await Future.delayed(const Duration(milliseconds: 100));
-    
-    final finalTiles = CacheUtils.getCurrentCacheCount();
-    final finalSize = CacheUtils.getCurrentCacheSize();
-    final freedBytes = initialSize - finalSize;
-    
     LoggingService.performance('Clear map cache', stopwatch.elapsed, 'cache clearing completed');
     LoggingService.summary('CLEAR_MAP_CACHE', {
-      'tiles_cleared': initialTiles - finalTiles,
-      'bytes_freed': freedBytes,
+      'tiles_cleared': initialTiles - (_mapCacheTileCount ?? 0),
+      'bytes_freed': initialSize - (_mapCacheSizeBytes ?? 0),
       'initial_tiles': initialTiles,
-      'final_tiles': finalTiles,
       'duration_ms': stopwatch.elapsedMilliseconds,
     });
-    
-    if (mounted) {
-      setState(() {}); // Refresh display
-    }
 
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -2217,7 +2220,9 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
                   AppExpansionCard.dataManagement(
                     icon: Icons.map,
                     title: 'Map Tile Cache',
-                    subtitle: '${CacheUtils.getCurrentCacheCount()} tiles • ${CacheUtils.formatBytes(CacheUtils.getCurrentCacheSize())}',
+                    subtitle: _mapCacheSizeBytes == null
+                        ? 'Loading…'
+                        : '$_mapCacheTileCount tiles • ${CacheUtils.formatBytes(_mapCacheSizeBytes!)}',
                     expansionKey: 'map_cache',
                     expansionManager: _expansionManager,
                     onExpansionChanged: (expanded) {
@@ -2227,7 +2232,9 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
                     },
                     children: [
                       const Text(
-                        'Map tiles are cached when first used to improve map performance. Clear the Map Cache to free up storage space.',
+                        'Map tiles are cached on-device across all map screens (sites, edit site, '
+                        'flight track) and persist between app restarts. Clear the cache to free up '
+                        'storage space or force fresh tiles.',
                         style: TextStyle(color: Colors.grey, fontSize: 12),
                       ),
                       const SizedBox(height: 16),
@@ -2235,11 +2242,11 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
                         rows: [
                           AppStatRow.dataManagement(
                             label: 'Cached Tiles',
-                            value: CacheUtils.getCurrentCacheCount().toString(),
+                            value: (_mapCacheTileCount ?? 0).toString(),
                           ),
                           AppStatRow.dataManagement(
                             label: 'Cache Size',
-                            value: CacheUtils.formatBytes(CacheUtils.getCurrentCacheSize()),
+                            value: CacheUtils.formatBytes(_mapCacheSizeBytes ?? 0),
                           ),
                         ],
                         padding: EdgeInsets.zero,
@@ -2248,7 +2255,7 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
                       SizedBox(
                         width: double.infinity,
                         child: OutlinedButton.icon(
-                          onPressed: CacheUtils.getCurrentCacheCount() > 0 ? _clearMapCache : null,
+                          onPressed: (_mapCacheTileCount ?? 0) > 0 ? _clearMapCache : null,
                           icon: const Icon(Icons.cleaning_services),
                           label: const Text('Clear Map Cache'),
                           style: OutlinedButton.styleFrom(

--- a/the_paragliding_app/lib/presentation/screens/data_management_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/data_management_screen.dart
@@ -2238,20 +2238,6 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
                         style: TextStyle(color: Colors.grey, fontSize: 12),
                       ),
                       const SizedBox(height: 16),
-                      AppStatRowGroup.dataManagement(
-                        rows: [
-                          AppStatRow.dataManagement(
-                            label: 'Cached Tiles',
-                            value: (_mapCacheTileCount ?? 0).toString(),
-                          ),
-                          AppStatRow.dataManagement(
-                            label: 'Cache Size',
-                            value: CacheUtils.formatBytes(_mapCacheSizeBytes ?? 0),
-                          ),
-                        ],
-                        padding: EdgeInsets.zero,
-                      ),
-                      const SizedBox(height: 16),
                       SizedBox(
                         width: double.infinity,
                         child: OutlinedButton.icon(

--- a/the_paragliding_app/lib/utils/cache_utils.dart
+++ b/the_paragliding_app/lib/utils/cache_utils.dart
@@ -1,48 +1,49 @@
-import 'package:flutter/painting.dart';
+import 'dart:io';
 
-/// Utility functions for managing map tile caching
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import 'map_tile_provider.dart';
+
+/// Utility functions for inspecting and clearing the on-disk map tile cache
+/// shared by every map screen (see [MapTileProvider]).
 class CacheUtils {
-  /// Get information about the current image cache state
-  static String getCacheInfo() {
-    final cache = PaintingBinding.instance.imageCache;
-    final sizeInMB = (cache.currentSizeBytes / (1024 * 1024)).toStringAsFixed(1);
-    return '${cache.currentSize} tiles, $sizeInMB MB';
+  static const _sizeMonitorFileName = 'sizeMonitor.bin';
+
+  /// Directory flutter_map's built-in caching provider writes tiles to.
+  static Future<Directory> _cacheDirectory() async {
+    final cacheDir = await getApplicationCacheDirectory();
+    return Directory(p.join(cacheDir.path, 'fm_cache'));
   }
-  
-  /// Clear all cached map tiles
-  static void clearMapCache() {
-    final cache = PaintingBinding.instance.imageCache;
-    cache.clear();
-    cache.clearLiveImages();
+
+  /// Number of cached tiles and their total size on disk.
+  /// Returns zero for both if no map has been viewed yet.
+  static Future<({int tileCount, int sizeBytes})> getDiskCacheStats() async {
+    final dir = await _cacheDirectory();
+    if (!await dir.exists()) return (tileCount: 0, sizeBytes: 0);
+
+    var tileCount = 0;
+    var sizeBytes = 0;
+    await for (final entity in dir.list()) {
+      if (entity is! File) continue;
+      if (p.basename(entity.path) == _sizeMonitorFileName) continue;
+      tileCount++;
+      sizeBytes += await entity.length();
+    }
+    return (tileCount: tileCount, sizeBytes: sizeBytes);
   }
-  
-  /// Get the current cache size in bytes
-  static int getCurrentCacheSize() {
-    return PaintingBinding.instance.imageCache.currentSizeBytes;
+
+  /// Delete every cached tile. The shared caching provider re-initialises
+  /// itself (with the same config) the next time any map loads a tile.
+  static Future<void> clearDiskTileCache() async {
+    await MapTileProvider.cachingProvider.destroy(deleteCache: true);
   }
-  
-  /// Get the current number of cached tiles
-  static int getCurrentCacheCount() {
-    return PaintingBinding.instance.imageCache.currentSize;
-  }
-  
+
   /// Format bytes into human-readable units
   static String formatBytes(int bytes) {
     if (bytes < 1024) return '$bytes B';
     if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
     if (bytes < 1024 * 1024 * 1024) return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
     return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(2)} GB';
-  }
-  
-  /// Get detailed cache statistics
-  static Map<String, dynamic> getCacheStats() {
-    final cache = PaintingBinding.instance.imageCache;
-    return {
-      'tileCount': cache.currentSize,
-      'sizeBytes': cache.currentSizeBytes,
-      'sizeFormatted': formatBytes(cache.currentSizeBytes),
-      'maxSizeBytes': cache.maximumSizeBytes,
-      'maxSize': cache.maximumSize,
-    };
   }
 }

--- a/the_paragliding_app/lib/utils/map_tile_provider.dart
+++ b/the_paragliding_app/lib/utils/map_tile_provider.dart
@@ -4,21 +4,37 @@ import 'package:flutter_map/flutter_map.dart';
 import '../services/logging_service.dart';
 
 /// Unified tile provider for all Flutter Map instances in the app.
-/// Provides consistent caching and debug logging across all map screens.
+///
+/// Every map screen (nearby sites, edit site, flight track) goes through
+/// [createInstance], so they all share one [BuiltInMapCachingProvider] -
+/// flutter_map's disk-backed tile cache, persisted at
+/// `<ApplicationCacheDirectory>/fm_cache` and surviving app restarts. That
+/// provider is a process-wide singleton that only respects configuration
+/// (like [maxCacheSizeBytes]) the first time it's created, so it's
+/// configured explicitly here rather than left to whichever screen happens
+/// to load a tile first. See `CacheUtils` for inspecting/clearing it.
 class MapTileProvider {
-  /// Standard headers for all tile requests with reasonable caching
+  /// Cap for the shared on-disk tile cache. 300 MB comfortably covers a
+  /// season of OSM/satellite tiles across all map screens without letting
+  /// an unbounded cache eat into a phone's storage.
+  static const int maxCacheSizeBytes = 300 * 1024 * 1024;
+
   static Map<String, String> get _standardHeaders => {
     'User-Agent': 'TheParaglidingApp/1.0',
-    'Cache-Control': 'max-age=86400', // 24 hours cache
   };
-  
+
+  static BuiltInMapCachingProvider get cachingProvider =>
+      BuiltInMapCachingProvider.getOrCreateInstance(
+        maxCacheSize: maxCacheSizeBytes,
+      );
+
   /// Create a new tile provider instance.
   /// Returns debug provider in debug mode, standard provider in release.
-  /// Each instance shares the same caching via Flutter Map's internal cache.
+  /// Each instance shares the same on-disk cache (see class doc).
   static TileProvider createInstance() {
-    return kDebugMode 
-        ? _DebugNetworkTileProvider(headers: _standardHeaders)
-        : NetworkTileProvider(headers: _standardHeaders);
+    return kDebugMode
+        ? _DebugNetworkTileProvider(headers: _standardHeaders, cachingProvider: cachingProvider)
+        : NetworkTileProvider(headers: _standardHeaders, cachingProvider: cachingProvider);
   }
   
   /// Get error callback for debug mode tile error logging
@@ -31,7 +47,7 @@ class MapTileProvider {
 
 /// Debug tile provider that logs network requests for development
 class _DebugNetworkTileProvider extends NetworkTileProvider {
-  _DebugNetworkTileProvider({super.headers});
+  _DebugNetworkTileProvider({super.headers, super.cachingProvider});
   
   @override
   ImageProvider getImage(TileCoordinates coordinates, TileLayer options) {


### PR DESCRIPTION
## Summary
- All map screens (sites, edit site, flight track) already shared flutter_map's built-in disk-backed tile cache (a process-wide `BuiltInMapCachingProvider` singleton, `<ApplicationCacheDirectory>/fm_cache`) but nothing in the app configured or exposed it.
- The Data Management "Map Tile Cache" card previously read/cleared `PaintingBinding.imageCache` (Flutter's small in-memory decode cache) — which does nothing to the real, persistent, cross-screen tile cache on disk.
- `MapTileProvider` now explicitly configures the shared caching provider with a 300 MB cap instead of leaving it to whichever screen loads a tile first, and drops a `Cache-Control` request header that had no effect on the cache's actual freshness logic.
- `CacheUtils` now reports and clears the real on-disk cache. Data Management's card loads real stats asynchronously and its Clear button now actually frees the persistent cache. Removed the redundant tile-count/size stat rows from the card body since the subtitle already shows the same summary.

## Test plan
- [x] `flutter analyze` clean (changed files + full project)
- [x] Verified on Linux desktop: `fm_cache` on disk populated with real tile files during a session
- [x] Verified cache **reuse** across a full process restart — snapshotted mtimes of 6 tile files, killed and relaunched the app, confirmed those files' mtimes were unchanged (served from disk, not re-fetched) while ~50 genuinely new tiles were added
- [x] Confirmed Data Management card now shows real, matching figures (775 tiles / 11.68 MB) instead of the old near-zero in-memory reading
- [ ] Final check running on a Pixel 9 device (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)