### PR TITLE
Cover the v3 -> v4 upgrade, and let it run twice

### DIFF
--- a/the_paragliding_app/lib/data/datasources/database_helper.dart
+++ b/the_paragliding_app/lib/data/datasources/database_helper.dart
@@ -456,8 +456,24 @@ class DatabaseHelper {
       if (oldVersion < 4) {
         LoggingService.database(
             'MIGRATE', 'Applying migration v3 -> v4: pge_site_id -> catalog_site_id');
+
+        // Rename only if the old column is still there. Unconditionally, this
+        // throws on a database where the rename has already been applied, and
+        // because _onUpgrade rethrows the whole open fails - leaving an app
+        // that cannot reach the user's flight log at all, on every launch.
+        // A released install always still has pge_site_id, so this guard is
+        // not on the user's path; it exists so that one anomalous database
+        // costs a skipped statement rather than the entire log.
+        final columns = await db.rawQuery('PRAGMA table_info(sites)');
+        final hasOldColumn = columns.any((c) => c['name'] == 'pge_site_id');
+
         await db.execute('DROP INDEX IF EXISTS idx_sites_pge_site_id');
-        await db.execute('ALTER TABLE sites RENAME COLUMN pge_site_id TO catalog_site_id');
+        if (hasOldColumn) {
+          await db.execute('ALTER TABLE sites RENAME COLUMN pge_site_id TO catalog_site_id');
+        } else {
+          LoggingService.database(
+              'MIGRATE', 'sites.pge_site_id already renamed; skipping the rename');
+        }
         await db.execute(
             'CREATE INDEX IF NOT EXISTS idx_sites_catalog_site_id ON sites(catalog_site_id)');
 

--- a/the_paragliding_app/test/catalog_site_id_migration_test.dart
+++ b/the_paragliding_app/test/catalog_site_id_migration_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:the_paragliding_app/data/datasources/database_helper.dart';
+
+import 'helpers/test_helpers.dart';
+
+/// Covers the v3 -> v4 migration, which renames `sites.pge_site_id` to
+/// `catalog_site_id` on every existing install.
+///
+/// This drives the real `openDatabase(version:, onUpgrade:)` path rather than
+/// calling the migration directly, which is the whole point. Calling
+/// `_onUpgrade` by hand - the shape `duration_backfill_test.dart` uses - proves
+/// the SQL runs, but cannot prove sqflite then *records* the new version. If it
+/// does not, the rename succeeds on first launch and the identical rename is
+/// attempted again on the next one, against a column that no longer exists.
+/// That throws, `_onUpgrade` rethrows, and the database fails to open: the app
+/// is unusable and the user's flight log is unreachable.
+///
+/// A Pixel 9 was found in exactly that end state - `user_version` 3, yet
+/// `catalog_site_id` and its index already present - which is what this test
+/// exists to rule in or out. The reopen at the end is the assertion that
+/// matters; everything before it is setup.
+void main() {
+  /// The v3 `sites` table as released in v1.0.6+18, reproduced verbatim.
+  ///
+  /// Duplicating schema in a test usually invites drift, but a shipped schema
+  /// is frozen by definition - this is what is on users' phones, and it must
+  /// never be updated to match current `_onCreate`. That is the state the
+  /// migration has to cope with.
+  const v3SitesTable = '''
+      CREATE TABLE sites (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        latitude REAL NOT NULL,
+        longitude REAL NOT NULL,
+        altitude REAL,
+        country TEXT,
+        custom_name INTEGER DEFAULT 0,
+        pge_site_id INTEGER,
+        is_favorite INTEGER DEFAULT 0,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP
+      )
+    ''';
+
+  late String dbPath;
+  String? previousOverride;
+
+  setUp(() async {
+    await TestHelpers.initializeDatabaseForTesting();
+    previousOverride = DatabaseHelper.databasePathOverride;
+
+    // A file, not `inMemoryDatabasePath`: an in-memory database is discarded on
+    // close, and this test has to close one and open it again to see whether
+    // the recorded version survived.
+    dbPath = TestHelpers.fixturePath(
+        'v3_upgrade_${DateTime.now().microsecondsSinceEpoch}.db');
+    await deleteDatabase(dbPath);
+
+    // Release the singleton's memoised connection before repointing it.
+    await DatabaseHelper.instance.close();
+    DatabaseHelper.databasePathOverride = dbPath;
+  });
+
+  tearDown(() async {
+    await DatabaseHelper.instance.close();
+    DatabaseHelper.databasePathOverride = previousOverride;
+    await deleteDatabase(dbPath);
+  });
+
+  /// Build a pre-federation install: schema at v3, holding a linked site.
+  Future<void> createV3Database({int pgeSiteId = 4632}) async {
+    final db = await openDatabase(
+      dbPath,
+      version: 3,
+      onCreate: (db, version) async {
+        await db.execute(v3SitesTable);
+        await db.execute(
+            'CREATE INDEX IF NOT EXISTS idx_sites_pge_site_id ON sites(pge_site_id)');
+        await db.insert('sites', {
+          'name': 'Mt Borah',
+          'latitude': -30.6789,
+          'longitude': 150.609,
+          'pge_site_id': pgeSiteId,
+          'created_at': DateTime.now().toIso8601String(),
+        });
+      },
+    );
+
+    // Guard the fixture itself: if this is not really a v3 database holding the
+    // old column, the test below proves nothing.
+    expect(await db.getVersion(), 3);
+    final columns = await db.rawQuery('PRAGMA table_info(sites)');
+    expect(columns.map((c) => c['name']), contains('pge_site_id'));
+    await db.close();
+  }
+
+  Future<List<String>> sitesColumns(Database db) async =>
+      (await db.rawQuery('PRAGMA table_info(sites)'))
+          .map((c) => c['name'] as String)
+          .toList();
+
+  test('renames pge_site_id to catalog_site_id, keeping the link', () async {
+    await createV3Database(pgeSiteId: 4632);
+
+    final db = await DatabaseHelper.instance.database;
+
+    final columns = await sitesColumns(db);
+    expect(columns, contains('catalog_site_id'));
+    expect(columns, isNot(contains('pge_site_id')),
+        reason: 'the old name must be gone, not merely shadowed');
+
+    final site = (await db.query('sites')).single;
+    expect(site['catalog_site_id'], 4632,
+        reason: 'the link must survive the rename, not be dropped');
+    expect(site['name'], 'Mt Borah');
+  });
+
+  test('records the new version, so the migration is not attempted twice',
+      () async {
+    await createV3Database();
+
+    final db = await DatabaseHelper.instance.database;
+    expect(await db.getVersion(), DatabaseHelper.databaseVersion,
+        reason: 'an unrecorded upgrade re-runs the rename on the next launch');
+  });
+
+  test('reopens cleanly after upgrading - the second launch', () async {
+    await createV3Database(pgeSiteId: 4632);
+
+    // First launch: performs the upgrade.
+    await DatabaseHelper.instance.database;
+    await DatabaseHelper.instance.close();
+
+    // Second launch. This is the one that failed on the device: the rename is
+    // attempted again against a column that is no longer there, and the open
+    // throws rather than returning a usable database.
+    final db = await DatabaseHelper.instance.database;
+
+    expect(await db.getVersion(), DatabaseHelper.databaseVersion);
+    expect(await sitesColumns(db), contains('catalog_site_id'));
+    expect((await db.query('sites')).single['catalog_site_id'], 4632,
+        reason: 'reopening must not disturb the migrated data');
+  });
+
+  test('upgrades a v3 database whose rename already ran', () async {
+    // The exact state the Pixel was found in: the schema change had been
+    // applied but the version still read 3. Whatever produced it, a migration
+    // that cannot survive being re-entered turns it into an app that will not
+    // open - so the rename has to be conditional on the old column existing.
+    final seed = await openDatabase(
+      dbPath,
+      version: 3,
+      onCreate: (db, version) async {
+        await db.execute(v3SitesTable
+            .replaceAll('pge_site_id INTEGER', 'catalog_site_id INTEGER'));
+        await db.execute(
+            'CREATE INDEX IF NOT EXISTS idx_sites_catalog_site_id ON sites(catalog_site_id)');
+      },
+    );
+    await seed.close();
+
+    final db = await DatabaseHelper.instance.database;
+
+    expect(await db.getVersion(), DatabaseHelper.databaseVersion);
+    expect(await sitesColumns(db), contains('catalog_site_id'));
+  });
+}


### PR DESCRIPTION
## Why

The rename of `sites.pge_site_id` to `catalog_site_id` (#324) is the one migration that touches **every existing install**, and nothing exercised it. `federated_catalog_upgrade_test.dart` is named for the upgrade but calls `recreateDatabase()`, so it starts from a fresh v4 schema and never enters `_onUpgrade`.

This came out of a debug install on a Pixel 9 that could not open its database at all, on every launch:

```
[E] DatabaseHelper: Database migration failed | at=database_helper.dart:471
error=no such column: "pge_site_id"
sql 'ALTER TABLE sites RENAME COLUMN pge_site_id TO catalog_site_id'
```

## The test

It drives the real `openDatabase(version:, onUpgrade:)` path rather than calling the migration directly. That distinction is the whole point: calling `_onUpgrade` by hand — the shape `duration_backfill_test.dart` uses — proves the SQL runs, but **not** that sqflite then *records* the new version. If the version did not stick, the identical rename would be attempted on the next launch against a column that is no longer there, throw, and fail the open.

| Case | Before | After |
|---|---|---|
| renames the column, keeps the link | ✅ | ✅ |
| records the new version | ✅ | ✅ |
| reopens cleanly — the second launch | ✅ | ✅ |
| upgrades a v3 database whose rename already ran | ❌ | ✅ |

**No released user is exposed to this.** `v1.0.6+18` ships `databaseVersion = 3` with `pge_site_id` in `_onCreate`, so every production database still has the old column. The upgrade records version 4 and reopens cleanly — verified, not assumed.

## The guard

The failing case is a v3 database whose rename had already been applied — `user_version` 3, yet `catalog_site_id` and its index present. Only a dev device that ran an intermediate build from #324 reaches it. But a migration that cannot survive being re-entered turns any such database into an app that will not open, so the rename is now conditional on the old column existing. It fails without the guard and passes with it.

The v3 schema in the test is reproduced from the release tag verbatim, with a note that it is frozen by definition and must not be updated to track `_onCreate` — it is what is on users' phones.

## Verification

- `flutter analyze` — no issues
- `flutter test` — 211 passed / 18 skipped (up from 207)
- Regression case confirmed red against the unfixed migration before the guard was added

🤖 Generated with [Claude Code](https://claude.com/claude-code)
