### PR TITLE
Screenshot the Linux app via the engine, not the compositor

### DIFF
--- a/.claude/skills/run-app/SKILL.md
+++ b/.claude/skills/run-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-app
-description: Run, hot-reload, screenshot and read logs for this Flutter app, on Linux desktop or on an Android phone/emulator. Use when asked to run, launch, start, restart or hot-reload the app, to screenshot it, to check its runtime logs, or to verify a change in the running app rather than in tests. Covers bin/dev_run.sh, bin/dev_reload.sh, wireless adb device ids, and the debug-vs-production package trap.
+description: Run, hot-reload, screenshot and read logs for this Flutter app, on Linux desktop or on an Android phone/emulator. Use when asked to run, launch, start, restart or hot-reload the app, to screenshot it, to check its runtime logs, or to verify a change in the running app rather than in tests. Covers bin/dev_run.sh, bin/dev_reload.sh, bin/dev_screenshot.sh, wireless adb device ids, and the debug-vs-production package trap.
 ---
 
 # Running this app
@@ -22,13 +22,19 @@ implementation, so 3D screens show a "3D Map Not Available" placeholder on deskt
 > sandbox reaches neither the X11 socket nor the phone's LAN address, and in both cases
 > the failure reads as a missing display or a missing phone rather than as a permissions
 > problem, so it gets misdiagnosed every time. Same for `bin/dev_reload.sh`,
-> `bin/dev_logs.sh`, `scrot`, and any `adb` command.
+> `bin/dev_logs.sh`, `bin/dev_screenshot.sh`, and any `adb` command.
 >
 > | you see | it is | do |
 > |---|---|---|
 > | `cannot open display: :0` | the sandbox, hiding X11 | re-run with the sandbox off |
 > | `Network is unreachable` | the sandbox, hiding the LAN | re-run with the sandbox off |
+> | `flutter pid N is not visible` | the sandbox's own PID namespace | re-run with the sandbox off |
 > | `No route to host` | genuinely the network | phone asleep or off Wi-Fi — see below |
+>
+> The sandbox runs in its own PID namespace, so a healthy app's pid is invisible inside
+> it and `kill -0` fails exactly as it would for a dead one. Nothing distinguishes the
+> two from in there — which is why `bin/dev_screenshot.sh` names both possibilities
+> instead of declaring the app dead.
 >
 > There **is** a display. Do not conclude the environment is headless and go looking for
 > `xvfb` — that has burned a whole verification cycle more than once.
@@ -78,19 +84,38 @@ assume; a reload that goes nowhere looks exactly like one that worked.
 ```bash
 tail -n 50 dev_data/flutter.log                  # recent output
 grep -E "\[[IWEDP]\]\[\+" dev_data/flutter.log   # just this app's LoggingService lines
-adb -s "$DEV" exec-out screencap -p > dev_data/screenshot.png   # then Read the PNG
+bin/dev_screenshot.sh                            # desktop  -> dev_data/screenshot.png
+adb -s "$DEV" exec-out screencap -p > dev_data/screenshot.png   # Android; then Read the PNG
 ```
 
-Use `exec-out`, not `shell` — `shell` mangles the binary. Pass `-s "$DEV"`; there is
-usually more than one thing attached.
+For adb use `exec-out`, not `shell` — `shell` mangles the binary. Pass `-s "$DEV"`; there
+is usually more than one thing attached.
 
-**`screencap` is Android-only.** On Linux desktop the equivalent is `scrot -o
-dev_data/desktop.png` (sandbox off), but it grabs the whole X root window — on a
-multi-monitor desktop that is a 3665x1080 image which can come back **entirely black**
-while the app is running perfectly well. A black PNG is not evidence the app failed. For
-desktop, verify from `dev_data/flutter.log` and by querying
-`dev_data/app_documents/FlightLog.db` directly, or ask the person at the keyboard what
-they see.
+**On desktop, screenshot with `bin/dev_screenshot.sh` — never a screenshot tool.** No
+Wayland capture tool can work in this container, so do not go looking for one: this is
+Crostini, `WAYLAND_DISPLAY` is sommelier's socket, and the real compositor is ChromeOS's,
+on the host side of the VM. `grim` gets `compositor doesn't support
+wlr-screencopy-unstable-v1` and always will — a guest is not allowed to read the host
+framebuffer. `scrot` sees only the Xwayland root, which a native-Wayland Flutter window
+is not in; that, not multi-monitor, is why it used to return an all-black PNG.
+
+`dev_screenshot.sh` sidesteps the compositor entirely: it asks the Flutter engine for its
+last rasterized frame over the VM service `flutter run` already exposes. So it needs no
+focus, is unbothered by an obscured or backgrounded window, comes out at full resolution
+with no chrome to crop, and **nothing about how the app is launched changes** — desktop
+stays native Wayland. It validates the PNG before writing, so a short or non-PNG payload
+fails loudly rather than leaving a plausible-looking file. What it returns is the *last
+rasterized frame*, so let the UI settle after a hot reload before shooting, or you
+capture the frame mid-rebuild and read it as a rendering bug.
+
+It captures the Flutter scene only — no platform views. That costs nothing on Linux (the
+3D map is a placeholder there anyway), but on Android prefer `adb exec-out screencap`,
+which also gets the Cesium webview and the system UI. The script does work against a
+device target, since `flutter run` forwards the VM service to localhost; treat that as
+the fallback for when adb is being difficult.
+
+Still worth doing alongside: `dev_data/flutter.log`, and querying
+`dev_data/app_documents/FlightLog.db` directly.
 
 To be told about problems as they happen instead of grepping after the fact, watch the
 log with the `Monitor` tool rather than polling it:
@@ -142,6 +167,13 @@ that file **is** the readiness check. There is no status command and none is nee
 
 Allowed as of 2026-08-08 — it used to say "ask the user to navigate". Navigate to the
 screen under test and look at it yourself; a UI fix nobody has looked at is unverified.
+
+**Android only.** Input injection has no desktop equivalent here: `xdotool` cannot reach
+native-Wayland windows, and sommelier exposes neither the virtual-keyboard nor the
+virtual-pointer protocol, so `wtype` and `ydotool` are out too. On desktop you can *see*
+any screen (`bin/dev_screenshot.sh`) but only reach the ones the app opens on its own —
+for anything needing taps, use the phone, or ask the person at the keyboard to navigate
+and then screenshot.
 
 ```bash
 DEV=adb-52110DLAQ001UT-hkZkFs._adb-tls-connect._tcp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@ bin/dev_run.sh -d chrome      # Same, on another device
 
 bin/dev_reload.sh             # Hot reload  (SIGUSR1 via dev_data/flutter.pid)
 bin/dev_reload.sh R           # Hot restart (SIGUSR2) - needed for main()/initState changes
+
+bin/dev_screenshot.sh         # Screenshot the desktop app -> dev_data/screenshot.png
 ```
 
 Hot reload also works with the standard `r` / `R` keys if you started it in a
@@ -724,7 +726,8 @@ task needs the app to actually run.
 | Task | Commands | Notes |
 |------|----------|-------|
 | Fix hot reload issues | `kill "$(cat dev_data/flutter.pid)"` → start again | No pid file means it already exited |
-| Debug UI | `adb exec-out screencap -p > dev_data/screenshot.png` → analyze | Unlock the phone first |
+| Debug UI (desktop) | `bin/dev_screenshot.sh` → Read the PNG | Via the VM service, not the compositor - no screenshot tool works under Crostini |
+| Debug UI (Android) | `adb exec-out screencap -p > dev_data/screenshot.png` → analyze | Unlock the phone first |
 | Performance check | `grep "\[P\]" dev_data/flutter.log` | Performance logs |
 | Schema change | Clear data → restart → reimport | Dev workflow |
 
@@ -744,7 +747,8 @@ Use format `file_path:line_number` in logs:
 - [Database Schema](docs/DATABASE.md) - Complete table definitions
 - [Timestamp Processing](docs/TIMESTAMPS.md) - UTC/local conversion
 - at the end of complex set of changes use flutter analyze to find errors
-- use adb screenshots on emulator
+- use adb screenshots on emulator; on Linux desktop use `bin/dev_screenshot.sh` (see the
+  `run-app` skill - Wayland capture tools cannot work in this container)
 - Call sites in local DB "Flown Sites" and sites from PGE API "New Sites"
 - Call sites in local DB "Flown Sites" and sites from PGE API "New Sites"
 - always start the app with `bin/dev_run.sh --background`

--- a/bin/dev_screenshot.sh
+++ b/bin/dev_screenshot.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# Screenshot the app running on Linux desktop, without touching the compositor.
+#
+#   bin/dev_screenshot.sh                # -> dev_data/screenshot.png
+#   bin/dev_screenshot.sh -o shot.png    # write somewhere else
+#
+# Needs an app started by bin/dev_run.sh (debug or profile - a release build has no
+# VM service). Run it with the sandbox disabled, like the rest of bin/.
+#
+# Why not a screenshot tool: this box is Crostini, so WAYLAND_DISPLAY is sommelier's
+# socket and the real compositor is ChromeOS's, on the host side of the VM. grim gets
+# "compositor doesn't support wlr-screencopy-unstable-v1" - a guest container is not
+# allowed to read the host framebuffer, and no Wayland capture tool will change that.
+# scrot only sees the Xwayland root, which a native-Wayland Flutter window is not in;
+# that is the all-black PNG this project used to blame on multi-monitor. So capture
+# from the engine instead: the Flutter engine registers a _flutter.screenshot service
+# extension returning the last rasterized frame as a base64 PNG, and the VM service
+# answers plain HTTP GET. Nothing about how the app runs has to change.
+#
+# It captures the Flutter scene only - no window decorations, and no platform views.
+# That costs nothing on Linux (flutter_inappwebview has no Linux implementation, so
+# the 3D map is a placeholder there anyway). On Android prefer
+# `adb exec-out screencap`, which also gets the Cesium webview and the system UI; this
+# script does work against a device target, since flutter run forwards the VM service
+# to localhost, but it is the fallback there rather than the default.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PID_FILE="$REPO_ROOT/dev_data/flutter.pid"
+LOG_FILE="$REPO_ROOT/dev_data/flutter.log"
+out="$REPO_ROOT/dev_data/screenshot.png"
+timeout_s="${DEV_SCREENSHOT_TIMEOUT:-30}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o|--out)
+      # ${2-} not $2: under `set -u` a bare -o would die with an unbound-variable
+      # trace instead of saying what was wrong.
+      out="${2-}"
+      [[ -n "$out" ]] || { echo "ERROR: $1 requires a path" >&2; exit 1; }
+      shift 2
+      ;;
+    -h|--help)
+      # Print the header comment block, as bin/dev_run.sh does.
+      awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument '$1' (try --help)" >&2
+      exit 1
+      ;;
+  esac
+done
+
+for cmd in curl jq base64; do
+  command -v "$cmd" >/dev/null || { echo "ERROR: $cmd is required but not installed" >&2; exit 1; }
+done
+
+# Liveness first, same check as bin/dev_reload.sh: flutter writes the pid file only
+# once the app is up and removes it on exit, so it *is* the readiness check.
+if [[ ! -f "$PID_FILE" ]]; then
+  echo "ERROR: $PID_FILE not found - is the app running via bin/dev_run.sh?" >&2
+  exit 1
+fi
+pid="$(cat "$PID_FILE")"
+if ! kill -0 "$pid" 2>/dev/null; then
+  # Do not call this a stale pid file, the way dev_reload.sh can afford to. The agent
+  # sandbox runs in its own PID namespace, so a perfectly healthy app is invisible
+  # here and a confident "not running" would be a lie. Nothing distinguishes the two
+  # cases from inside, so say both.
+  echo "ERROR: flutter pid $pid is not visible from here. Either:" >&2
+  echo "       - the app has stopped, and $PID_FILE is stale; or" >&2
+  echo "       - you are in the agent sandbox, which hides host processes and blocks" >&2
+  echo "         localhost, so a running app looks exactly like a dead one." >&2
+  echo "       If the app is running, re-run with the sandbox disabled." >&2
+  exit 1
+fi
+
+# Anchor on the "Dart VM Service" line. A looser match for an http://127.0.0.1 URL
+# also hits the DevTools line printed right after it, and picking that one yields an
+# HTML page and a 0-byte screenshot with no error anywhere.
+uri="$(sed -n 's#.*Dart VM Service.*available at: \(http://[^ ]*\)#\1#p' "$LOG_FILE" 2>/dev/null | tail -1)"
+if [[ -z "$uri" ]]; then
+  echo "ERROR: no VM service URL in $LOG_FILE." >&2
+  echo "       A release build has none; otherwise restart with bin/dev_run.sh --background." >&2
+  exit 1
+fi
+
+response="$(mktemp "${TMPDIR:-/tmp}/dev_screenshot.XXXXXX")"
+trap 'rm -f "$response"' EXIT
+
+rc=0
+curl_err="$(curl -sS --max-time "$timeout_s" "${uri}_flutter.screenshot" -o "$response" 2>&1)" || rc=$?
+if (( rc != 0 )); then
+  # We only get here with a live pid, so a refused connection is not a dead app -
+  # it is the agent sandbox, which blocks localhost. Same misdiagnosis as
+  # "cannot open display: :0" for X11 and "Network is unreachable" for the phone.
+  if (( rc == 7 )); then
+    hostport="${uri#*//}"
+    hostport="${hostport%%/*}"
+    echo "ERROR: cannot reach the VM service at $hostport while flutter pid $pid is alive." >&2
+    echo "       That is the agent sandbox blocking localhost, not a stopped app." >&2
+    echo "       Re-run with the sandbox disabled (dangerouslyDisableSandbox: true)." >&2
+  else
+    echo "ERROR: curl failed (exit $rc): $curl_err" >&2
+  fi
+  exit 1
+fi
+
+# JSON-RPC over GET answers either {"result":{...}} or {"error":{"message":...}}.
+if ! jq -e 'has("result") and (.result.screenshot | type == "string")' "$response" >/dev/null 2>&1; then
+  err_msg="$(jq -r '.error.message // empty' "$response" 2>/dev/null || true)"
+  if [[ -n "$err_msg" ]]; then
+    echo "ERROR: the VM service rejected _flutter.screenshot: $err_msg" >&2
+  else
+    echo "ERROR: unexpected response from the VM service (first 200 bytes):" >&2
+    head -c 200 "$response" >&2
+    echo >&2
+  fi
+  exit 1
+fi
+
+mkdir -p "$(dirname "$out")"
+# Decode beside the destination and move into place, so a failed or truncated decode
+# never leaves a plausible-looking file where the caller will read it as current.
+tmp_png="$(mktemp "${out}.XXXXXX")"
+trap 'rm -f "$response" "$tmp_png"' EXIT
+jq -r '.result.screenshot' "$response" | base64 -d >"$tmp_png" ||
+  { echo "ERROR: could not decode the screenshot payload" >&2; exit 1; }
+
+# Check the artifact, not the exit code. An empty or truncated capture is a valid-
+# looking PNG path with nothing in it, and that reads as "the app rendered nothing".
+magic="$(head -c 8 "$tmp_png" | od -An -tx1 | tr -d ' \n')"
+if [[ "$magic" != "89504e470d0a1a0a" ]]; then
+  echo "ERROR: decoded payload is not a PNG (magic: ${magic:-empty})" >&2
+  exit 1
+fi
+bytes="$(stat -c %s "$tmp_png")"
+if (( bytes < 1000 )); then
+  echo "ERROR: screenshot is only $bytes bytes - truncated, not a real frame" >&2
+  exit 1
+fi
+
+mv "$tmp_png" "$out"
+trap 'rm -f "$response"' EXIT
+echo "Wrote $out ($bytes bytes, $(file -b "$out" 2>/dev/null | cut -d, -f2- | sed 's/^ //'))"


### PR DESCRIPTION
## Why

There was no way to screenshot the app on Linux desktop, and the documented workaround was a dead end rather than a bug to fix:

- This is **Crostini + sommelier**. `WAYLAND_DISPLAY` is sommelier's socket; the real compositor is ChromeOS's `exo`/ash, on the host side of the VM.
- `grim` fails with `compositor doesn't support wlr-screencopy-unstable-v1`, and always will — a guest container is not allowed to read the host framebuffer.
- `scrot` sees only the Xwayland root, which a native-Wayland Flutter window is not in. That, not multi-monitor, is why it came back **entirely black**.

So the run-app skill told agents to verify desktop work from `flutter.log`, from `FlightLog.db`, or by asking the person at the keyboard — and UI changes on desktop went unlooked-at.

## What

`bin/dev_screenshot.sh` captures from the **engine** instead of the compositor: it asks for the last rasterized frame over the VM service `flutter run` already exposes (`_flutter.screenshot`, which answers plain HTTP GET), then decodes the base64 PNG.

**Nothing about how the app is launched changes** — `bin/dev_run.sh` is untouched and desktop stays native Wayland. It also needs no focus, is unbothered by an obscured or backgrounded window, and comes out at full resolution with no chrome to crop.

```bash
bin/dev_screenshot.sh                # -> dev_data/screenshot.png
bin/dev_screenshot.sh -o shot.png
```

Scope is deliberately desktop-only. Android keeps `adb exec-out screencap`, which is strictly better there — it captures platform views (the Cesium webview) and system UI, neither of which the VM service can see. The script happens to work against a device target too, so it is documented as the fallback for when adb is being difficult.

## Verification

Every guard was driven to red deliberately, not just seen passing. Guards 3–7 ran the **real script** from a fake repo root (`bin/` + `dev_data/` copies) so the pid file and log could be controlled without touching the live ones.

| test | result |
|---|---|
| happy path, `-o`, other cwd, `-h`, bad arg | pass — PNGs read back as full-fidelity UI |
| tracks live state | hot restart between two shots: different md5, second shows the restarted app |
| no pid file | fired for real when the app was closed mid-session |
| dead pid / sandboxed | honest dual message, exit 1 |
| no VM service line in log | clear error naming the log |
| JSON-RPC error | `Method not found`, no file written |
| non-PNG payload / 8-byte payload | both assertions fire, no file written |

No path leaves a file at the destination on failure — a truncated capture must not sit there looking current.

## Note on the liveness check

It cannot say "stale pid file" the way `dev_reload.sh` does. The agent sandbox runs in its own PID namespace (`pid:[4026533085]` vs `4026532712`), so a healthy app's pid is invisible and `kill -0` fails exactly as it would for a dead one. Nothing distinguishes the two from inside, so the script names both possibilities instead of confidently declaring the app dead.

## Docs

- `.claude/skills/run-app/SKILL.md` — §4 points at the script and explains *why* no Wayland tool can work here, so nobody re-litigates `grim`/`xvfb`; sandbox table gains the PID-namespace row; "Driving the UI" marked Android-only (`xdotool` cannot reach native-Wayland windows, and sommelier exposes neither the virtual-keyboard nor virtual-pointer protocol).
- `CLAUDE.md` — command block, "Debug UI" row split desktop/Android, stale `use adb screenshots` note.

No Dart changed, so no `flutter analyze` / `flutter test` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)