### PR TITLE
Release 1.0.6+18

### DIFF
--- a/distribution/whatsnew/whatsnew-en-GB
+++ b/distribution/whatsnew/whatsnew-en-GB
@@ -1,2 +1,6 @@
-• When you add a Cesium Ion access token, the box no longer shows greyed-out
-  sample text that looked like a key had already been entered
+• Airspace downloads work again. OpenAIP moved their data server in July, which
+  stopped every country download; the app now uses the new one
+• Downloaded airspace appears straight away. It could previously stay hidden
+  behind an already-ticked Airspace box until you switched the filter off and on
+• Map Tile Cache in Data Management now shows how much map data is really stored
+  on your device, and clearing it frees that space

--- a/the_paragliding_app/pubspec.yaml
+++ b/the_paragliding_app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.5+17
+version: 1.0.6+18
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
Version bump and release notes for the next Play internal-track release.

`1.0.5+17` → `1.0.6+18`. versionCode 18 because 17 is published; versionName 1.0.6 because
the release carries user-visible change — the rule in `GOOGLE_PLAY_DEPLOYMENT.md`, which
exists because builds 5 through 11 all shipped as `1.0.2`.

## What ships

Three user-visible changes since `v1.0.5+17`:

- **#317** — airspace downloads work again. OpenAIP switched their public export bucket to
  Requester Pays in late July, so every country download returned `400 UserProjectMissing`.
  This broke airspace in **every released version**, not just the last one.
- **#319** — downloaded airspace now appears without toggling the filter. Two preferences
  disagreed about whether the layer was on, so the box could read ticked over an empty map.
- **#318** — the Map Tile Cache card in Data Management reports and clears the real on-disk
  cache instead of Flutter's in-memory decode cache.

## Release notes

```
• Airspace downloads work again. OpenAIP moved their data server in July, which
  stopped every country download; the app now uses the new one
• Downloaded airspace appears straight away. It could previously stay hidden
  behind an already-ticked Airspace box until you switched the filter off and on
• Map Tile Cache in Data Management now shows how much map data is really stored
  on your device, and clearing it frees that space
```

**433 characters**, against Play's 500.

Worth noting the margin is real rather than lucky: the file is 439 *bytes*, because the `•`
bullets are 3 bytes each. The length gate added in #315 counts characters (`wc -m`), which is
what Play actually limits — the earlier byte-based version would have been measuring the
wrong thing.

## Claim checking

Each bullet was verified against the code rather than taken from a commit message, after a
release note earlier in this series described a fix that never happened:

| claim | checked against |
|---|---|
| airspace downloads work | live bucket + real app: 1,819 AU airspaces downloaded and stored |
| airspace appears without toggling | Linux run: migration at +3.0s, 114 airspaces rendered by +5.6s, no interaction |
| tile cache card reports real storage | `cache_utils.dart:14-22` now reads `<ApplicationCacheDirectory>/fm_cache` |

**Deliberately not claimed:** that map tiles are "now cached". flutter_map 8 already cached
them to disk via a process-wide `BuiltInMapCachingProvider`; #318 configured that cache
(300 MB cap) and fixed what the card *reported*. "Tiles are now cached" would have been
false.

## Verification

- `flutter analyze` — no issues
- `flutter test --concurrency=1` — **174 passed, 17 skipped**
- versionCode 18 exceeds every existing `v*` tag (highest is `v1.0.5+17`)

After merge this needs a tag to publish:

```bash
git switch main && git pull
git tag -a v1.0.6+18 -m "Release 1.0.6+18" && git push origin v1.0.6+18
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
