### PR TITLE
Release 1.0.7+19

### DIFF
--- a/distribution/whatsnew/whatsnew-en-GB
+++ b/distribution/whatsnew/whatsnew-en-GB
@@ -1,6 +1,6 @@
-• Airspace downloads work again. OpenAIP moved their data server in July, which
-  stopped every country download; the app now uses the new one
-• Downloaded airspace appears straight away. It could previously stay hidden
-  behind an already-ticked Airspace box until you switched the filter off and on
-• Map Tile Cache in Data Management now shows how much map data is really stored
-  on your device, and clearing it frees that space
+• The site guide now merges several guides into one catalogue rather than
+  listing ParaglidingEarth alone, and no longer hides sites marked closed
+• Site details opens as a full page, so the wind, forecast and guide tabs have
+  room instead of sharing a cramped sheet
+• Each guide gets its own link, and those links open the site you tapped -
+  some previously opened an unrelated one

--- a/the_paragliding_app/pubspec.yaml
+++ b/the_paragliding_app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.6+18
+version: 1.0.7+19
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
Release commit for **1.0.7+19**. Version bump and Play release notes only — no code changes.

## Versioning

- **versionCode 19** because 18 is published.
- **versionName 1.0.7** rather than another 1.0.6 build, because this release carries user-visible change — the rule in `GOOGLE_PLAY_DEPLOYMENT.md`, which exists because builds 5–11 all shipped as 1.0.2.

## Release notes (386 chars, limit 500)

Covering only what a user can actually see since 1.0.6+18:

- The site catalogue is federated — it merges several guides rather than listing ParaglidingEarth alone, and sites marked closed are no longer dropped
- Site details is a full page instead of a bottom sheet, so the wind, forecast and per-guide tabs have room
- Each guide has its own link, and those links resolve to the site that was tapped (some previously opened an unrelated site)

## Note on the database migration

This is the **first release where the v3 → v4 rename of `sites.pge_site_id` runs on real installs**. It gained upgrade-path coverage in #325: verified to migrate once, record `user_version = 4`, and reopen cleanly on the second launch. Not user-visible, so not in the notes.

## Tag guards this satisfies

| Check in `build.yml` | Status |
|---|---|
| Tag matches pubspec version | `v1.0.7+19` = `1.0.7+19` |
| versionCode higher than every released tag | 19 > 18 (`v1.0.6+18`) |
| Release notes exist and ≤ 500 chars | 386 |
| Tagged commit is on main | satisfied once this merges |

Tagging `v1.0.7+19` after merge publishes to the Play **internal** track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
