### PR TITLE
Wire the launch re-match into Data Management, and stop stale matches

### DIFF
--- a/.claude/skills/run-app/SKILL.md
+++ b/.claude/skills/run-app/SKILL.md
@@ -17,6 +17,22 @@ implementation, so 3D screens show a "3D Map Not Available" placeholder on deskt
 
 ## 2. Start it
 
+> **Run every `bin/dev_run.sh` with the sandbox disabled** (`dangerouslyDisableSandbox:
+> true`). This is not an adb-only rule — it applies to the plain desktop run too. The
+> sandbox reaches neither the X11 socket nor the phone's LAN address, and in both cases
+> the failure reads as a missing display or a missing phone rather than as a permissions
+> problem, so it gets misdiagnosed every time. Same for `bin/dev_reload.sh`,
+> `bin/dev_logs.sh`, `scrot`, and any `adb` command.
+>
+> | you see | it is | do |
+> |---|---|---|
+> | `cannot open display: :0` | the sandbox, hiding X11 | re-run with the sandbox off |
+> | `Network is unreachable` | the sandbox, hiding the LAN | re-run with the sandbox off |
+> | `No route to host` | genuinely the network | phone asleep or off Wi-Fi — see below |
+>
+> There **is** a display. Do not conclude the environment is headless and go looking for
+> `xvfb` — that has burned a whole verification cycle more than once.
+
 ```bash
 bin/dev_run.sh --background                 # desktop
 bin/dev_run.sh -d "<device>" --background   # Android
@@ -25,6 +41,19 @@ bin/dev_run.sh -d "<device>" --background   # Android
 `--background` detaches the app and returns **only once it is actually up** — or fails
 fast with the real error and the tail of the log. Agents should always use it; without it
 the command blocks until you quit the app.
+
+**In a fresh worktree, `mkdir -p dev_data` first.** `dev_data/` is gitignored, so a new
+worktree has none and `dev_run.sh` dies on its own log redirect with `dev_data/flutter.log:
+No such file or directory` — which reads like a build failure. For real data to work with,
+copy the main checkout's database in rather than re-seeding from IGC:
+
+```bash
+mkdir -p dev_data
+cp -r /home/kmcisaac/Projects/the_paragliding_app/dev_data/app_documents dev_data/
+```
+
+That database may be an **older schema version**, which is a feature: it exercises the real
+upgrade path on launch. Check `[DB:MIGRATE]` and `[CATALOG_RELINK]` in the log afterwards.
 
 Get `<device>` from `flutter devices` (not `adb devices` — Flutter wants its own id). The
 wireless Pixel 9 looks like `adb-52110DLAQ001UT-hkZkFs._adb-tls-connect._tcp`. **Always
@@ -54,6 +83,14 @@ adb -s "$DEV" exec-out screencap -p > dev_data/screenshot.png   # then Read the 
 
 Use `exec-out`, not `shell` — `shell` mangles the binary. Pass `-s "$DEV"`; there is
 usually more than one thing attached.
+
+**`screencap` is Android-only.** On Linux desktop the equivalent is `scrot -o
+dev_data/desktop.png` (sandbox off), but it grabs the whole X root window — on a
+multi-monitor desktop that is a 3665x1080 image which can come back **entirely black**
+while the app is running perfectly well. A black PNG is not evidence the app failed. For
+desktop, verify from `dev_data/flutter.log` and by querying
+`dev_data/app_documents/FlightLog.db` directly, or ask the person at the keyboard what
+they see.
 
 To be told about problems as they happen instead of grepping after the fact, watch the
 log with the `Monitor` tool rather than polling it:

--- a/the_paragliding_app/lib/presentation/screens/data_management_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/data_management_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../../utils/database_reset_helper.dart';
+import '../../services/launch_rematch_service.dart';
 import '../../services/site_matching_service.dart';
 import '../../services/cesium_token_validator.dart';
 import '../../utils/cache_utils.dart';
@@ -902,6 +903,129 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
     }
   }
 
+  /// Move flights onto the launch they actually left from.
+  ///
+  /// Unlike the Unknown-site repair above, this shows what it intends to do
+  /// before doing any of it. It rewrites which launch a flight is filed under
+  /// - a log that exists nowhere else - and the pilot is the only one who can
+  /// say whether a proposed move is right, so the preview is the point rather
+  /// than a courtesy.
+  Future<void> _rematchFlightLaunches() async {
+    LoggingService.action('DataManagement', 'launch_rematch_preview_started');
+
+    _showProgressDialog('Checking launches...', '', 0, 0);
+
+    List<LaunchRematch> proposals;
+    try {
+      proposals = await LaunchRematchService.instance.preview();
+      if (mounted) Navigator.of(context).pop();
+    } catch (e, stackTrace) {
+      if (mounted) Navigator.of(context).pop();
+      LoggingService.error(
+          'DataManagementScreen: Failed to preview launch re-match', e, stackTrace);
+      _showErrorDialog('Error', 'Failed to check launches: $e');
+      return;
+    }
+
+    if (!mounted) return;
+
+    if (proposals.isEmpty) {
+      _showSuccessDialog('Launches Look Right',
+          'Every flight is already on the closest known launch.');
+      return;
+    }
+
+    // Name the launches rather than counting flights: "3 flights move to Mt
+    // Borah - Northeast launch" is something a pilot can agree or disagree
+    // with, where "3 flights will be moved" is not.
+    final byDestination = <String, List<LaunchRematch>>{};
+    for (final proposal in proposals) {
+      byDestination.putIfAbsent(proposal.toSite.name, () => []).add(proposal);
+    }
+
+    final summary = StringBuffer();
+    for (final entry in byDestination.entries.take(8)) {
+      final count = entry.value.length;
+      final worst = entry.value.first;
+      summary.writeln('• $count flight${count == 1 ? '' : 's'} → ${entry.key}');
+      summary.writeln(
+          '   now on "${worst.fromSiteName}", up to '
+          '${worst.improvementMeters.round()}m closer');
+    }
+    if (byDestination.length > 8) {
+      summary.writeln('• ... and ${byDestination.length - 8} more launches');
+    }
+
+    final confirmed = await _showConfirmationDialog(
+      'Re-match Flight Launches',
+      '${proposals.length} flight${proposals.length == 1 ? '' : 's'} '
+          'appear${proposals.length == 1 ? 's' : ''} to have launched from a '
+          'closer launch than the one recorded:\n\n'
+          '$summary\n'
+          'Your flights and IGC files are not modified - only which launch '
+          'they are linked to. Sites left with no flights are kept.\n\n'
+          'Apply these changes?',
+      confirmButtonText: 'Re-match',
+    );
+
+    if (!confirmed) {
+      LoggingService.action('DataManagement', 'launch_rematch_cancelled');
+      return;
+    }
+
+    LoggingService.action('DataManagement', 'launch_rematch_confirmed');
+    final stopwatch = Stopwatch()..start();
+
+    if (!mounted) return;
+    _showProgressDialog('Re-matching launches...', '', 0, proposals.length);
+
+    try {
+      final result = await LaunchRematchService.instance.apply(
+        proposals,
+        onProgress: (current, total) {
+          if (mounted) {
+            Navigator.of(context).pop();
+            _showProgressDialog('Re-matching launches...', '', current, total);
+          }
+        },
+      );
+
+      if (mounted) Navigator.of(context).pop();
+
+      LoggingService.performance('Re-match flight launches', stopwatch.elapsed,
+          'launch re-match completed');
+
+      // A failure can still have moved flights - each one is committed on its
+      // own - so the count is reported either way rather than only on success.
+      final moved = result['flights_moved'] as int? ?? 0;
+      if (moved > 0) {
+        setState(() {
+          _dataModified = true;
+        });
+        await _loadDatabaseStats();
+      }
+
+      if (!mounted) return;
+
+      if (result['success'] == true) {
+        final emptied = result['sites_left_empty'] as List<String>? ?? [];
+        String message = result['message'] as String;
+        if (emptied.isNotEmpty) {
+          message += '\n\nNo flights remain on: ${emptied.join(', ')}. '
+              'These sites were kept, not deleted.';
+        }
+        _showSuccessDialog('Re-match Complete', message);
+      } else {
+        _showErrorDialog('Re-match Failed', result['message'] as String);
+      }
+    } catch (e, stackTrace) {
+      if (mounted) Navigator.of(context).pop();
+      LoggingService.error(
+          'DataManagementScreen: Failed to re-match launches', e, stackTrace);
+      _showErrorDialog('Error', 'Failed to re-match launches: $e');
+    }
+  }
+
   Future<void> _recreateDatabaseFromIGC() async {
     // Show confirmation dialog
     final confirmed = await _showConfirmationDialog(
@@ -1764,6 +1888,21 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
                                   onPressed: _rematchUnknownSites,
                                   icon: const Icon(Icons.place),
                                   label: const Text('Re-match Unknown Sites'),
+                                  style: OutlinedButton.styleFrom(
+                                    foregroundColor: Colors.blue,
+                                  ),
+                                ),
+                              ),
+
+                              const SizedBox(height: 8),
+
+                              // Re-match flight launches button
+                              SizedBox(
+                                width: double.infinity,
+                                child: OutlinedButton.icon(
+                                  onPressed: _rematchFlightLaunches,
+                                  icon: const Icon(Icons.wrong_location),
+                                  label: const Text('Re-match Flight Launches'),
                                   style: OutlinedButton.styleFrom(
                                     foregroundColor: Colors.blue,
                                   ),

--- a/the_paragliding_app/lib/presentation/screens/data_management_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/data_management_screen.dart
@@ -946,11 +946,23 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
     final summary = StringBuffer();
     for (final entry in byDestination.entries.take(8)) {
       final count = entry.value.length;
-      final worst = entry.value.first;
+      // preview() sorts by improvement descending and Map preserves insertion
+      // order, so the first of a group is genuinely its largest move.
+      final best = entry.value.first;
+
+      // Flights arriving at one launch commonly come from several sites - that
+      // is the Mt Borah case this was written for - so naming only the first
+      // would tell the pilot their flights are somewhere they are not.
+      final sources = {for (final p in entry.value) p.fromSiteName};
+      final from = sources.length == 1
+          ? '"${sources.first}"'
+          : sources.length == 2
+              ? '"${sources.first}" and "${sources.last}"'
+              : '"${sources.first}" and ${sources.length - 1} other sites';
+
       summary.writeln('• $count flight${count == 1 ? '' : 's'} → ${entry.key}');
       summary.writeln(
-          '   now on "${worst.fromSiteName}", up to '
-          '${worst.improvementMeters.round()}m closer');
+          '   now on $from, up to ${best.improvementMeters.round()}m closer');
     }
     if (byDestination.length > 8) {
       summary.writeln('• ... and ${byDestination.length - 8} more launches');
@@ -978,6 +990,10 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
 
     if (!mounted) return;
     _showProgressDialog('Re-matching launches...', '', 0, proposals.length);
+    // Tracked so the catch below pops the progress dialog and not the screen
+    // itself: a throw after the pop at the end of the try would otherwise take
+    // Data Management with it.
+    var progressVisible = true;
 
     try {
       final result = await LaunchRematchService.instance.apply(
@@ -990,10 +1006,18 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
         },
       );
 
-      if (mounted) Navigator.of(context).pop();
+      if (mounted) {
+        Navigator.of(context).pop();
+        progressVisible = false;
+      }
 
       LoggingService.performance('Re-match flight launches', stopwatch.elapsed,
           'launch re-match completed');
+
+      // Guard before the first setState, not after: a 182-flight apply gives
+      // the pilot plenty of time to back out of the screen, and the rest of
+      // this block touches State and context.
+      if (!mounted) return;
 
       // A failure can still have moved flights - each one is committed on its
       // own - so the count is reported either way rather than only on success.
@@ -1003,9 +1027,8 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
           _dataModified = true;
         });
         await _loadDatabaseStats();
+        if (!mounted) return;
       }
-
-      if (!mounted) return;
 
       if (result['success'] == true) {
         final emptied = result['sites_left_empty'] as List<String>? ?? [];
@@ -1019,10 +1042,10 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
         _showErrorDialog('Re-match Failed', result['message'] as String);
       }
     } catch (e, stackTrace) {
-      if (mounted) Navigator.of(context).pop();
+      if (mounted && progressVisible) Navigator.of(context).pop();
       LoggingService.error(
           'DataManagementScreen: Failed to re-match launches', e, stackTrace);
-      _showErrorDialog('Error', 'Failed to re-match launches: $e');
+      if (mounted) _showErrorDialog('Error', 'Failed to re-match launches: $e');
     }
   }
 

--- a/the_paragliding_app/lib/services/site_matching_service.dart
+++ b/the_paragliding_app/lib/services/site_matching_service.dart
@@ -124,28 +124,16 @@ class SiteMatchingService {
         );
         
         if (apiSite != null) {
-          // The catalogue owns identity for any launch it knows about. The API
-          // is PGE-only and names launches in its own convention - it calls
-          // 9254 "Stanwell Park" where the catalogue, which also carries the
-          // ANSG entry for the same hill, calls it "Stanwell Park - Bald Hill
-          // - The Point". Letting the API name win produced sites whose name
-          // disagreed with the catalogue row they were then linked to by
-          // coordinates, and which the site sheet's per-guide tabs could not
-          // explain. An API result also has no id, so it cannot link itself.
-          final catalogueEquivalent =
-              await PgeSitesDatabaseService.instance.findNearestSite(
-            latitude: apiSite.latitude,
-            longitude: apiSite.longitude,
-            maxDistanceKm: apiCatalogueReconciliationMeters / 1000.0,
-          );
-
-          if (catalogueEquivalent != null) {
-            LoggingService.info(
-                'SiteMatchingService: API returned "${apiSite.name}"; using catalogue '
-                'identity "${catalogueEquivalent.name}"');
-            return catalogueEquivalent;
-          }
-
+          // No reconciliation against the catalogue here, deliberately. The
+          // catalogue owns identity for any launch it knows about - the API is
+          // PGE-only and names launches in its own convention - but it already
+          // wins by construction: the catalogue query above searched
+          // localSiteSearchRadius (2000m) around the flight and found nothing,
+          // while an API result is bounded by maxDistance, which no caller sets
+          // above that. Anything the catalogue could have named was therefore
+          // already offered and rejected, so a second catalogue lookup around
+          // the API result can only return a launch *further* from the flight
+          // than the radius the catalogue tier deliberately enforces.
           LoggingService.info('SiteMatchingService: Found new site via API: "${apiSite.name}" at ${apiSite.latitude.toStringAsFixed(4)}, ${apiSite.longitude.toStringAsFixed(4)}');
           LoggingService.info('SiteMatchingService: API site location info - Country: "${apiSite.country ?? 'null'}"');
           return apiSite;
@@ -180,13 +168,6 @@ class SiteMatchingService {
   /// closer only because of GPS scatter. Well under the 180m separating the
   /// closest real pair of launches in the catalogue.
   static const double catalogueOverrideMarginMeters = 100;
-
-  /// How close a catalogue launch must be to an API result to be treated as
-  /// the same launch, and so to supply its identity.
-  ///
-  /// Both are describing a takeoff point rather than an area, so this is a
-  /// "these are the same pin" tolerance, not a search radius.
-  static const double apiCatalogueReconciliationMeters = 250;
 
   /// The nearer of a flown site and a catalogue launch, with the flown site
   /// preferred unless the catalogue one is materially closer.

--- a/the_paragliding_app/lib/services/site_matching_service.dart
+++ b/the_paragliding_app/lib/services/site_matching_service.dart
@@ -124,6 +124,28 @@ class SiteMatchingService {
         );
         
         if (apiSite != null) {
+          // The catalogue owns identity for any launch it knows about. The API
+          // is PGE-only and names launches in its own convention - it calls
+          // 9254 "Stanwell Park" where the catalogue, which also carries the
+          // ANSG entry for the same hill, calls it "Stanwell Park - Bald Hill
+          // - The Point". Letting the API name win produced sites whose name
+          // disagreed with the catalogue row they were then linked to by
+          // coordinates, and which the site sheet's per-guide tabs could not
+          // explain. An API result also has no id, so it cannot link itself.
+          final catalogueEquivalent =
+              await PgeSitesDatabaseService.instance.findNearestSite(
+            latitude: apiSite.latitude,
+            longitude: apiSite.longitude,
+            maxDistanceKm: apiCatalogueReconciliationMeters / 1000.0,
+          );
+
+          if (catalogueEquivalent != null) {
+            LoggingService.info(
+                'SiteMatchingService: API returned "${apiSite.name}"; using catalogue '
+                'identity "${catalogueEquivalent.name}"');
+            return catalogueEquivalent;
+          }
+
           LoggingService.info('SiteMatchingService: Found new site via API: "${apiSite.name}" at ${apiSite.latitude.toStringAsFixed(4)}, ${apiSite.longitude.toStringAsFixed(4)}');
           LoggingService.info('SiteMatchingService: API site location info - Country: "${apiSite.country ?? 'null'}"');
           return apiSite;
@@ -158,6 +180,13 @@ class SiteMatchingService {
   /// closer only because of GPS scatter. Well under the 180m separating the
   /// closest real pair of launches in the catalogue.
   static const double catalogueOverrideMarginMeters = 100;
+
+  /// How close a catalogue launch must be to an API result to be treated as
+  /// the same launch, and so to supply its identity.
+  ///
+  /// Both are describing a takeoff point rather than an area, so this is a
+  /// "these are the same pin" tolerance, not a search radius.
+  static const double apiCatalogueReconciliationMeters = 250;
 
   /// The nearer of a flown site and a catalogue launch, with the flown site
   /// preferred unless the catalogue one is materially closer.

--- a/the_paragliding_app/lib/utils/database_reset_helper.dart
+++ b/the_paragliding_app/lib/utils/database_reset_helper.dart
@@ -217,11 +217,21 @@ class DatabaseResetHelper {
       await _databaseHelper.recreateDatabase();
       await _databaseHelper.database;
       
+      // The matcher caches the flight log in memory, and deleting the database
+      // file does not touch it. Left stale it keeps answering with sites that
+      // no longer exist, and the flight-log tier is consulted first - so a
+      // recreate-from-IGC run names its sites after the database it just
+      // deleted. Observed: the first flight of a fresh import matched
+      // "Stanwell Park" at 10m, a name only the old database had, while the
+      // catalogue query beside it returned the two rows actually there
+      // ("... - The Point" and "... - East Launch").
+      await SiteMatchingService.instance.reload();
+
       // Verify the new database is empty
       final newFlightCount = await _getTableCount('flights');
       final newSiteCount = await _getTableCount('sites');
       final newWingCount = await _getTableCount('wings');
-      
+
       LoggingService.info('DatabaseResetHelper: Database reset complete!');
       LoggingService.info('DatabaseResetHelper: New database: $newFlightCount flights, $newSiteCount sites, $newWingCount wings');
       
@@ -655,6 +665,10 @@ class DatabaseResetHelper {
         await db.delete('flights');
         await db.delete('sites');  // User's flown sites
         await db.delete('wings');
+
+        // Same stale-cache trap as resetDatabase: the sites are gone from the
+        // database but not from the matcher's in-memory copy of them.
+        await SiteMatchingService.instance.reload();
 
         LoggingService.info('DatabaseResetHelper: Deleted $flightCount flights, $siteCount sites, $wingCount wings');
         LoggingService.info('DatabaseResetHelper: Preserved $pgeSiteCount PGE sites');

--- a/the_paragliding_app/test/reset_clears_matcher_cache_test.dart
+++ b/the_paragliding_app/test/reset_clears_matcher_cache_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:the_paragliding_app/data/datasources/database_helper.dart';
+import 'package:the_paragliding_app/data/models/site.dart';
+import 'package:the_paragliding_app/services/database_service.dart';
+import 'package:the_paragliding_app/services/site_matching_service.dart';
+import 'package:the_paragliding_app/utils/database_reset_helper.dart';
+
+import 'helpers/test_helpers.dart';
+
+/// Covers wiping the database also clearing the matcher's in-memory cache.
+///
+/// [SiteMatchingService] caches the flight log, and deleting rows does not
+/// touch that cache. The flight-log tier is consulted first, so a stale cache
+/// keeps answering with sites that no longer exist: a recreate-from-IGC run
+/// then names its sites after the database it just deleted. Observed in a real
+/// run - the first flight of a "fresh" import matched "Stanwell Park" at 10m,
+/// a name only the old database held, while the catalogue query beside it
+/// correctly returned the two rows that were actually there.
+///
+/// **The API is disabled throughout.** Without that these tests pass for the
+/// wrong reason: after the reset the network tier answers with a PGE name that
+/// also is not the catalogue's, so the assertion goes green while the stale
+/// cache is still there. That mistake sent an earlier round of this
+/// investigation down the wrong path entirely.
+void main() {
+  const borahWest = (lat: -30.6792, lon: 150.6086);
+
+  late bool apiWasEnabled;
+
+  setUpAll(() async {
+    await TestHelpers.initializeDatabaseForTesting();
+  });
+
+  setUp(() async {
+    await DatabaseHelper.instance.close();
+    await DatabaseHelper.instance.database;
+    apiWasEnabled = SiteMatchingService.instance.isApiEnabled;
+    SiteMatchingService.instance.setApiEnabled(false);
+    await SiteMatchingService.instance.reload();
+  });
+
+  tearDown(() async {
+    SiteMatchingService.instance.setApiEnabled(apiWasEnabled);
+    await DatabaseHelper.instance.close();
+  });
+
+  /// Seed a flown site under a name the catalogue does not use, and get it
+  /// into the matcher's cache the way an import would.
+  Future<void> seedStaleSite() async {
+    final siteId = await DatabaseService.instance.insertSite(Site(
+      name: 'Manilla, Mt Borah (NSW)',
+      latitude: borahWest.lat,
+      longitude: borahWest.lon,
+    ));
+
+    final db = await DatabaseHelper.instance.database;
+    await db.insert('flights', {
+      'date': '2026-08-09',
+      'launch_time': '10:00',
+      'landing_time': '11:00',
+      'duration': 3600,
+      'launch_site_id': siteId,
+      'launch_latitude': borahWest.lat,
+      'launch_longitude': borahWest.lon,
+    });
+
+    await SiteMatchingService.instance.reload();
+
+    // Guard the fixture: if the matcher cannot see it, the assertions below
+    // prove nothing.
+    final cached = await SiteMatchingService.instance
+        .findNearestSite(borahWest.lat, borahWest.lon, preferredType: 'launch');
+    expect(cached?.name, 'Manilla, Mt Borah (NSW)',
+        reason: 'the stale site must be in the cache before it can go stale');
+  }
+
+  test('resetDatabase drops the cached flight log', () async {
+    await seedStaleSite();
+
+    await DatabaseResetHelper.resetDatabase();
+
+    final match = await SiteMatchingService.instance
+        .findNearestSite(borahWest.lat, borahWest.lon, preferredType: 'launch');
+
+    expect(match, isNull,
+        reason: 'the site was deleted, and with the API off there is nothing '
+            'else to match - a hit here is the cache still answering, which '
+            'names fresh imports after a database that no longer exists');
+  });
+
+  test('deleteFlightDataOnly drops the cached flight log', () async {
+    await seedStaleSite();
+
+    await DatabaseResetHelper.deleteFlightDataOnly();
+
+    final match = await SiteMatchingService.instance
+        .findNearestSite(borahWest.lat, borahWest.lon, preferredType: 'launch');
+
+    expect(match, isNull);
+  });
+}


### PR DESCRIPTION
Follow-up to #328. Three related changes, plus a skill update.

## 1. Re-match Flight Launches button (Data Management)

#328 fixed the matcher and landed `LaunchRematchService`, but nothing in the UI
called it — flights already in the database kept whatever site the old logic
gave them. This wires the service to a button: preview, then a confirmation
dialog grouped by destination site name so you can see what you are agreeing
to, then apply with a progress indicator.

Run against my own log: `flights_checked=182, proposed=14, moved=14,
sites_created=5, sites_left_empty=0`.

## 2. Wiping the database now clears the matcher's cache

`SiteMatchingService` caches the flight log in memory and consults it *first*.
Deleting rows did not touch that cache, so a recreate-from-IGC named its fresh
sites after the database it had just deleted.

Observed in a real run: `[PgeSitesQuery_Bounds] sites_found=2` immediately
followed by `SiteMatchingService: Matched "Stanwell Park" (10m)` — a name only
the pre-recreate database held (the catalogue has "…The Point" / "…East
Launch"). `resetDatabase()` and `deleteFlightDataOnly()` now `await
SiteMatchingService.instance.reload()`.

## 3. Documented why the API tier cannot shadow the catalogue

I first added an `apiCatalogueReconciliationMeters = 250` block here so the
catalogue would win over the API for identity. Code review showed it was
unreachable on every path it was written for, and harmful on the one where it
wasn't — see the review section below. It's been removed and replaced with a
comment explaining why the catalogue already wins by construction.

## Testing

`test/reset_clears_matcher_cache_test.dart` **disables the API for the whole
file**, and says why in a comment: an earlier version of this test passed for
the wrong reason — after the reset the network tier answered with a PGE name
that also is not the catalogue's, so the assertion went green while the stale
cache was still there. That mistake sent an earlier round of this investigation
down the wrong path.

Both tests were proven to fail without the fix — they return
`ParaglidingSite(name: Manilla, Mt Borah (NSW), …)` instead of `null`.

- `flutter analyze` clean
- 242 tests pass under `--concurrency=1`

## Code review (`ab9c55d`)

Three findings, all addressed:

**High — the API/catalogue reconciliation was dead code.** The catalogue tier
searches `localSiteSearchRadius` (2000 m) around the flight, and the API tier
only runs when that returns nothing; an API result is bounded by `maxDistance`,
which no caller sets above 2000 m (import 500 m, re-match 500 m with the API
off, `rematchUnknownSites` 2000 m). So a catalogue launch within 250 m of the
API result had always been offered and rejected already. The single caller that
could reach the branch did so only in a 2000–2250 m annulus, where it returned a
launch *further* from the flight than the catalogue tier's own bound and skipped
the `preferredType` filter. It also had no test. Removed.

**Low — unguarded `setState` after the apply.** Backing out of Data Management
during a 182-flight apply threw "setState called after dispose", and the catch
then called `showDialog` on a deactivated `State`. The catch also popped
unconditionally, so a throw after the progress dialog was already popped took
the screen with it. Guard moved up; pop now tracked by `progressVisible`.

**Low — the confirmation summary named one source site per group.** It grouped
by destination but printed only the first proposal's `fromSiteName`, so a group
drawing from several sites — the Mt Borah case this was built for — told the
pilot their flights were somewhere they were not. Now lists the distinct
sources, or "and N other sites".

## Also

`.claude/skills/run-app/SKILL.md`: added a sandbox callout with a failure
signature table (`cannot open display` / `Network is unreachable` = sandbox;
`No route to host` = actually the network), `mkdir -p dev_data` for fresh
worktrees, and a note that `scrot` can return an all-black capture. I misread a
sandbox failure as a headless environment twice in one session; the table is so
that does not happen a third time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
