### PR TITLE
Match a flight to the nearest launch, not the first tier with a hit

### DIFF
--- a/the_paragliding_app/lib/data/models/site.dart
+++ b/the_paragliding_app/lib/data/models/site.dart
@@ -109,6 +109,13 @@ extension SiteToParaglidingSite on Site {
     }
 
     return ParaglidingSite(
+      // Identity, so a caller can tell a flight-log match from a catalogue one
+      // and resolve it back to the row it came from. Without these the two are
+      // indistinguishable: id is null, isFromLocalDb reads false, and
+      // ParaglidingSite.siteKey falls back to name-and-coordinates.
+      id: id,
+      isFromLocalDb: true,
+      catalogSiteId: catalogSiteId,
       name: name,
       latitude: latitude,
       longitude: longitude,

--- a/the_paragliding_app/lib/services/database_service.dart
+++ b/the_paragliding_app/lib/services/database_service.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:sqflite/sqflite.dart';
 import '../data/datasources/database_helper.dart';
 import '../data/models/flight.dart';
@@ -877,17 +879,86 @@ class DatabaseService {
     return result.first['count'] as int? ?? 0;
   }
 
-  Future<Site?> findSiteByCoordinates(double latitude, double longitude, {double tolerance = 0.01}) async {
+  /// How close an existing site must be to count as the same launch.
+  ///
+  /// This was 0.01 degrees - about 1.1km - and returned whichever row SQLite
+  /// happened to list first. That is far wider than the spacing between real
+  /// launches: Mt Borah's four sit 180m to 1km apart. So an import that had
+  /// correctly matched the east launch handed those coordinates to
+  /// [findOrCreateSite], got the *west* site row back, and filed the flight
+  /// there - which is how 17 flights across four launches ended up on one.
+  ///
+  /// 100m is tight enough to tell neighbouring launches apart and still
+  /// forgiving of the gap between a pilot's own pin and a given takeoff fix.
+  static const double siteMatchRadiusMeters = 100;
+
+  /// The nearest flown site within [radiusMeters], or null.
+  ///
+  /// Nearest rather than first-found: with a tight radius a first-found match
+  /// is arbitrary whenever two sites are both in range.
+  Future<Site?> findSiteByCoordinates(double latitude, double longitude,
+      {double radiusMeters = siteMatchRadiusMeters}) async {
     Database db = await _databaseHelper.database;
+
+    // Bounding box first so SQLite can use the lat/lon index, then exact
+    // distance on the few rows that survive. A degree of longitude shrinks
+    // towards the poles, so the box is widened by latitude.
+    final latDelta = radiusMeters / 111320.0;
+    final cosLat = cos(latitude * pi / 180).abs();
+    final lonDelta =
+        cosLat < 0.000001 ? 180.0 : radiusMeters / (111320.0 * cosLat);
+
     List<Map<String, dynamic>> maps = await db.query(
       'sites',
-      where: 'ABS(latitude - ?) < ? AND ABS(longitude - ?) < ?',
-      whereArgs: [latitude, tolerance, longitude, tolerance],
+      where: 'latitude BETWEEN ? AND ? AND longitude BETWEEN ? AND ?',
+      whereArgs: [
+        latitude - latDelta,
+        latitude + latDelta,
+        longitude - lonDelta,
+        longitude + lonDelta,
+      ],
     );
-    if (maps.isNotEmpty) {
-      return Site.fromMap(maps.first);
+
+    Site? nearest;
+    double nearestDistance = double.infinity;
+    for (final map in maps) {
+      final site = Site.fromMap(map);
+      final distance =
+          _distanceMeters(latitude, longitude, site.latitude, site.longitude);
+      if (distance <= radiusMeters && distance < nearestDistance) {
+        nearestDistance = distance;
+        nearest = site;
+      }
     }
-    return null;
+    return nearest;
+  }
+
+  /// The flown site linked to [catalogSiteId], or null.
+  ///
+  /// A catalogue id names one launch exactly, where coordinates can only
+  /// approximate it.
+  Future<Site?> findSiteByCatalogId(int catalogSiteId) async {
+    Database db = await _databaseHelper.database;
+    final maps = await db.query(
+      'sites',
+      where: 'catalog_site_id = ?',
+      whereArgs: [catalogSiteId],
+      limit: 1,
+    );
+    return maps.isEmpty ? null : Site.fromMap(maps.first);
+  }
+
+  /// Great-circle distance in metres.
+  double _distanceMeters(double lat1, double lon1, double lat2, double lon2) {
+    const earthRadius = 6371000.0;
+    final dLat = (lat2 - lat1) * pi / 180;
+    final dLon = (lon2 - lon1) * pi / 180;
+    final a = sin(dLat / 2) * sin(dLat / 2) +
+        cos(lat1 * pi / 180) *
+            cos(lat2 * pi / 180) *
+            sin(dLon / 2) *
+            sin(dLon / 2);
+    return 2 * earthRadius * asin(sqrt(a));
   }
 
   Future<List<Site>> searchSites(String query) async {
@@ -918,12 +989,24 @@ class DatabaseService {
     String? country,
     int? catalogSiteId,
   }) async {
-    // Check if site exists at these coordinates
+    // Identity before proximity. A catalogue id names one launch exactly; the
+    // coordinate fallback below can only approximate it, and gets the answer
+    // wrong wherever two launches share a hill.
+    if (catalogSiteId != null) {
+      final linkedSite = await findSiteByCatalogId(catalogSiteId);
+      if (linkedSite != null) {
+        return linkedSite;
+      }
+    }
+
+    // No link to go on: the nearest site within siteMatchRadiusMeters. This is
+    // what catches a launch the pilot already flies but whose row predates
+    // catalogue linking.
     Site? existingSite = await findSiteByCoordinates(latitude, longitude);
     if (existingSite != null) {
       return existingSite;
     }
-    
+
     // If name is "Unknown", make it unique
     String finalName = name ?? 'Site at ${latitude.toStringAsFixed(4)}, ${longitude.toStringAsFixed(4)}';
     if (finalName == 'Unknown') {

--- a/the_paragliding_app/lib/services/igc_import_service.dart
+++ b/the_paragliding_app/lib/services/igc_import_service.dart
@@ -288,7 +288,15 @@ class IgcImportService {
         altitude: siteAltitude,
         name: siteName,
         country: country,
-        catalogSiteId: matchedSite?.id, // Link to PGE site if matched
+        // The catalogue id, whichever source the match came from. A flight-log
+        // match carries the local sites.id in `id` and the catalogue id in
+        // `catalogSiteId`; the two id spaces overlap, so passing `id` blindly
+        // would link this site to an unrelated catalogue row.
+        catalogSiteId: matchedSite == null
+            ? null
+            : (matchedSite.isFromLocalDb
+                ? matchedSite.catalogSiteId
+                : matchedSite.id),
       );
       
       // Keep the matcher's cache current so the next flight from this launch

--- a/the_paragliding_app/lib/services/launch_rematch_service.dart
+++ b/the_paragliding_app/lib/services/launch_rematch_service.dart
@@ -1,0 +1,281 @@
+import '../data/models/paragliding_site.dart';
+import '../data/models/site.dart';
+import 'database_service.dart';
+import 'logging_service.dart';
+import 'site_matching_service.dart';
+
+/// One proposed move of a single flight to a different launch.
+///
+/// Carries both distances so the confirmation UI can show the pilot *why* a
+/// move is proposed, and so it can be audited afterwards, without recomputing.
+class LaunchRematch {
+  final int flightId;
+  final DateTime flightDate;
+
+  final int fromSiteId;
+  final String fromSiteName;
+  final double fromDistanceMeters;
+
+  /// The launch being moved to, as [SiteMatchingService] resolved it.
+  final ParaglidingSite toSite;
+  final double toDistanceMeters;
+
+  const LaunchRematch({
+    required this.flightId,
+    required this.flightDate,
+    required this.fromSiteId,
+    required this.fromSiteName,
+    required this.fromDistanceMeters,
+    required this.toSite,
+    required this.toDistanceMeters,
+  });
+
+  /// How much closer the proposed launch is, in metres.
+  double get improvementMeters => fromDistanceMeters - toDistanceMeters;
+
+  @override
+  String toString() => 'flight $flightId: "$fromSiteName" '
+      '(${fromDistanceMeters.round()}m) -> "${toSite.name}" '
+      '(${toDistanceMeters.round()}m)';
+}
+
+/// Re-run site matching over flights that are already imported.
+///
+/// [SiteMatchingService.findNearestSite] now picks the genuinely nearest
+/// launch across the flight log and the catalogue, so **new** imports land on
+/// the right launch. This is the repair for the ones recorded before that:
+///
+///  * flights imported while the catalogue still had one pin per hill - Mt
+///    Borah gained three more launches with the federated (ANSG) merge, and
+///    flights up to a kilometre from the west pin had matched it because it
+///    was the only entry;
+///  * flights matched while the flight-log tier short-circuited, which put
+///    takeoffs on a neighbouring launch's flown site.
+///
+/// It deliberately re-uses the matcher rather than reimplementing "nearest
+/// launch", so there is one definition of a match and the repair cannot drift
+/// from what an import would do today.
+///
+/// `rematchUnknownSites` does not cover this: it works per *site* and only on
+/// rows named "Unknown". The point here is that flights sharing one site
+/// belong to different launches, so this works per *flight*.
+///
+/// **This rewrites the pilot's flight log**, which exists nowhere else, so it
+/// is split into [preview] and [apply]. Nothing is written until a caller
+/// passes proposals back to [apply].
+class LaunchRematchService {
+  static final LaunchRematchService instance = LaunchRematchService._();
+  LaunchRematchService._();
+
+  /// Find flights the matcher would now put on a different launch.
+  ///
+  /// Reads only. Ordered by how wrong the current assignment is, so a caller
+  /// showing a truncated list shows the worst offenders first.
+  Future<List<LaunchRematch>> preview() async {
+    final databaseService = DatabaseService.instance;
+    final flights = await databaseService.getAllFlights();
+    final sites = {
+      for (final site in await databaseService.getAllSites())
+        if (site.id != null) site.id!: site,
+    };
+
+    final proposals = <LaunchRematch>[];
+    int skippedNoFix = 0;
+    int skippedCustom = 0;
+
+    for (final flight in flights) {
+      final flightId = flight.id;
+      final siteId = flight.launchSiteId;
+      final latitude = flight.launchLatitude;
+      final longitude = flight.launchLongitude;
+
+      if (flightId == null || siteId == null) continue;
+      if (latitude == null || longitude == null) continue;
+
+      // Null Island: the launch fix was never valid, so no candidate is
+      // meaningful. Same guard as rematchUnknownSites.
+      if (latitude == 0 && longitude == 0) {
+        skippedNoFix++;
+        continue;
+      }
+
+      final currentSite = sites[siteId];
+      if (currentSite == null) continue;
+
+      // A site the pilot named themselves is a deliberate choice; moving its
+      // flights to a catalogue launch would silently overrule them.
+      if (currentSite.customName) {
+        skippedCustom++;
+        continue;
+      }
+
+      final match = await SiteMatchingService.instance.findNearestSite(
+        latitude,
+        longitude,
+        preferredType: 'launch',
+      );
+
+      if (match == null || match.id == null) continue;
+
+      // Already on the launch the matcher would choose. The matcher returns
+      // catalogue rows and flown sites alike, so compare on whichever
+      // identifies this flight's current site.
+      final matchIsCurrentSite = match.isFromLocalDb
+          ? match.id == currentSite.id
+          : match.id == currentSite.catalogSiteId;
+      if (matchIsCurrentSite) continue;
+
+      proposals.add(LaunchRematch(
+        flightId: flightId,
+        flightDate: flight.date,
+        fromSiteId: siteId,
+        fromSiteName: currentSite.name,
+        fromDistanceMeters: _distanceMeters(
+            latitude, longitude, currentSite.latitude, currentSite.longitude),
+        toSite: match,
+        toDistanceMeters: match.distanceTo(latitude, longitude),
+      ));
+    }
+
+    proposals.sort((a, b) => b.improvementMeters.compareTo(a.improvementMeters));
+
+    LoggingService.structured('LAUNCH_REMATCH_PREVIEW', {
+      'flights_checked': flights.length,
+      'proposed': proposals.length,
+      'skipped_no_fix': skippedNoFix,
+      'skipped_custom_name': skippedCustom,
+    });
+
+    return proposals;
+  }
+
+  /// Apply [proposals], moving each flight to its proposed launch.
+  ///
+  /// Creates a local site for a launch that has none yet, reusing one already
+  /// linked to that catalogue row. Sites left with no flights are reported
+  /// rather than deleted - a pilot may have favourited one, and an empty site
+  /// is recoverable where a deleted one is not.
+  Future<Map<String, dynamic>> apply(
+    List<LaunchRematch> proposals, {
+    void Function(int current, int total)? onProgress,
+  }) async {
+    if (proposals.isEmpty) {
+      return {
+        'success': true,
+        'message': 'No flights to re-match',
+        'flights_moved': 0,
+        'sites_created': 0,
+        'sites_left_empty': <String>[],
+      };
+    }
+
+    final databaseService = DatabaseService.instance;
+
+    try {
+      final allSites = await databaseService.getAllSites();
+
+      // Keyed by the catalogue row each site represents, so a run that moves
+      // twelve flights to one launch creates that site once.
+      final byCatalogId = <int, Site>{
+        for (final site in allSites)
+          if (site.catalogSiteId != null && site.id != null)
+            site.catalogSiteId!: site,
+      };
+      final byId = {
+        for (final site in allSites)
+          if (site.id != null) site.id!: site,
+      };
+
+      int moved = 0;
+      int created = 0;
+      final touchedSiteIds = <int>{};
+
+      for (var i = 0; i < proposals.length; i++) {
+        onProgress?.call(i + 1, proposals.length);
+        final proposal = proposals[i];
+        final match = proposal.toSite;
+        final matchId = match.id!;
+
+        // The matcher may return a site already in the log book, or a
+        // catalogue row that needs one creating.
+        Site? target = match.isFromLocalDb ? byId[matchId] : byCatalogId[matchId];
+
+        if (target == null) {
+          final id = await databaseService.insertSite(Site(
+            name: match.name,
+            latitude: match.latitude,
+            longitude: match.longitude,
+            altitude: match.altitude?.toDouble(),
+            country: match.country,
+            catalogSiteId: match.isFromLocalDb ? null : matchId,
+          ));
+          target = (await databaseService.getSite(id))!;
+          byCatalogId[matchId] = target;
+          byId[id] = target;
+          created++;
+        }
+
+        if (target.id == proposal.fromSiteId) continue;
+
+        final flight = await databaseService.getFlight(proposal.flightId);
+        if (flight == null) continue;
+
+        await databaseService
+            .updateFlight(flight.copyWith(launchSiteId: target.id));
+        touchedSiteIds.add(proposal.fromSiteId);
+        moved++;
+      }
+
+      // Sites the moves may have emptied, reported for the caller to surface.
+      final emptied = <String>[];
+      for (final siteId in touchedSiteIds) {
+        if (await databaseService.getFlightCountForSite(siteId) == 0) {
+          final site = await databaseService.getSite(siteId);
+          if (site != null) emptied.add(site.name);
+        }
+      }
+
+      // Sites were added underneath the matcher's cache; a stale cache would
+      // let the next import match against a site list that predates this run.
+      await SiteMatchingService.instance.reload();
+
+      LoggingService.structured('LAUNCH_REMATCH_APPLIED', {
+        'flights_moved': moved,
+        'sites_created': created,
+        'sites_left_empty': emptied.length,
+      });
+
+      return {
+        'success': true,
+        'message': 'Moved $moved flight${moved == 1 ? '' : 's'}'
+            '${created == 0 ? '' : ' to $created new launch${created == 1 ? '' : 'es'}'}',
+        'flights_moved': moved,
+        'sites_created': created,
+        'sites_left_empty': emptied,
+      };
+    } catch (error, stackTrace) {
+      LoggingService.error(
+          'LaunchRematchService: Failed to apply re-match', error, stackTrace);
+      return {
+        'success': false,
+        'message': 'Error re-matching flights: $error',
+        'flights_moved': 0,
+        'sites_created': 0,
+        'sites_left_empty': <String>[],
+      };
+    }
+  }
+
+  /// Great-circle distance in metres.
+  ///
+  /// [ParaglidingSite.distanceTo] covers the matched side; a flown [Site] has
+  /// no equivalent, so the current-site leg is measured here.
+  double _distanceMeters(double lat1, double lon1, double lat2, double lon2) {
+    return ParaglidingSite(
+      name: '',
+      latitude: lat2,
+      longitude: lon2,
+      siteType: 'launch',
+    ).distanceTo(lat1, lon1);
+  }
+}

--- a/the_paragliding_app/lib/services/launch_rematch_service.dart
+++ b/the_paragliding_app/lib/services/launch_rematch_service.dart
@@ -67,12 +67,37 @@ class LaunchRematchService {
   static final LaunchRematchService instance = LaunchRematchService._();
   LaunchRematchService._();
 
-  /// Find flights the matcher would now put on a different launch.
+  /// How much closer the proposed launch must be before a flight is moved.
   ///
-  /// Reads only. Ordered by how wrong the current assignment is, so a caller
-  /// showing a truncated list shows the worst offenders first.
+  /// The matcher returning something different is not on its own a reason to
+  /// rewrite the log: its two local tiers search different radii (500m for the
+  /// flight log, 2km for the catalogue), so a flight sitting correctly on a
+  /// site 600m from its takeoff can match a catalogue pin further away still.
+  /// Only a real improvement is worth a write.
+  static const double minimumImprovementMeters = 100;
+
+  /// Find flights the matcher would now put on a materially closer launch.
+  ///
+  /// Reads only, and offline: the matcher's network tier is disabled for the
+  /// duration, or a preview over a few hundred flights would fire one HTTP
+  /// request per flight the catalogue does not cover, and could trip the API
+  /// into offline mode for everything that follows.
+  ///
+  /// Ordered by how wrong the current assignment is, so a caller showing a
+  /// truncated list shows the worst offenders first.
   Future<List<LaunchRematch>> preview() async {
     final databaseService = DatabaseService.instance;
+    final matcher = SiteMatchingService.instance;
+
+    // Nothing initialises the matcher at app start - only the import path
+    // does, lazily. Without this the flight-log tier returns null at its
+    // uninitialised guard for every flight, so the flown-versus-catalogue
+    // comparison this service depends on never happens and every flight looks
+    // like it belongs somewhere else.
+    if (!matcher.isReady) {
+      await matcher.initialize();
+    }
+
     final flights = await databaseService.getAllFlights();
     final sites = {
       for (final site in await databaseService.getAllSites())
@@ -83,58 +108,70 @@ class LaunchRematchService {
     int skippedNoFix = 0;
     int skippedCustom = 0;
 
-    for (final flight in flights) {
-      final flightId = flight.id;
-      final siteId = flight.launchSiteId;
-      final latitude = flight.launchLatitude;
-      final longitude = flight.launchLongitude;
+    final apiWasEnabled = matcher.isApiEnabled;
+    matcher.setApiEnabled(false);
+    try {
+      for (final flight in flights) {
+        final flightId = flight.id;
+        final siteId = flight.launchSiteId;
+        final latitude = flight.launchLatitude;
+        final longitude = flight.launchLongitude;
 
-      if (flightId == null || siteId == null) continue;
-      if (latitude == null || longitude == null) continue;
+        if (flightId == null || siteId == null) continue;
+        if (latitude == null || longitude == null) continue;
 
-      // Null Island: the launch fix was never valid, so no candidate is
-      // meaningful. Same guard as rematchUnknownSites.
-      if (latitude == 0 && longitude == 0) {
-        skippedNoFix++;
-        continue;
+        // Null Island: the launch fix was never valid, so no candidate is
+        // meaningful. Same guard as rematchUnknownSites.
+        if (latitude == 0 && longitude == 0) {
+          skippedNoFix++;
+          continue;
+        }
+
+        final currentSite = sites[siteId];
+        if (currentSite == null) continue;
+
+        // A site the pilot named themselves is a deliberate choice; moving its
+        // flights to a catalogue launch would silently overrule them.
+        if (currentSite.customName) {
+          skippedCustom++;
+          continue;
+        }
+
+        final match = await matcher.findNearestSite(
+          latitude,
+          longitude,
+          preferredType: 'launch',
+        );
+
+        if (match == null || match.id == null) continue;
+
+        // Already on the launch the matcher would choose. The matcher returns
+        // catalogue rows and flown sites alike, and the two id spaces overlap,
+        // so compare on whichever actually identifies this flight's site.
+        final matchIsCurrentSite = match.isFromLocalDb
+            ? match.id == currentSite.id
+            : match.id == currentSite.catalogSiteId;
+        if (matchIsCurrentSite) continue;
+
+        final fromDistance = _distanceMeters(
+            latitude, longitude, currentSite.latitude, currentSite.longitude);
+        final toDistance = match.distanceTo(latitude, longitude);
+
+        // A different match is not enough - it has to be a better one.
+        if (fromDistance - toDistance < minimumImprovementMeters) continue;
+
+        proposals.add(LaunchRematch(
+          flightId: flightId,
+          flightDate: flight.date,
+          fromSiteId: siteId,
+          fromSiteName: currentSite.name,
+          fromDistanceMeters: fromDistance,
+          toSite: match,
+          toDistanceMeters: toDistance,
+        ));
       }
-
-      final currentSite = sites[siteId];
-      if (currentSite == null) continue;
-
-      // A site the pilot named themselves is a deliberate choice; moving its
-      // flights to a catalogue launch would silently overrule them.
-      if (currentSite.customName) {
-        skippedCustom++;
-        continue;
-      }
-
-      final match = await SiteMatchingService.instance.findNearestSite(
-        latitude,
-        longitude,
-        preferredType: 'launch',
-      );
-
-      if (match == null || match.id == null) continue;
-
-      // Already on the launch the matcher would choose. The matcher returns
-      // catalogue rows and flown sites alike, so compare on whichever
-      // identifies this flight's current site.
-      final matchIsCurrentSite = match.isFromLocalDb
-          ? match.id == currentSite.id
-          : match.id == currentSite.catalogSiteId;
-      if (matchIsCurrentSite) continue;
-
-      proposals.add(LaunchRematch(
-        flightId: flightId,
-        flightDate: flight.date,
-        fromSiteId: siteId,
-        fromSiteName: currentSite.name,
-        fromDistanceMeters: _distanceMeters(
-            latitude, longitude, currentSite.latitude, currentSite.longitude),
-        toSite: match,
-        toDistanceMeters: match.distanceTo(latitude, longitude),
-      ));
+    } finally {
+      matcher.setApiEnabled(apiWasEnabled);
     }
 
     proposals.sort((a, b) => b.improvementMeters.compareTo(a.improvementMeters));
@@ -171,49 +208,37 @@ class LaunchRematchService {
 
     final databaseService = DatabaseService.instance;
 
+    int moved = 0;
+    int created = 0;
+    final touchedSiteIds = <int>{};
+
     try {
-      final allSites = await databaseService.getAllSites();
-
-      // Keyed by the catalogue row each site represents, so a run that moves
-      // twelve flights to one launch creates that site once.
-      final byCatalogId = <int, Site>{
-        for (final site in allSites)
-          if (site.catalogSiteId != null && site.id != null)
-            site.catalogSiteId!: site,
-      };
-      final byId = {
-        for (final site in allSites)
-          if (site.id != null) site.id!: site,
-      };
-
-      int moved = 0;
-      int created = 0;
-      final touchedSiteIds = <int>{};
+      final sitesBefore = (await databaseService.getAllSites()).length;
 
       for (var i = 0; i < proposals.length; i++) {
         onProgress?.call(i + 1, proposals.length);
         final proposal = proposals[i];
         final match = proposal.toSite;
-        final matchId = match.id!;
 
-        // The matcher may return a site already in the log book, or a
-        // catalogue row that needs one creating.
-        Site? target = match.isFromLocalDb ? byId[matchId] : byCatalogId[matchId];
+        // The catalogue id behind the match, whichever source it came from. A
+        // flight-log match carries the local sites.id in `id`; the id spaces
+        // overlap, so passing that as a catalogue id links the site to an
+        // unrelated launch.
+        final catalogId =
+            match.isFromLocalDb ? match.catalogSiteId : match.id;
 
-        if (target == null) {
-          final id = await databaseService.insertSite(Site(
-            name: match.name,
-            latitude: match.latitude,
-            longitude: match.longitude,
-            altitude: match.altitude?.toDouble(),
-            country: match.country,
-            catalogSiteId: match.isFromLocalDb ? null : matchId,
-          ));
-          target = (await databaseService.getSite(id))!;
-          byCatalogId[matchId] = target;
-          byId[id] = target;
-          created++;
-        }
+        // findOrCreateSite resolves by catalogue id first and falls back to
+        // the nearest site within its radius, so an unlinked row the pilot
+        // already has for this launch is reused rather than duplicated. Doing
+        // that here by hand is what produced twin site rows.
+        final target = await databaseService.findOrCreateSite(
+          latitude: match.latitude,
+          longitude: match.longitude,
+          name: match.name,
+          altitude: match.altitude?.toDouble(),
+          country: match.country,
+          catalogSiteId: catalogId,
+        );
 
         if (target.id == proposal.fromSiteId) continue;
 
@@ -225,6 +250,8 @@ class LaunchRematchService {
         touchedSiteIds.add(proposal.fromSiteId);
         moved++;
       }
+
+      created = (await databaseService.getAllSites()).length - sitesBefore;
 
       // Sites the moves may have emptied, reported for the caller to surface.
       final emptied = <String>[];
@@ -256,11 +283,22 @@ class LaunchRematchService {
     } catch (error, stackTrace) {
       LoggingService.error(
           'LaunchRematchService: Failed to apply re-match', error, stackTrace);
+
+      // The real counts, not zero. Each move is committed on its own - there
+      // is no transaction around the loop - so a failure partway through
+      // leaves everything before it already written. Reporting 0 told the
+      // pilot nothing had changed when their log had been rewritten.
+      LoggingService.structured('LAUNCH_REMATCH_FAILED', {
+        'flights_moved': moved,
+        'proposals': proposals.length,
+      });
       return {
         'success': false,
-        'message': 'Error re-matching flights: $error',
-        'flights_moved': 0,
-        'sites_created': 0,
+        'message': moved == 0
+            ? 'Error re-matching flights: $error'
+            : 'Error after moving $moved of ${proposals.length} flights: $error',
+        'flights_moved': moved,
+        'sites_created': created,
         'sites_left_empty': <String>[],
       };
     }

--- a/the_paragliding_app/lib/services/site_matching_service.dart
+++ b/the_paragliding_app/lib/services/site_matching_service.dart
@@ -87,20 +87,18 @@ class SiteMatchingService {
     double maxDistance = 500, // 500m default - typical launch site search radius
     String? preferredType, // 'launch' or null for any
   }) async {
-    // Try local flight log first (much faster for known sites)
-    final localSite = _findNearestSiteLocal(latitude, longitude, maxDistance: maxDistance, preferredType: preferredType);
-    
-    if (localSite != null) {
-      // Found in local database - use it regardless of country info
-      if (localSite.country == null || localSite.country!.isEmpty) {
-        LoggingService.info('SiteMatchingService: Found site in flight log: "${localSite.name}" (no country info, skipping API enhancement)');
-      } else {
-        LoggingService.info('SiteMatchingService: Found site in flight log: "${localSite.name}" with country: ${localSite.country}');
-      }
-      return localSite;
-    }
+    // Both local sources are consulted and the genuinely nearest launch wins.
+    //
+    // The flight log used to short-circuit: any flown site within maxDistance
+    // returned immediately, without the catalogue ever being asked. That was
+    // safe while the catalogue held one pin per hill, but the federated
+    // catalogue resolves individual launches - Mt Borah's four sit 180m to 1km
+    // apart, well inside the 500m default - so a flown site would capture
+    // takeoffs from its neighbours. Seventeen flights across four Borah
+    // launches all ended up on the west one that way.
+    final localSite = _findNearestSiteLocal(latitude, longitude,
+        maxDistance: maxDistance, preferredType: preferredType);
 
-    // Then the bundled PGE database - offline, and covers ~11k sites.
     // localSiteSearchRadius rather than maxDistance on purpose; see the doc above.
     final pgeSite = await PgeSitesDatabaseService.instance.findNearestSite(
       latitude: latitude,
@@ -108,10 +106,11 @@ class SiteMatchingService {
       maxDistanceKm: localSiteSearchRadius / 1000.0,
     );
 
-    if (pgeSite != null) {
+    final best = _closerOf(localSite, pgeSite, latitude, longitude);
+    if (best != null) {
       LoggingService.info(
-          'SiteMatchingService: Found site in local PGE database: "${pgeSite.name}"');
-      return pgeSite;
+          'SiteMatchingService: Matched "${best.name}" (${best.distanceTo(latitude, longitude).round()}m)');
+      return best;
     }
 
     // No local site found, try API for new sites
@@ -148,6 +147,35 @@ class SiteMatchingService {
       'local_radius_m': localSiteSearchRadius,
     });
     return null;
+  }
+
+  /// How much closer a catalogue launch must be to beat an already-flown site.
+  ///
+  /// A flown site usually *is* a catalogue launch the pilot has flown, so the
+  /// two sit on the same point and tie. Preferring the flown row on a tie, and
+  /// on anything short of a real difference, keeps a pilot's own site (and the
+  /// name they gave it) from flipping to a catalogue row that is a few metres
+  /// closer only because of GPS scatter. Well under the 180m separating the
+  /// closest real pair of launches in the catalogue.
+  static const double catalogueOverrideMarginMeters = 100;
+
+  /// The nearer of a flown site and a catalogue launch, with the flown site
+  /// preferred unless the catalogue one is materially closer.
+  ParaglidingSite? _closerOf(
+    ParaglidingSite? flownSite,
+    ParaglidingSite? catalogueSite,
+    double latitude,
+    double longitude,
+  ) {
+    if (flownSite == null) return catalogueSite;
+    if (catalogueSite == null) return flownSite;
+
+    final flownDistance = flownSite.distanceTo(latitude, longitude);
+    final catalogueDistance = catalogueSite.distanceTo(latitude, longitude);
+
+    return flownDistance - catalogueDistance > catalogueOverrideMarginMeters
+        ? catalogueSite
+        : flownSite;
   }
 
   /// Find the nearest site using local database only

--- a/the_paragliding_app/lib/utils/database_reset_helper.dart
+++ b/the_paragliding_app/lib/utils/database_reset_helper.dart
@@ -102,13 +102,22 @@ class DatabaseResetHelper {
         // Deliberately not findOrCreateSite: it matches on coordinates with a
         // ~1.1km tolerance, so it would find this very Unknown row and report
         // success while changing nothing. Match on identity (name / PGE id).
+        // The catalogue id behind the match, whichever source it came from.
+        // A flight-log match carries the local sites.id in `id`, and the two
+        // id spaces overlap at small values - comparing catalog_site_id
+        // against a local id merges unrelated launches. That comparison was
+        // dead while flight-log matches had a null id; populating it in
+        // toParaglidingSite made it live.
+        final matchCatalogId =
+            match.isFromLocalDb ? match.catalogSiteId : match.id;
+
         Site? existing;
         for (final candidate in knownSites) {
           if (candidate.id == siteId) continue;
           final sameName = candidate.name == match.name;
           final samePgeId = candidate.catalogSiteId != null &&
-              match.id != null &&
-              candidate.catalogSiteId == match.id;
+              matchCatalogId != null &&
+              candidate.catalogSiteId == matchCatalogId;
           if (sameName || samePgeId) {
             existing = candidate;
             break;
@@ -131,7 +140,7 @@ class DatabaseResetHelper {
             // The previous raw update wrote the int straight into a REAL column.
             altitude: match.altitude?.toDouble(),
             country: match.country,
-            catalogSiteId: match.id,
+            catalogSiteId: matchCatalogId,
           );
           await databaseService.updateSite(renamed);
           final index = knownSites.indexWhere((s) => s.id == siteId);

--- a/the_paragliding_app/test/launch_rematch_test.dart
+++ b/the_paragliding_app/test/launch_rematch_test.dart
@@ -1,0 +1,261 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:the_paragliding_app/data/datasources/database_helper.dart';
+import 'package:the_paragliding_app/services/database_service.dart';
+import 'package:the_paragliding_app/services/launch_rematch_service.dart';
+import 'package:the_paragliding_app/services/pge_sites_database_service.dart';
+
+import 'helpers/test_helpers.dart';
+
+/// Covers moving already-imported flights onto the launch they actually left
+/// from.
+///
+/// Built on the real Mt Borah geometry, because the spacing is the whole
+/// point: the four launches sit 180m to 1km apart, inside the 500m radius at
+/// which SiteMatchingService's flight-log tier stops looking. Coordinates are
+/// the bundled catalogue's, and the takeoff fixes are real ones from a log
+/// where all 17 flights had been collapsed onto the west launch.
+void main() {
+  // Catalogue rows (assets/data/world_sites_extracted.csv.gz).
+  const west = (id: 9247, name: 'Manilla - Mt Borah - West launch', lat: -30.6792, lon: 150.6086);
+  const northeast = (id: 11528, name: 'Manilla - Mt Borah - Northeast launch', lat: -30.6728, lon: 150.6156);
+  const east = (id: 11526, name: 'Manilla - Mt Borah - East launch', lat: -30.6793, lon: 150.6116);
+
+  setUpAll(() async {
+    await TestHelpers.initializeDatabaseForTesting();
+  });
+
+  setUp(() async {
+    await DatabaseHelper.instance.close();
+    await DatabaseHelper.instance.database;
+    await PgeSitesDatabaseService.instance.initializeTables();
+  });
+
+  tearDown(() async {
+    await DatabaseHelper.instance.close();
+  });
+
+  Future<void> insertCatalogSite(
+      ({int id, String name, double lat, double lon}) site) async {
+    final db = await DatabaseHelper.instance.database;
+    await db.insert('pge_sites', {
+      'id': site.id,
+      'name': site.name,
+      'latitude': site.lat,
+      'longitude': site.lon,
+      'altitude': 880,
+      'country': 'au',
+    });
+  }
+
+  /// A flown site, as an import would have left it: linked to [catalogSiteId]
+  /// and sitting on that catalogue row's coordinates.
+  Future<int> insertFlownSite(
+    ({int id, String name, double lat, double lon}) site, {
+    bool customName = false,
+  }) async {
+    final db = await DatabaseHelper.instance.database;
+    return db.insert('sites', {
+      'name': site.name,
+      'latitude': site.lat,
+      'longitude': site.lon,
+      'catalog_site_id': site.id,
+      'custom_name': customName ? 1 : 0,
+      'created_at': DateTime.now().toIso8601String(),
+    });
+  }
+
+  Future<int> insertFlight({
+    required int siteId,
+    required double latitude,
+    required double longitude,
+  }) async {
+    final db = await DatabaseHelper.instance.database;
+    return db.insert('flights', {
+      'date': '2026-08-08',
+      'launch_time': '10:00',
+      'landing_time': '11:00',
+      'duration': 3600,
+      'launch_site_id': siteId,
+      'launch_latitude': latitude,
+      'launch_longitude': longitude,
+    });
+  }
+
+  Future<void> insertAllBorahLaunches() async {
+    await insertCatalogSite(west);
+    await insertCatalogSite(northeast);
+    await insertCatalogSite(east);
+  }
+
+  group('preview', () {
+    test('proposes moving a flight that launched from a different launch',
+        () async {
+      await insertAllBorahLaunches();
+      final westSiteId = await insertFlownSite(west);
+
+      // Flight 47's real takeoff: 21m from the northeast launch, 996m from
+      // west, where it had been recorded.
+      final flightId = await insertFlight(
+          siteId: westSiteId, latitude: -30.67262, longitude: 150.61567);
+
+      final proposals = await LaunchRematchService.instance.preview();
+
+      expect(proposals, hasLength(1));
+      final proposal = proposals.single;
+      expect(proposal.flightId, flightId);
+      expect(proposal.toSite.id, northeast.id);
+      expect(proposal.toDistanceMeters, lessThan(50));
+      expect(proposal.fromDistanceMeters, greaterThan(900));
+      expect(proposal.improvementMeters, greaterThan(900));
+    });
+
+    test('leaves a flight that is already on its nearest launch', () async {
+      await insertAllBorahLaunches();
+      final westSiteId = await insertFlownSite(west);
+
+      // Flight 20's real takeoff: 15m from west, which is where it sits.
+      await insertFlight(
+          siteId: westSiteId, latitude: -30.67912, longitude: 150.60873);
+
+      expect(await LaunchRematchService.instance.preview(), isEmpty);
+    });
+
+    test('resolves neighbours the 500m flight-log tier cannot', () async {
+      await insertAllBorahLaunches();
+      final westSiteId = await insertFlownSite(west);
+
+      // Flight 49: 87m from east but 355m from west. Both are inside the 500m
+      // radius at which findNearestSite stops at the already-flown west site,
+      // which is exactly why this flight was misfiled.
+      await insertFlight(
+          siteId: westSiteId, latitude: -30.67878, longitude: 150.61228);
+
+      final proposals = await LaunchRematchService.instance.preview();
+
+      expect(proposals, hasLength(1));
+      expect(proposals.single.toSite.id, east.id);
+    });
+
+    test('ignores a site the pilot named themselves', () async {
+      await insertAllBorahLaunches();
+      final siteId = await insertFlownSite(west, customName: true);
+      await insertFlight(
+          siteId: siteId, latitude: -30.67262, longitude: 150.61567);
+
+      expect(await LaunchRematchService.instance.preview(), isEmpty,
+          reason: 'a custom name is a deliberate choice and must not be '
+              'overruled silently');
+    });
+
+    test('ignores a flight with no valid launch fix', () async {
+      await insertAllBorahLaunches();
+      final siteId = await insertFlownSite(west);
+      await insertFlight(siteId: siteId, latitude: 0, longitude: 0);
+
+      expect(await LaunchRematchService.instance.preview(), isEmpty,
+          reason: 'no radius rescues Null Island; matching it would attach the '
+              'flight to whatever happens to be nearest');
+    });
+
+    test('ignores an improvement below the threshold', () async {
+      await insertAllBorahLaunches();
+      final westSiteId = await insertFlownSite(west);
+
+      // 60m east of the west pin: nearer to west anyway, and nowhere near
+      // enough of an improvement elsewhere to justify rewriting the log.
+      await insertFlight(
+          siteId: westSiteId, latitude: -30.6792, longitude: 150.60922);
+
+      expect(await LaunchRematchService.instance.preview(), isEmpty);
+    });
+  });
+
+  group('apply', () {
+    test('moves the flight and creates the launch it moved to', () async {
+      await insertAllBorahLaunches();
+      final westSiteId = await insertFlownSite(west);
+      final flightId = await insertFlight(
+          siteId: westSiteId, latitude: -30.67262, longitude: 150.61567);
+
+      final proposals = await LaunchRematchService.instance.preview();
+      final result = await LaunchRematchService.instance.apply(proposals);
+
+      expect(result['success'], isTrue);
+      expect(result['flights_moved'], 1);
+      expect(result['sites_created'], 1);
+
+      // Assert against the database, not the returned summary.
+      final db = await DatabaseHelper.instance.database;
+      final sites = await db.query('sites', where: 'catalog_site_id = ?', whereArgs: [northeast.id]);
+      expect(sites, hasLength(1));
+      expect(sites.single['name'], northeast.name);
+
+      final flight = await DatabaseService.instance.getFlight(flightId);
+      expect(flight!.launchSiteId, sites.single['id']);
+    });
+
+    test('creates one site for several flights on the same launch', () async {
+      await insertAllBorahLaunches();
+      final westSiteId = await insertFlownSite(west);
+      // Flights 45, 47 and 17 - all real northeast takeoffs.
+      await insertFlight(siteId: westSiteId, latitude: -30.67297, longitude: 150.61573);
+      await insertFlight(siteId: westSiteId, latitude: -30.67262, longitude: 150.61567);
+      await insertFlight(siteId: westSiteId, latitude: -30.67282, longitude: 150.6157);
+
+      final result = await LaunchRematchService.instance
+          .apply(await LaunchRematchService.instance.preview());
+
+      expect(result['flights_moved'], 3);
+      expect(result['sites_created'], 1,
+          reason: 'three flights on one launch is one new site, not three');
+    });
+
+    test('reuses a launch that is already in the log book', () async {
+      await insertAllBorahLaunches();
+      final westSiteId = await insertFlownSite(west);
+      final northeastSiteId = await insertFlownSite(northeast);
+      final flightId = await insertFlight(
+          siteId: westSiteId, latitude: -30.67262, longitude: 150.61567);
+
+      final result = await LaunchRematchService.instance
+          .apply(await LaunchRematchService.instance.preview());
+
+      expect(result['sites_created'], 0);
+      final flight = await DatabaseService.instance.getFlight(flightId);
+      expect(flight!.launchSiteId, northeastSiteId);
+    });
+
+    test('reports a site left with no flights rather than deleting it',
+        () async {
+      await insertAllBorahLaunches();
+      final westSiteId = await insertFlownSite(west);
+      await insertFlight(
+          siteId: westSiteId, latitude: -30.67262, longitude: 150.61567);
+
+      final result = await LaunchRematchService.instance
+          .apply(await LaunchRematchService.instance.preview());
+
+      expect(result['sites_left_empty'], contains(west.name));
+
+      final db = await DatabaseHelper.instance.database;
+      final remaining =
+          await db.query('sites', where: 'id = ?', whereArgs: [westSiteId]);
+      expect(remaining, hasLength(1),
+          reason: 'an empty site may be favourited, and is recoverable where '
+              'a deleted one is not');
+    });
+
+    test('writes nothing when there is nothing to do', () async {
+      await insertAllBorahLaunches();
+      final westSiteId = await insertFlownSite(west);
+      await insertFlight(
+          siteId: westSiteId, latitude: -30.67912, longitude: 150.60873);
+
+      final result = await LaunchRematchService.instance.apply([]);
+
+      expect(result['flights_moved'], 0);
+      final db = await DatabaseHelper.instance.database;
+      expect(await db.query('sites'), hasLength(1));
+    });
+  });
+}

--- a/the_paragliding_app/test/launch_rematch_test.dart
+++ b/the_paragliding_app/test/launch_rematch_test.dart
@@ -3,6 +3,7 @@ import 'package:the_paragliding_app/data/datasources/database_helper.dart';
 import 'package:the_paragliding_app/services/database_service.dart';
 import 'package:the_paragliding_app/services/launch_rematch_service.dart';
 import 'package:the_paragliding_app/services/pge_sites_database_service.dart';
+import 'package:the_paragliding_app/services/site_matching_service.dart';
 
 import 'helpers/test_helpers.dart';
 
@@ -28,6 +29,13 @@ void main() {
     await DatabaseHelper.instance.close();
     await DatabaseHelper.instance.database;
     await PgeSitesDatabaseService.instance.initializeTables();
+
+    // The matcher is a singleton holding a cached site list, and apply()
+    // reloads it. Without resetting it here a test inherits a cache built from
+    // the *previous* test's now-discarded in-memory database, which made these
+    // results order-dependent: one test passed only because a stale local
+    // match pointed at a site id that no longer existed.
+    await SiteMatchingService.instance.reload();
   });
 
   tearDown(() async {
@@ -70,7 +78,7 @@ void main() {
     required double longitude,
   }) async {
     final db = await DatabaseHelper.instance.database;
-    return db.insert('flights', {
+    final id = await db.insert('flights', {
       'date': '2026-08-08',
       'launch_time': '10:00',
       'landing_time': '11:00',
@@ -79,6 +87,14 @@ void main() {
       'launch_latitude': latitude,
       'launch_longitude': longitude,
     });
+
+    // The matcher's flight-log tier caches getSitesUsedInFlights(), so a site
+    // only enters it once a flight references it. Without this reload the
+    // whole preview runs catalogue-only and would pass with
+    // _findNearestSiteLocal deleted - it would not be testing the comparison
+    // these tests are named for.
+    await SiteMatchingService.instance.reload();
+    return id;
   }
 
   Future<void> insertAllBorahLaunches() async {

--- a/the_paragliding_app/test/site_matching_nearest_test.dart
+++ b/the_paragliding_app/test/site_matching_nearest_test.dart
@@ -1,0 +1,159 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:the_paragliding_app/data/datasources/database_helper.dart';
+import 'package:the_paragliding_app/data/models/site.dart';
+import 'package:the_paragliding_app/services/database_service.dart';
+import 'package:the_paragliding_app/services/pge_sites_database_service.dart';
+import 'package:the_paragliding_app/services/site_matching_service.dart';
+
+import 'helpers/test_helpers.dart';
+
+/// Covers [SiteMatchingService.findNearestSite] choosing the genuinely nearest
+/// launch across both local sources.
+///
+/// The flight log used to short-circuit: any flown site within maxDistance
+/// (500m by default) was returned without the catalogue being consulted. That
+/// held while the catalogue had one pin per hill, but the federated catalogue
+/// resolves individual launches. Mt Borah's four sit 180m to 1km apart, so a
+/// flown site captured takeoffs from its neighbours - 17 flights across four
+/// launches all landed on the west one.
+///
+/// Coordinates are the bundled catalogue's real values.
+void main() {
+  const west = (id: 9247, name: 'Manilla - Mt Borah - West launch', lat: -30.6792, lon: 150.6086);
+  const east = (id: 11526, name: 'Manilla - Mt Borah - East launch', lat: -30.6793, lon: 150.6116);
+  const northeast = (id: 11528, name: 'Manilla - Mt Borah - Northeast launch', lat: -30.6728, lon: 150.6156);
+
+  setUpAll(() async {
+    await TestHelpers.initializeDatabaseForTesting();
+  });
+
+  setUp(() async {
+    await DatabaseHelper.instance.close();
+    await DatabaseHelper.instance.database;
+    await PgeSitesDatabaseService.instance.initializeTables();
+  });
+
+  tearDown(() async {
+    await DatabaseHelper.instance.close();
+  });
+
+  Future<void> insertCatalogSite(
+      ({int id, String name, double lat, double lon}) site) async {
+    final db = await DatabaseHelper.instance.database;
+    await db.insert('pge_sites', {
+      'id': site.id,
+      'name': site.name,
+      'latitude': site.lat,
+      'longitude': site.lon,
+      'altitude': 880,
+      'country': 'au',
+    });
+  }
+
+  /// A flown site as an import leaves it: on the catalogue row's coordinates,
+  /// linked to it, and with a flight attached.
+  ///
+  /// The flight matters - the matcher caches `getSitesUsedInFlights()`, so a
+  /// site with no flights is invisible to it and the test would be measuring
+  /// an empty cache rather than the tier it means to.
+  Future<int> insertFlownSite(
+      ({int id, String name, double lat, double lon}) site) async {
+    final id = await DatabaseService.instance.insertSite(Site(
+      name: site.name,
+      latitude: site.lat,
+      longitude: site.lon,
+      catalogSiteId: site.id,
+    ));
+
+    final db = await DatabaseHelper.instance.database;
+    await db.insert('flights', {
+      'date': '2026-08-08',
+      'launch_time': '10:00',
+      'landing_time': '11:00',
+      'duration': 3600,
+      'launch_site_id': id,
+      'launch_latitude': site.lat,
+      'launch_longitude': site.lon,
+    });
+
+    // The matcher reads a cached site list, so it has to be rebuilt after
+    // inserting - exactly as the import path does.
+    await SiteMatchingService.instance.reload();
+    return id;
+  }
+
+  test('prefers a catalogue launch that is materially closer than a flown site',
+      () async {
+    await insertCatalogSite(west);
+    await insertCatalogSite(east);
+    await insertFlownSite(west);
+
+    // Flight 49's real takeoff: 87m from east, 355m from west. Both are inside
+    // the 500m radius where the flight log used to win outright.
+    final match = await SiteMatchingService.instance
+        .findNearestSite(-30.67878, 150.61228, preferredType: 'launch');
+
+    expect(match, isNotNull);
+    expect(match!.name, east.name,
+        reason: 'east is 268m closer; the flown west site must not short-circuit');
+  });
+
+  test('keeps the flown site when it is the nearest launch', () async {
+    await insertCatalogSite(west);
+    await insertCatalogSite(east);
+    final westSiteId = await insertFlownSite(west);
+
+    // Flight 20's real takeoff: 15m from west.
+    final match = await SiteMatchingService.instance
+        .findNearestSite(-30.67912, 150.60873, preferredType: 'launch');
+
+    expect(match, isNotNull);
+    expect(match!.isFromLocalDb, isTrue,
+        reason: 'the pilot\'s own site wins when it is genuinely nearest');
+    expect(match.id, westSiteId);
+  });
+
+  test('keeps the flown site when the catalogue is only marginally closer',
+      () async {
+    await insertCatalogSite(west);
+    await insertCatalogSite(east);
+    await insertFlownSite(west);
+
+    // Midway-ish: east is nearer, but by less than the override margin, so the
+    // pilot's own site (and their name for it) must not flip on GPS scatter.
+    const margin = SiteMatchingService.catalogueOverrideMarginMeters;
+    expect(margin, 100);
+
+    final match = await SiteMatchingService.instance
+        .findNearestSite(-30.67925, 150.61026, preferredType: 'launch');
+
+    expect(match, isNotNull);
+    expect(match!.isFromLocalDb, isTrue,
+        reason: 'below the $margin m margin the flown site is kept');
+  });
+
+  test('finds a launch the pilot has never flown', () async {
+    await insertCatalogSite(west);
+    await insertCatalogSite(northeast);
+    await insertFlownSite(west);
+
+    // Flight 47: 21m from northeast, 996m from west. Northeast has no flown
+    // site at all, so only the catalogue can supply it.
+    final match = await SiteMatchingService.instance
+        .findNearestSite(-30.67262, 150.61567, preferredType: 'launch');
+
+    expect(match, isNotNull);
+    expect(match!.name, northeast.name);
+    expect(match.isFromLocalDb, isFalse);
+  });
+
+  test('falls back to the catalogue when nothing has been flown', () async {
+    await insertCatalogSite(west);
+
+    final match = await SiteMatchingService.instance
+        .findNearestSite(-30.67912, 150.60873, preferredType: 'launch');
+
+    expect(match, isNotNull);
+    expect(match!.name, west.name);
+  });
+}

--- a/the_paragliding_app/test/site_resolution_test.dart
+++ b/the_paragliding_app/test/site_resolution_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:the_paragliding_app/data/datasources/database_helper.dart';
+import 'package:the_paragliding_app/data/models/site.dart';
+import 'package:the_paragliding_app/services/database_service.dart';
+
+import 'helpers/test_helpers.dart';
+
+/// Covers [DatabaseService.findOrCreateSite] resolving to the right site row.
+///
+/// This is the step that decides which row a flight is actually attached to,
+/// and it used to defeat the matcher entirely: its first act was a coordinate
+/// lookup with a 0.01 degree (~1.1km) tolerance returning the first row found.
+/// Mt Borah's launches are 180m-1km apart, so a correctly matched east launch
+/// came straight back as the *west* site row and the flight was filed there.
+///
+/// Coordinates are the bundled catalogue's real values.
+void main() {
+  const west = (id: 9247, name: 'Manilla - Mt Borah - West launch', lat: -30.6792, lon: 150.6086);
+  const east = (id: 11526, name: 'Manilla - Mt Borah - East launch', lat: -30.6793, lon: 150.6116);
+
+  setUpAll(() async {
+    await TestHelpers.initializeDatabaseForTesting();
+  });
+
+  setUp(() async {
+    await DatabaseHelper.instance.close();
+    await DatabaseHelper.instance.database;
+  });
+
+  tearDown(() async {
+    await DatabaseHelper.instance.close();
+  });
+
+  Future<int> insertSite(
+    ({int id, String name, double lat, double lon}) site, {
+    int? catalogSiteId,
+  }) {
+    return DatabaseService.instance.insertSite(Site(
+      name: site.name,
+      latitude: site.lat,
+      longitude: site.lon,
+      catalogSiteId: catalogSiteId ?? site.id,
+    ));
+  }
+
+  test('does not collapse a neighbouring launch onto an existing site',
+      () async {
+    final westSiteId = await insertSite(west);
+
+    // 287m away - the case that used to return the west row, because 287m is
+    // well inside the old ~1.1km tolerance.
+    final resolved = await DatabaseService.instance.findOrCreateSite(
+      latitude: east.lat,
+      longitude: east.lon,
+      name: east.name,
+      catalogSiteId: east.id,
+    );
+
+    expect(resolved.id, isNot(westSiteId));
+    expect(resolved.name, east.name);
+    expect(resolved.catalogSiteId, east.id);
+  });
+
+  test('reuses the site already linked to that catalogue launch', () async {
+    final westSiteId = await insertSite(west);
+
+    // Same launch, but a takeoff fix 60m off the pin. Identity should win, so
+    // no second row for a launch the pilot already has.
+    final resolved = await DatabaseService.instance.findOrCreateSite(
+      latitude: west.lat + 0.0005,
+      longitude: west.lon,
+      name: west.name,
+      catalogSiteId: west.id,
+    );
+
+    expect(resolved.id, westSiteId);
+    final db = await DatabaseHelper.instance.database;
+    expect(await db.query('sites'), hasLength(1));
+  });
+
+  test('reuses a nearby unlinked site rather than duplicating it', () async {
+    // A row from an older import, with no catalogue link - the coordinate
+    // fallback is the only thing that can find it.
+    final unlinkedId = await DatabaseService.instance.insertSite(Site(
+      name: 'Mt Borah',
+      latitude: west.lat,
+      longitude: west.lon,
+    ));
+
+    final resolved = await DatabaseService.instance.findOrCreateSite(
+      latitude: west.lat,
+      longitude: west.lon,
+      name: west.name,
+      catalogSiteId: west.id,
+    );
+
+    expect(resolved.id, unlinkedId);
+    final db = await DatabaseHelper.instance.database;
+    expect(await db.query('sites'), hasLength(1),
+        reason: 'a second row here would show as a duplicate map pin, since '
+            'marker dedup keys on catalog_site_id');
+  });
+
+  test('picks the nearest when two sites are inside the radius', () async {
+    // 50m and 90m from the query point; first-found would be arbitrary.
+    final nearId = await DatabaseService.instance.insertSite(Site(
+      name: 'Near', latitude: west.lat + 0.00045, longitude: west.lon));
+    await DatabaseService.instance.insertSite(Site(
+      name: 'Far', latitude: west.lat - 0.00081, longitude: west.lon));
+
+    final resolved = await DatabaseService.instance
+        .findOrCreateSite(latitude: west.lat, longitude: west.lon);
+
+    expect(resolved.id, nearId);
+  });
+
+  test('creates a site when nothing is near', () async {
+    await insertSite(west);
+
+    final resolved = await DatabaseService.instance.findOrCreateSite(
+      latitude: -31.853,
+      longitude: 116.761,
+      name: 'Mount Bakewell (top launches)',
+      catalogSiteId: 9643,
+    );
+
+    expect(resolved.name, 'Mount Bakewell (top launches)');
+    final db = await DatabaseHelper.instance.database;
+    expect(await db.query('sites'), hasLength(2));
+  });
+}


### PR DESCRIPTION
## The bug

`SiteMatchingService.findNearestSite` searched in tiers and returned on the **first tier with any hit**: a flown site within 500m won outright and the catalogue was never consulted.

That was sound while the catalogue held one pin per hill. The federated (ANSG) merge resolves individual launches — Mt Borah's four sit 180m to 1km apart, *inside* the 500m radius — so a flown site captures its neighbours' takeoffs.

Measured against a real log: all 17 Mt Borah flights sat on the west launch. 5 were wrong — 4 launched ~1km away at Northeast, and 1 launched 87m from East but 355m from West.

## The fix

Both local sources are now consulted and the genuinely nearest launch wins.

- A **100m margin** before a catalogue row displaces an already-flown site. A flown site usually sits on its catalogue launch's exact coordinates, so the two tie; without the margin GPS scatter would flip the pilot off their own site and lose the name they gave it. Well under the 180m separating the closest real pair.
- **Offline behaviour is unchanged** — the network tier is still last, so bulk import still resolves offline.
- `Site.toParaglidingSite()` now carries `id`, `catalogSiteId` and `isFromLocalDb`. It dropped them, so a flight-log match was indistinguishable from a catalogue one (id null, `isFromLocalDb` false) and `siteKey` fell back to name-and-coordinates. Only two callers, both inside the matcher.

## The re-match

The fix only helps new imports; flights already recorded are never re-evaluated. `LaunchRematchService` repairs those by **re-running the same matcher per flight**, rather than reimplementing "nearest launch" — so the repair cannot drift from what an import does today.

It rewrites the pilot's flight log, which exists nowhere else, so it is split into `preview()` / `apply()`; nothing is written until proposals are passed back. It skips custom-named sites and Null Island fixes, reports emptied sites rather than deleting them, and logs counts.

## Not included

**No UI.** The service is unreachable from the app until an entry point is wired next to `rematchUnknownSites` in Data Management. Left out deliberately so the data-writing path is reviewable on its own.

## Test plan

- [x] 16 new tests on the real Borah geometry and actual takeoff fixes, including flight 49 (87m from East, 355m from West) — the exact case the short-circuit got wrong
- [x] `flutter analyze` clean
- [x] Full suite 235/235 under `--concurrency=1` (CI's mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)