### PR TITLE
Fix a query that blanks flown-site details, and keep a catalogue row on its own key

### DIFF
--- a/the_paragliding_app/lib/presentation/screens/data_management_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/data_management_screen.dart
@@ -315,6 +315,14 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
       // is not the same as when it last downloaded one - "checked yesterday,
       // unchanged" and "not checked for a month" look identical otherwise, and
       // only one of them is a problem.
+      // Which copy is on disk, so "Last Downloaded: Recently" cannot imply new
+      // data after a Reset to Bundled - the file is freshly written, but its
+      // contents are older than what is published. Derived rather than stored:
+      // the reset clears the validators, so having none means the bundled copy.
+      final validators = await PreferencesHelper.getCatalogValidators();
+      final fromPublished =
+          validators.etag != null || validators.lastModified != null;
+
       final checkedAt = await PreferencesHelper.getCatalogCheckedDate();
       final lastChecked = checkedAt == null
           ? 'Never'
@@ -323,10 +331,11 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
       final combinedStats = {
         ...stats,
         'database_size_mb': ((stats['database_size_bytes'] ?? 0) / 1024 / 1024).toStringAsFixed(1),
-        'last_downloaded': lastDownloaded,
+        'last_downloaded': lastDownloaded == 'Never'
+            ? lastDownloaded
+            : '$lastDownloaded · ${fromPublished ? 'published' : 'bundled'}',
         'last_checked': lastChecked,
         'source_file_size_mb': ((downloadStatus['file_size_bytes'] ?? 0) / 1024 / 1024).toStringAsFixed(1),
-        'status': stats['sites_count'] > 0 ? 'Active' : 'Not downloaded',
         'is_outdated': downloadStatus['is_outdated'] ?? false,
       };
 
@@ -385,6 +394,10 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
       await _runCatalogUpdate();
     } finally {
       if (mounted) setState(() => _catalogBusy = false);
+      // Here rather than on each success path: a failed download or import still
+      // performed the check, and stamped it, so the rows have to catch up or
+      // "Last Checked" reads as though nothing happened.
+      await _loadPgeSitesStats();
     }
   }
 
@@ -2447,12 +2460,20 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
 
                   const SizedBox(height: 24),
 
-                  // PGE Sites Database
+                  // Site catalogue. Not "PGE sites": it merges ParaglidingEarth
+                  // with national guides, and 135 Australian launches have no PGE
+                  // entry at all - naming one source misrepresents the rest.
                   AppExpansionCard.dataManagement(
                     icon: Icons.public,
-                    title: 'PGE Sites Database',
+                    title: 'Site Database',
+                    // "Active" used to sit in the last slot, which only ever
+                    // meant sites_count > 0 - nothing the count beside it did not
+                    // already say. Replaced with the one thing a collapsed card
+                    // should surface: whether there is anything to do.
                     subtitle: _pgeSitesStats != null
-                        ? '${_formatNumber(_pgeSitesStats!['sites_count'] ?? 0)} sites • ${_pgeSitesStats!['database_size_mb'] ?? '0.0'}MB • ${_pgeSitesStats!['status'] ?? 'Unknown'}'
+                        ? '${_formatNumber(_pgeSitesStats!['sites_count'] ?? 0)} sites'
+                            '${(_pgeSitesStats!['sites_count'] ?? 0) == 0 ? ' • not downloaded' : ''}'
+                            '${_pgeSitesStats!['is_outdated'] == true ? ' • update available' : ''}'
                         : 'Loading...',
                     expansionKey: 'pge_sites_db',
                     expansionManager: _expansionManager,
@@ -2463,21 +2484,16 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
                     },
                     children: [
                       const Text(
-                        'The location of every PGE site is stored locally to improve site map performance.',
+                        'Worldwide launch sites, merged from ParaglidingEarth and '
+                        'national site guides and stored on this device. Site '
+                        'lookups and the site map work without a connection, '
+                        'which matters where you fly.',
                         style: TextStyle(color: Colors.grey, fontSize: 12),
                       ),
                       const SizedBox(height: 16),
                       if (_pgeSitesStats != null) ...[
                         AppStatRowGroup.dataManagement(
                           rows: [
-                            AppStatRow.dataManagement(
-                              label: 'Total Sites',
-                              value: _formatNumber(_pgeSitesStats!['sites_count'] ?? 0),
-                            ),
-                            AppStatRow.dataManagement(
-                              label: 'Database Size',
-                              value: '${_pgeSitesStats!['database_size_mb'] ?? '0.0'}MB',
-                            ),
                             AppStatRow.dataManagement(
                               label: 'Last Downloaded',
                               value: _pgeSitesStats!['last_downloaded'] ?? 'Never',
@@ -2494,10 +2510,6 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
                                 label: 'Status',
                                 value: 'Update available',
                               ),
-                            AppStatRow.dataManagement(
-                              label: 'Source Size',
-                              value: '${_pgeSitesStats!['source_file_size_mb'] ?? '0.0'}MB',
-                            ),
                             if (_pgeSitesProgress != null && _pgeSitesProgress!.status == PgeSitesDownloadStatus.downloading)
                               AppStatRow.dataManagement(
                                 label: 'Download Progress',
@@ -2524,13 +2536,6 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
                         ),
                       ],
 
-                      const SizedBox(height: 16),
-                      const Text(
-                        'Worldwide paragliding sites, merged from ParaglidingEarth and '
-                        'national site guides, for offline use. This enables fast site '
-                        'lookups without internet connectivity.',
-                        style: TextStyle(color: Colors.grey, fontSize: 12),
-                      ),
                       const SizedBox(height: 16),
                       Row(
                         children: [

--- a/the_paragliding_app/lib/services/pge_sites_database_service.dart
+++ b/the_paragliding_app/lib/services/pge_sites_database_service.dart
@@ -411,6 +411,7 @@ class PgeSitesDatabaseService {
       var updated = 0;
       var unkeyable = 0;
       var deleted = 0;
+      var superseded = 0;
 
       await db.transaction((txn) async {
         // Key anything still unkeyed before matching on refs. initializeTables
@@ -424,18 +425,42 @@ class PgeSitesDatabaseService {
             .map((row) => row['ref'] as String?)
             .whereType<String>()
             .toSet();
+        // Frozen before the loop. `existingRefs` grows as the snapshot is keyed
+        // below, and a ref this import has just introduced is not evidence that
+        // the database already held the row.
+        final priorRefs = Set<String>.of(existingRefs);
         final snapshotRefs = <String>{};
+        // Tokens a surviving row names but is not keyed on, so the delete step
+        // can tell a merge apart from a withdrawal.
+        final supersededBy = <String, String>{};
 
         final batch = txn.batch();
         for (final siteData in sitesData) {
           // The CSV's own `id` is not imported: it is a row number that moves
           // whenever the producer's output does.
-          final ref = CatalogRef.fromSource(siteData['source'] as String?);
+          //
+          // A row the database already holds keeps the key it is stored under,
+          // instead of being re-derived from precedence every import. A launch
+          // first described only by `ansg:106-28` gains `pge:4632` the day PGE
+          // picks it up - routine as federation grows - and precedence alone
+          // would rename the row. A rename here is a delete plus an insert: the
+          // favourite goes with the deleted row, and every `sites.catalog_ref`
+          // pointing at it dangles for good, because the old key is never
+          // emitted again. Precedence therefore only keys rows that are new.
+          final tokens = CatalogRef.tokensOf(siteData['source'] as String?);
+          final held = tokens.where(priorRefs.contains);
+          final ref = held.isNotEmpty
+              ? held.first
+              : CatalogRef.fromSource(siteData['source'] as String?);
           if (ref == null) {
             unkeyable++;
             continue;
           }
           snapshotRefs.add(ref);
+          // Every other token on this row names the same launch.
+          for (final token in tokens) {
+            if (token != ref) supersededBy[token] = ref;
+          }
           // add() reports whether the ref is new to this batch, so a ref
           // appearing twice in one snapshot counts as one insert and one update
           // rather than two inserts - the upsert is what actually happens, and
@@ -483,7 +508,24 @@ class PgeSitesDatabaseService {
         }
         await batch.commit(noResult: true);
 
-        for (final gone in existingRefs.difference(snapshotRefs)) {
+        for (final gone in priorRefs.difference(snapshotRefs)) {
+          final successor = supersededBy[gone];
+          if (successor != null) {
+            // Two guides' entries merged into one catalogue row. The launch did
+            // not go away, so neither should the favourite nor the flown site's
+            // link. Unlike the positional relink this change removed, the two
+            // keys are known to name one launch, because the surviving row
+            // still lists the old key in its own `source`.
+            await txn.rawUpdate(
+              'UPDATE $_pgeSitesTable SET is_favorite = 1 WHERE ref = ? AND '
+              'EXISTS (SELECT 1 FROM $_pgeSitesTable WHERE ref = ? '
+              'AND is_favorite = 1)',
+              [successor, gone],
+            );
+            await txn.update('sites', {'catalog_ref': successor},
+                where: 'catalog_ref = ?', whereArgs: [gone]);
+            superseded++;
+          }
           deleted += await txn
               .delete(_pgeSitesTable, where: 'ref = ?', whereArgs: [gone]);
         }
@@ -503,6 +545,7 @@ class PgeSitesDatabaseService {
         'rows_inserted': inserted,
         'rows_updated': updated,
         'rows_deleted': deleted,
+        'rows_superseded_by_merge': superseded,
         'rows_unkeyable_skipped': unkeyable,
         'favourites_held': favourites ?? 0,
         'site_links_dangling': dangling ?? 0,
@@ -902,7 +945,7 @@ class PgeSitesDatabaseService {
   Future<ParaglidingSite?> getSiteByRef(String ref) async {
     final db = await DatabaseHelper.instance.database;
     final rows = await db.rawQuery('''
-      SELECT s.*, cc.country_name
+      SELECT s.*, COALESCE(cc.name, s.country) as country_name
       FROM $_pgeSitesTable s
       LEFT JOIN $_countryCodesTable cc ON UPPER(s.country) = cc.code
       WHERE s.ref = ?

--- a/the_paragliding_app/test/catalog_ref_stability_test.dart
+++ b/the_paragliding_app/test/catalog_ref_stability_test.dart
@@ -53,6 +53,29 @@ void main() {
         },
       ];
 
+  /// A launch only the Australian guide describes, alongside the two above so
+  /// the fixtures in setUp are not disturbed.
+  List<Map<String, dynamic>> catalogueAnsgOnly() => [
+        ...catalogueA(),
+        {
+          'id': 19, 'name': 'Corryong - Mt Elliot', 'longitude': 147.9,
+          'latitude': -36.19, 'altitude': 500, 'country': 'au',
+          'source': 'ansg:106-28', 'wind_n': 2,
+        },
+      ];
+
+  /// The same launch after ParaglidingEarth starts describing it too. The
+  /// producer emits a second, higher-precedence token; nothing about the launch
+  /// itself has changed.
+  List<Map<String, dynamic>> catalogueAnsgPlusPge() => [
+        ...catalogueA(),
+        {
+          'id': 19, 'name': 'Corryong - Mt Elliot', 'longitude': 147.9,
+          'latitude': -36.19, 'altitude': 500, 'country': 'au',
+          'source': 'ansg:106-28;pge:7001', 'wind_n': 2,
+        },
+      ];
+
   setUp(() async {
     await TestHelpers.initializeDatabaseForTesting();
     await DatabaseHelper.instance.recreateDatabase();
@@ -146,5 +169,93 @@ void main() {
       north: -30.0, south: -31.0, east: 151.0, west: 150.0,
     );
     expect(sites.firstWhere((s) => s.name == 'Mt Borah').altitude, 800);
+  });
+
+  test('a launch that gains a higher-precedence guide keeps its key', () async {
+    // CatalogRef.fromSource returns the *highest-precedence* token, so deriving
+    // the key afresh on every import renamed a row the day a second guide began
+    // describing it - ansg:106-28 becoming pge:7001. A rename is a delete plus
+    // an insert: the favourite went with the deleted row, and the flown site's
+    // link pointed at a key the producer will never emit again, so unlike a
+    // withdrawal it could not self-heal. Drop the `held` lookup in
+    // importSitesData and this goes red.
+    await PgeSitesDatabaseService.instance.importSitesData(
+        rows: catalogueAnsgOnly());
+    await db.update('pge_sites', {'is_favorite': 1},
+        where: 'ref = ?', whereArgs: ['ansg:106-28']);
+    await db.insert('sites', {
+      'id': 2, 'name': 'Corryong', 'latitude': -36.19, 'longitude': 147.9,
+      'catalog_ref': 'ansg:106-28',
+      'created_at': DateTime.now().toIso8601String(),
+    });
+
+    await PgeSitesDatabaseService.instance.importSitesData(
+        rows: catalogueAnsgPlusPge());
+
+    final site = (await db.query('sites', where: 'id = 2')).single;
+    expect(site['catalog_ref'], 'ansg:106-28',
+        reason: 'a row already keyed is not re-keyed by precedence');
+
+    final kept = (await db.query('pge_sites',
+            where: 'ref = ?', whereArgs: ['ansg:106-28']))
+        .single;
+    expect(kept['is_favorite'], 1, reason: 'the favourite must survive');
+    expect(
+        await db.query('pge_sites', where: 'ref = ?', whereArgs: ['pge:7001']),
+        isEmpty,
+        reason: 'the row was updated in place, not replaced under a new key');
+  });
+
+  test('two entries merging into one carry the favourite and the link',
+      () async {
+    // The residual case: both keys are already in the database, so one of them
+    // genuinely has to go. It is still not a withdrawal - the surviving row
+    // names the old key in its own `source` - so the favourite and the flown
+    // site follow it across rather than being dropped.
+    await PgeSitesDatabaseService.instance.importSitesData(rows: [
+      ...catalogueAnsgOnly(),
+      {
+        'id': 20, 'name': 'Corryong (PGE)', 'longitude': 147.9,
+        'latitude': -36.19, 'altitude': 500, 'country': 'au',
+        'source': 'pge:7001', 'wind_n': 2,
+      },
+    ]);
+    await db.update('pge_sites', {'is_favorite': 1},
+        where: 'ref = ?', whereArgs: ['pge:7001']);
+    await db.insert('sites', {
+      'id': 2, 'name': 'Corryong', 'latitude': -36.19, 'longitude': 147.9,
+      'catalog_ref': 'pge:7001',
+      'created_at': DateTime.now().toIso8601String(),
+    });
+
+    // The producer works out they are one launch and emits a single row.
+    await PgeSitesDatabaseService.instance.importSitesData(
+        rows: catalogueAnsgPlusPge());
+
+    final site = (await db.query('sites', where: 'id = 2')).single;
+    expect(site['catalog_ref'], 'ansg:106-28',
+        reason: 'the link follows the launch onto the surviving key');
+
+    final survivor = (await db.query('pge_sites',
+            where: 'ref = ?', whereArgs: ['ansg:106-28']))
+        .single;
+    expect(survivor['is_favorite'], 1,
+        reason: 'the favourite was on the absorbed row and must not be lost');
+  });
+
+  test('the catalogue tab can read the row a flown site is linked to', () async {
+    // getSiteByRef selected `cc.country_name`, which country_codes does not have
+    // - its columns are (code, name), and every sibling query in that file uses
+    // COALESCE(cc.name, s.country). So it threw `no such column` for every flown
+    // site carrying a catalog_ref, and site_details_screen calls it with no
+    // catchError, so the wind/altitude/guide tab silently never populated.
+    await PgeSitesDatabaseService.instance.importSitesData(rows: catalogueA());
+
+    final site =
+        await PgeSitesDatabaseService.instance.getSiteByRef('pge:4632');
+
+    expect(site, isNotNull, reason: 'the query must not throw');
+    expect(site!.name, 'Manilla - Mt Borah - West launch');
+    expect(site.altitude, 800);
   });
 }


### PR DESCRIPTION
Replaces #332, which could not merge. #330 was squash-merged, so `main` holds one commit containing that work while `catalog-stable-refs` still had the pre-squash history — both sides had "changed" the same lines since the merge base, and reusing the branch was the mistake. These are the same two commits cherry-picked onto current `main`: 3 files, and `git merge-tree` against `main` is clean.

## The one that matters — live on `main` now

**`getSiteByRef` selected a column that does not exist**, so it threw for every flown site carrying a `catalog_ref`:

```sql
SELECT s.*, cc.country_name          -- country_codes is (code, name)
```

Every sibling query in the file uses `COALESCE(cc.name, s.country) as country_name`. `site_details_screen.dart:129` calls it with no `catchError`, so on a flown site the **wind, altitude and guide tabs silently never populated**. The bug predates #330 under the old `getSiteById`, but #330 is what put it on the flown-site path, and it had no test at all.

## A favourite could be lost outright, not merely dangle

`CatalogRef.fromSource` returns the highest-precedence token, and the import re-derived every row's key on every import. So a launch first described only by the Australian guide — `ansg:106-28` — was *renamed* to `pge:4632` the day ParaglidingEarth picked it up. That is routine as federation grows, not an upstream mistake.

A rename here is a delete plus an insert: `is_favorite` went with the deleted row, and `sites.catalog_ref` pointed at a key the producer will never emit again. Unlike the withdrawn-entry case `catalog_ref_stability_test.dart` already covers, **that cannot self-heal.**

A row the database already holds now keeps the key it is stored under; precedence only keys rows that are new. Where both keys are already stored one genuinely has to go, and the merge is carried rather than dropped — the surviving row still names the old key in its own `source`, so the two are known to be one launch, and the favourite and every `sites.catalog_ref` follow it across, logged as `rows_superseded_by_merge`.

Not the positional relink #330 deleted: that guessed from row numbers, this moves a link only when the catalogue itself states the two keys name the same launch.

## Data Management card

Reviewed in the running app:

- **"PGE Sites Database" → "Site Database".** The old title named one source; 135 Australian launches have no ParaglidingEarth entry at all.
- **One description, at the top.** There were two, so the explanation of what the card is came *after* the numbers.
- **The buttons say what they do and when.** Neither name carries it: "Check for Updates" sounds like it might touch the flight log, and "Reset to Bundled" gives no hint that it moves you backwards.
- **Dropped Total Sites, Database Size, Source Size.** The header already gives the count, and nobody asks the size of a 2 MB table. Last Downloaded and Last Checked stay — the only rows that tell you whether to press anything.
- **"Active" removed from the header line.** It was `sites_count > 0 ? 'Active' : …`, printed beside the count that already said so. That slot now shows "update available".

Two rows were reporting wrongly, both found by asking whether they update when the buttons are pressed:

- **Last Checked did not update after a failed check** — the download-failed and import-failed paths returned before the stats reload, so a check that really happened, and really was stamped, left the row stale. Moved into `finally`, which also covers an exception.
- **Last Downloaded is the file's mtime, so a Reset to Bundled read "Recently"** — fresh file, older contents, exactly backwards. Now reads "Recently · bundled" / "· published", derived from whether the HTTP validators exist rather than from new state.

## Verification

- Both defects are pinned by tests that go red without the fix.
- 265 tests pass on this branch; `flutter analyze` clean.
- Run on Linux desktop against a **real v4 database upgraded in place**: 43 of 43 flown-site links converted with 0 unresolved, 11,703 rows keyed, then an auto-refresh from the published catalogue (881 KB → 11,703 updates, 0 inserts, 0 dangling). The card renders with no overflow, and Last Downloaded correctly read "· bundled" after a Reset to Bundled.

Known gaps, neither blocking: the new button-help paragraph sits below the fold in a desktop window and nobody has laid eyes on it — desktop cannot be scrolled or tapped, so it wants a moment on the phone. And the reset's import took 39 s with two `database has been locked for 0:00:10` warnings against 3.6 s at startup; most likely contention with the stats reload while the app was interactive, but I have not established that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
