### PR TITLE
Give "airspace on" a single source of truth, defaulting to on

### DIFF
--- a/the_paragliding_app/lib/presentation/screens/nearby_sites_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/nearby_sites_screen.dart
@@ -94,7 +94,10 @@ class NearbySitesScreenState extends State<NearbySitesScreen> with WidgetsBindin
 
   // Preference keys for filter states
   static const String _sitesEnabledKey = 'nearby_sites_sites_enabled';
-  static const String _airspaceEnabledKey = 'nearby_sites_airspace_enabled';
+  // No airspace key here on purpose: OpenAipService.isAirspaceEnabled() is the
+  // single source of truth for whether airspace is drawn. This screen once kept
+  // its own copy defaulting to true while the service defaulted to false, which
+  // showed a ticked box over an empty map.
   static const String _forecastEnabledKey = 'nearby_sites_forecast_enabled';
   static const String _weatherStationsEnabledKey = 'nearby_sites_weather_stations_enabled';
 
@@ -361,7 +364,10 @@ class NearbySitesScreenState extends State<NearbySitesScreen> with WidgetsBindin
     try {
       final prefs = await SharedPreferences.getInstance();
       final sitesEnabled = prefs.getBool(_sitesEnabledKey) ?? true;
-      final airspaceEnabled = prefs.getBool(_airspaceEnabledKey) ?? true;
+      // From OpenAipService, not a local key. This screen used to keep its own
+      // copy defaulting to true while the service defaulted to false, so the
+      // checkbox read "on" while the map never drew any airspace.
+      final airspaceEnabled = await _openAipService.isAirspaceEnabled();
       final forecastEnabled = prefs.getBool(_forecastEnabledKey) ?? true;
       final weatherStationsEnabled = prefs.getBool(_weatherStationsEnabledKey) ?? true;
       final metarEnabled = prefs.getBool('weather_provider_${WeatherStationSource.awcMetar.name}_enabled') ?? true;
@@ -1463,7 +1469,9 @@ class NearbySitesScreenState extends State<NearbySitesScreen> with WidgetsBindin
       // Save the enabled states to preferences
       final prefs = await SharedPreferences.getInstance();
       await prefs.setBool(_sitesEnabledKey, sitesEnabled);
-      await prefs.setBool(_airspaceEnabledKey, airspaceEnabled);
+      // Airspace deliberately absent: OpenAipService owns that flag and is
+      // written below via setAirspaceEnabled(). A second copy here is exactly
+      // what let the checkbox and the map disagree.
       await prefs.setBool(_forecastEnabledKey, forecastEnabled);
       await prefs.setBool(_weatherStationsEnabledKey, weatherStationsEnabled);
       await prefs.setBool('weather_provider_${WeatherStationSource.awcMetar.name}_enabled', metarEnabled);

--- a/the_paragliding_app/lib/services/openaip_service.dart
+++ b/the_paragliding_app/lib/services/openaip_service.dart
@@ -48,9 +48,18 @@ class OpenAipService {
   // Airspace clipping preference
   static const String _airspaceClippingEnabledKey = 'openaip_airspace_clipping_enabled';
 
+  // The Sites screen used to keep its own copy of the airspace on/off flag.
+  // Retained only so the value can be migrated across; nothing reads it now.
+  static const String _legacyNearbySitesAirspaceKey = 'nearby_sites_airspace_enabled';
+
+  // Set once the legacy key has been reconciled with _airspaceEnabledKey.
+  static const String _airspaceEnabledMigratedKey = 'openaip_airspace_enabled_migrated';
+
   // Default values
   static const double _defaultOpacity = 0.15; // 15% optimal for airspace visibility
-  static const bool _defaultAirspaceEnabled = false;
+  // On by default: airspace is safety information, and a pilot who has gone to
+  // the trouble of downloading a country expects to see it.
+  static const bool _defaultAirspaceEnabled = true;
   static const bool _defaultClippingEnabled = true; // Default to enabled for backwards compatibility
 
   // Default airspace type exclusions (false = include/show, true = exclude/hide)
@@ -134,14 +143,46 @@ class OpenAipService {
   
   // Layer Visibility Management
   
-  /// Get visibility state for airspace layer
+  /// Whether the airspace overlay should be drawn.
+  ///
+  /// The single source of truth. The Sites screen used to keep a second copy
+  /// under its own key which defaulted to true, while this one defaulted to
+  /// false - so a fresh install showed a ticked "Airspace" box over a map that
+  /// drew none, and the only escape was to un-tick and re-tick the filter.
+  ///
+  /// Deliberately does not write on read. Persisting the default the first time
+  /// anything asked is what made that bug outlive a change of default: every
+  /// install already had `false` on disk.
   Future<bool> isAirspaceEnabled() async {
     final prefs = await SharedPreferences.getInstance();
-    if (!prefs.containsKey(_airspaceEnabledKey)) {
-      await prefs.setBool(_airspaceEnabledKey, _defaultAirspaceEnabled);
-      return _defaultAirspaceEnabled;
-    }
+    await _migrateLegacyAirspaceEnabled(prefs);
     return prefs.getBool(_airspaceEnabledKey) ?? _defaultAirspaceEnabled;
+  }
+
+  /// Reconcile the Sites screen's old copy of the flag with this one, once.
+  ///
+  /// Upgrading installs cannot simply adopt the new default: the old read-time
+  /// write means they already have `false` stored, so changing the default alone
+  /// would leave every existing user exactly as broken as before.
+  ///
+  /// The legacy value is what the checkbox actually showed the pilot, so it is
+  /// the better record of intent - someone who deliberately un-ticked airspace
+  /// keeps it off. Only installs with no legacy value adopt the new default.
+  Future<void> _migrateLegacyAirspaceEnabled(SharedPreferences prefs) async {
+    if (prefs.getBool(_airspaceEnabledMigratedKey) == true) return;
+
+    final legacy = prefs.getBool(_legacyNearbySitesAirspaceKey);
+    final resolved = legacy ?? _defaultAirspaceEnabled;
+
+    await prefs.setBool(_airspaceEnabledKey, resolved);
+    await prefs.remove(_legacyNearbySitesAirspaceKey);
+    await prefs.setBool(_airspaceEnabledMigratedKey, true);
+
+    LoggingService.structured('AIRSPACE_ENABLED_MIGRATED', {
+      'legacy_value': legacy,
+      'resolved': resolved,
+      'source': legacy == null ? 'new_default' : 'legacy_checkbox',
+    });
   }
   
   /// Set visibility state for airspace layer

--- a/the_paragliding_app/test/airspace_enabled_migration_test.dart
+++ b/the_paragliding_app/test/airspace_enabled_migration_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:the_paragliding_app/services/openaip_service.dart';
+
+/// Whether airspace is drawn used to be stored twice, with opposite defaults:
+///
+///   nearby_sites_airspace_enabled  (Sites screen)   default TRUE  -> the checkbox
+///   openaip_airspace_enabled       (OpenAipService) default FALSE -> the renderer
+///
+/// So a fresh install showed a ticked "Airspace" box over a map that never drew
+/// any, and the only escape was to un-tick and re-tick the filter - which is
+/// exactly what a user hit after downloading 1,819 Australian airspaces and
+/// seeing nothing.
+///
+/// OpenAipService is now the single source of truth, defaulting to on. These
+/// tests cover the migration, because simply changing the default is not enough:
+/// the old code persisted the default the first time anything read it, so every
+/// existing install already has `false` written to disk.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const serviceKey = 'openaip_airspace_enabled';
+  const legacyKey = 'nearby_sites_airspace_enabled';
+  const migratedKey = 'openaip_airspace_enabled_migrated';
+
+  group('airspace enabled migration', () {
+    test('a fresh install defaults to on', () async {
+      SharedPreferences.setMockInitialValues({});
+
+      expect(await OpenAipService.instance.isAirspaceEnabled(), isTrue);
+    });
+
+    test(
+      'the reported bug: ticked checkbox, renderer off, resolves to on',
+      () async {
+        // The exact state that produced "the toggle was checked but no airspace
+        // displayed" - and the state every upgrading install is in.
+        SharedPreferences.setMockInitialValues({
+          legacyKey: true,
+          serviceKey: false,
+        });
+
+        expect(await OpenAipService.instance.isAirspaceEnabled(), isTrue);
+      },
+    );
+
+    test('a deliberate opt-out is preserved', () async {
+      // Un-ticking the box is the only way the legacy key becomes false, so it
+      // is a real choice and must survive the migration.
+      SharedPreferences.setMockInitialValues({
+        legacyKey: false,
+        serviceKey: false,
+      });
+
+      expect(await OpenAipService.instance.isAirspaceEnabled(), isFalse);
+    });
+
+    test('the legacy key is removed once migrated', () async {
+      SharedPreferences.setMockInitialValues({legacyKey: true});
+
+      await OpenAipService.instance.isAirspaceEnabled();
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.containsKey(legacyKey), isFalse);
+      expect(prefs.getBool(migratedKey), isTrue);
+      expect(prefs.getBool(serviceKey), isTrue);
+    });
+
+    test('migration does not re-run and overwrite a later choice', () async {
+      // Turning airspace off after upgrading must stick. If the migration fired
+      // again it would resurrect the legacy value on the next read.
+      SharedPreferences.setMockInitialValues({legacyKey: true});
+      final service = OpenAipService.instance;
+
+      expect(await service.isAirspaceEnabled(), isTrue);
+
+      await service.setAirspaceEnabled(false);
+      expect(await service.isAirspaceEnabled(), isFalse);
+      expect(await service.isAirspaceEnabled(), isFalse);
+    });
+
+    test('reading does not persist the default', () async {
+      // The old read-time write is why changing the default could not fix
+      // existing installs on its own. A read must stay a read.
+      SharedPreferences.setMockInitialValues({migratedKey: true});
+
+      await OpenAipService.instance.isAirspaceEnabled();
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(
+        prefs.containsKey(serviceKey),
+        isFalse,
+        reason: 'isAirspaceEnabled() wrote the default to disk on a plain read',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Found while testing #317: after downloading 1,819 Australian airspaces, the map showed
nothing — with the "Airspace" box already ticked. Un-ticking and re-ticking it made 135
airspaces appear instantly.

## Cause

Whether airspace is drawn was stored **twice, with opposite defaults**:

| key | default | drives |
|---|---|---|
| `nearby_sites_airspace_enabled` (`nearby_sites_screen.dart:97,118`) | **true** | the checkbox |
| `openaip_airspace_enabled` (`openaip_service.dart:39,53`) | **false** | `AirspaceOverlayManager:123`, which decides whether to fetch |

`AirspaceOverlayManager` gates on the service key, found `false`, and returned early —
`AIRSPACE_FETCH_START` was never reached, so nothing in the logs even hinted that airspace
had been asked for. Confirmed from the session log: `AIRSPACE_FETCH_START` appears **twice in
five minutes**, both immediately after the toggle, and there were **zero** debounce or
cancellation events, ruling out a race.

`setAirspaceEnabled()` is reached *only* by applying the Map Filter dialog, so a toggle was
the one way to reconcile the two.

## Fix

`OpenAipService` owns the flag outright. The Sites screen reads it instead of keeping a copy,
and no longer writes one on apply. Default is now **on** — airspace is safety information,
and someone who downloaded a country expects to see it.

**Changing the default alone would have fixed nothing**, which is the subtle part.
`isAirspaceEnabled()` used to *persist* the default the first time anything read it, so every
existing install already has `false` on disk and would keep it forever. Two changes handle
that:

- reading no longer writes, so a default stays a default;
- a one-time migration adopts the legacy value where one exists. That value is what the
  checkbox actually showed the pilot, so it is the better record of intent — un-ticking the
  box is the only way it becomes `false`, and that choice survives. Installs with no legacy
  value take the new default.

## Verification

**Five of the six new tests were confirmed to fail against the old behaviour** before being
committed, per the repo's "prove a regression test fails without the fix" rule:

```
a fresh install defaults to on                              Expected: true   Actual: <false>
the reported bug: ticked checkbox, renderer off → on        Expected: true   Actual: <false>
the legacy key is removed once migrated                     Expected: false  Actual: <true>
migration does not re-run and overwrite a later choice      Expected: true   Actual: <false>
reading does not persist the default                        Expected: false  Actual: <true>
```

The sixth — "a deliberate opt-out is preserved" — passes either way by design, since `false`
stays `false`. Worth keeping so a future change cannot start overriding people who turned
airspace off on purpose.

**On Linux, against real preferences** carrying the exact broken state:

```
+3.0s  [AIRSPACE_ENABLED_MIGRATED] legacy_value=true | resolved=true | source=legacy_checkbox
+3.8s  [AIRSPACE_FETCH_START]
+5.4s  [SPATIAL_INDEX_QUERY] Found 36 geometries in bounds
+5.6s  [AIRSPACE] Loaded 114 airspaces in 1809ms
+5.6s  nearby_sites: Loaded 1 airspace layers
```

Airspace renders on startup with no user interaction, where before it was `Loaded 0 airspace
layers` indefinitely.

- `flutter analyze` — no issues
- `flutter test --concurrency=1` — **166 passed, 16 skipped**

## Note on the diff

`dart format` wanted to reformat both touched files wholesale (~1,000 lines on
`nearby_sites_screen.dart`), which would have buried a 58-line change. I reverted that and
kept the surrounding formatting as-is, so the diff shows only the actual change.

Independent of #317 and branched from `main`; they touch different files and can land in
either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
