### PR TITLE
Release 1.0.6+18

### DIFF
--- a/distribution/whatsnew/whatsnew-en-GB
+++ b/distribution/whatsnew/whatsnew-en-GB
@@ -1,2 +1,6 @@
-• When you add a Cesium Ion access token, the box no longer shows greyed-out
-  sample text that looked like a key had already been entered
+• Airspace downloads work again. OpenAIP moved their data server in July, which
+  stopped every country download; the app now uses the new one
+• Downloaded airspace appears straight away. It could previously stay hidden
+  behind an already-ticked Airspace box until you switched the filter off and on
+• Map Tile Cache in Data Management now shows how much map data is really stored
+  on your device, and clearing it frees that space

--- a/the_paragliding_app/pubspec.yaml
+++ b/the_paragliding_app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.5+17
+version: 1.0.6+18
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
## Summary
Bumps `pubspec.yaml` to 1.0.6+18 and updates the Play release notes. Cherry-picked
from the already-prepared `chore/release-1.0.6-18` branch (`de99c69`) onto current
`main`, which now also includes the FlightTrack2D rapid-rebuild fix (#321) - a
dev-only diagnostic fix, invisible to users, so it needs no release-note line.

Covers everything shipped since v1.0.5+17:
- OpenAIP airspace bucket-move fix (#317)
- "Airspace on" single-source-of-truth fix (#319)
- Map Tile Cache stats/UI cleanup (#318)
- FlightTrack2D rebuild-warning fix (#321, dev-only)

## Test plan
- [x] `flutter analyze` - clean (version/text-only change, no code touched)
- [x] Diff verified: only `pubspec.yaml` version bump + `whatsnew-en-GB` release notes changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)