### PR TITLE
Drive the Linux desktop UI from the VM service, not the compositor

### DIFF
--- a/.claude/skills/run-app/SKILL.md
+++ b/.claude/skills/run-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-app
-description: Run, hot-reload, screenshot and read logs for this Flutter app, on Linux desktop or on an Android phone/emulator. Use when asked to run, launch, start, restart or hot-reload the app, to screenshot it, to check its runtime logs, or to verify a change in the running app rather than in tests. Covers bin/dev_run.sh, bin/dev_reload.sh, bin/dev_screenshot.sh, wireless adb device ids, and the debug-vs-production package trap.
+description: Run, hot-reload, screenshot and read logs for this Flutter app, on Linux desktop or on an Android phone/emulator. Use when asked to run, launch, start, restart or hot-reload the app, to screenshot it, to check its runtime logs, or to verify a change in the running app rather than in tests. Also use when asked to tap, scroll, drag or otherwise drive the app's UI to reach a screen. Covers bin/dev_run.sh, bin/dev_reload.sh, bin/dev_screenshot.sh, bin/dev_input.sh, wireless adb device ids, and the debug-vs-production package trap.
 ---
 
 # Running this app
@@ -168,12 +168,56 @@ that file **is** the readiness check. There is no status command and none is nee
 Allowed as of 2026-08-08 — it used to say "ask the user to navigate". Navigate to the
 screen under test and look at it yourself; a UI fix nobody has looked at is unverified.
 
-**Android only.** Input injection has no desktop equivalent here: `xdotool` cannot reach
-native-Wayland windows, and sommelier exposes neither the virtual-keyboard nor the
-virtual-pointer protocol, so `wtype` and `ydotool` are out too. On desktop you can *see*
-any screen (`bin/dev_screenshot.sh`) but only reach the ones the app opens on its own —
-for anything needing taps, use the phone, or ask the person at the keyboard to navigate
-and then screenshot.
+Works on both targets now, by completely different routes. Desktop was Android-only until
+2026-08-10.
+
+### Desktop: `bin/dev_input.sh`
+
+```bash
+bin/dev_input.sh tap 598 1004              # tap the Log Book nav item
+bin/dev_input.sh scroll 478 500 900        # wheel down 900px at that point
+bin/dev_input.sh scroll 478 500 -900       # ... and back up
+bin/dev_input.sh drag 478 800 478 300 400  # drag up over 400ms
+```
+
+**Coordinates are screenshot pixels**, straight off `bin/dev_screenshot.sh` — the script
+divides by `devicePixelRatio` itself. That ratio is 1.0 on this desktop, so a missing
+conversion would look correct here and break on any HiDPI box; it is done in one place
+rather than left to the caller.
+
+Nothing was added to the app to make this work, and nothing needs to be. It evaluates Dart
+in the running isolate over the VM service — `GestureBinding.handlePointerEvent`, the same
+entry point the widget-test framework drives, which does its own hit test. No compositor
+involved, which is the whole point: `xdotool` cannot reach native-Wayland windows, and
+sommelier exposes neither the virtual-keyboard nor the virtual-pointer protocol, so
+`wtype` and `ydotool` are out. Same reasoning as `dev_screenshot.sh` going to the engine
+rather than to `grim`.
+
+Four things about it are worth knowing before you debug it:
+
+- **It dies with `flutter run`, not with the app.** Expression evaluation needs the
+  `compileExpression` service that `flutter run` registers, so it goes away the moment
+  flutter detaches even if the app is still on screen. `dev_run.sh` removes the pid file
+  then, and the script refuses on that — same readiness check as `dev_screenshot.sh`.
+- **No text entry.** Tapping a field moves the caret, but the engine owns the keyboard
+  channel and there is nothing to type on. Use the phone for anything involving typing.
+- **Platform views are not driven** (and not captured) — free on Linux, where the 3D map
+  is a placeholder anyway.
+- **A throw lands in `flutter.log`, not in the exit code**, because events are queued onto
+  the app's event loop instead of run inline. The script greps its own slice of the log for
+  `[DEV_INPUT] ERROR` and exits 1, so a failed injection cannot look like a success. That
+  check was verified by making it fail on purpose.
+
+The queueing is load-bearing, not incidental. The VM runs an evaluation at the next
+safepoint, which can be *inside* `drawFrame`; dispatching a pointer event from there
+reenters the framework mid-build and the scroll handler throws `setState() called during
+build`. It only bites once something is animating — a tap on an idle app looks perfect and
+a drag fails on its second move. Related trap: an evaluated closure shows up in a stack
+trace as a bare `Eval ()` frame with no file or line, which fails an assertion inside
+`StackFrame.fromStackTraceLine`, so a real exception surfaces as a confusing regex-match
+assertion. If you see one of those, look for the underlying error, not for a Flutter bug.
+
+### Android: `adb shell input`
 
 ```bash
 DEV=adb-52110DLAQ001UT-hkZkFs._adb-tls-connect._tcp
@@ -186,17 +230,21 @@ adb -s "$DEV" exec-out screencap -p > dev_data/screenshot.png
 
 Needs the sandbox off, like everything else that reaches the phone.
 
-- **Coordinates are device pixels.** The Pixel 9 is 1080x2424 px at dpr 2.625, so a widget
-  at 200dp from the left is at x=525. Read a screenshot to find a target — never guess from
-  Flutter layout numbers.
+- **Coordinates are device pixels, and adb will not convert them for you** — unlike
+  `dev_input.sh`. The Pixel 9 is 1080x2424 px at dpr 2.625, so a widget at 200dp from the
+  left is at x=525. Read a screenshot to find a target — never guess from Flutter layout
+  numbers.
+
+### Both targets
+
 - **Screenshot after every step, before the next.** Taps land on whatever is there now, and
   a tap that misses looks identical to one that worked until you look.
 - **Let the frame settle** — `sleep 1` between a tap and its screenshot, or the capture
   catches a half-built route mid-animation and reads as a rendering bug.
 - **Read `dev_data/flutter.log` alongside.** An overflow or exception caused by your own
   navigation is a real finding; one caused by a mistap is noise. The log tells them apart.
-- Still true: **never `pm clear`/`pm uninstall`** anything, suffixed or not, and unlock the
-  phone first — a screenshot of a locked phone is a valid PNG of the lock screen.
+- Still true on Android: **never `pm clear`/`pm uninstall`** anything, suffixed or not, and
+  unlock the phone first — a screenshot of a locked phone is a valid PNG of the lock screen.
 
 ## Wireless debugging (physical device)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ bin/dev_reload.sh             # Hot reload  (SIGUSR1 via dev_data/flutter.pid)
 bin/dev_reload.sh R           # Hot restart (SIGUSR2) - needed for main()/initState changes
 
 bin/dev_screenshot.sh         # Screenshot the desktop app -> dev_data/screenshot.png
+bin/dev_input.sh tap 598 1004 # Tap/scroll/drag the desktop app (screenshot pixels)
 ```
 
 Hot reload also works with the standard `r` / `R` keys if you started it in a
@@ -726,7 +727,7 @@ task needs the app to actually run.
 | Task | Commands | Notes |
 |------|----------|-------|
 | Fix hot reload issues | `kill "$(cat dev_data/flutter.pid)"` → start again | No pid file means it already exited |
-| Debug UI (desktop) | `bin/dev_screenshot.sh` → Read the PNG | Via the VM service, not the compositor - no screenshot tool works under Crostini |
+| Debug UI (desktop) | `bin/dev_screenshot.sh` → Read the PNG; `bin/dev_input.sh` to tap/scroll | Both go via the VM service, not the compositor - no screenshot or input tool works under Crostini |
 | Debug UI (Android) | `adb exec-out screencap -p > dev_data/screenshot.png` → analyze | Unlock the phone first |
 | Performance check | `grep "\[P\]" dev_data/flutter.log` | Performance logs |
 | Schema change | Clear data → restart → reimport | Dev workflow |
@@ -752,9 +753,11 @@ Use format `file_path:line_number` in logs:
 - Call sites in local DB "Flown Sites" and sites from PGE API "New Sites"
 - Call sites in local DB "Flown Sites" and sites from PGE API "New Sites"
 - always start the app with `bin/dev_run.sh --background`
-- **Driving the app's UI with adb is allowed** (changed 2026-08-08; it was previously
-  forbidden). Navigate to the screen you need and verify the change yourself rather than
-  asking the user to tap through it — a UI fix nobody looked at is unverified. See
-  "Driving the UI" in the `run-app` skill for the commands and what to check afterwards.
+- **Driving the app's UI yourself is allowed** (adb since 2026-08-08, Linux desktop since
+  2026-08-10; both were previously forbidden). Navigate to the screen you need and verify
+  the change yourself rather than asking the user to tap through it — a UI fix nobody
+  looked at is unverified. `bin/dev_input.sh` on desktop, `adb shell input` on a phone.
+  See "Driving the UI" in the `run-app` skill for the commands, the coordinate rules and
+  what to check afterwards.
 - Filters in Map FIlter, e.g, checkboxes, should have immediate effect in the map
 - When proposing a solution, look for the simple, idomatic solution suitable for a mobile app

--- a/bin/dev_input.dart
+++ b/bin/dev_input.dart
@@ -1,0 +1,320 @@
+// Injects pointer events into the running app through the Dart VM service.
+//
+// Driven by bin/dev_input.sh - see that script for usage and for why this
+// exists. Kept in Dart rather than folded into the shell script because the VM
+// service will not compile expressions over its HTTP GET endpoint (see below),
+// and dart:io is the only websocket client on this box that needs no packages.
+//
+// Usage: dart dev_input.dart <ws-uri> <command> [args...]
+//
+// Deliberately depends on nothing outside dart:*, so it runs with a bare
+// `dart dev_input.dart` from a directory with no pubspec.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+/// The library whose scope expressions are evaluated in.
+///
+/// Not the app's own root library: `main.dart` imports material.dart, which
+/// re-exports enough for `PointerDownEvent` but *not* `PointerScrollEvent` or
+/// `PointerDeviceKind`, so a scroll fails to compile there with a confusing
+/// "Couldn't find constructor". The gestures binding library has every pointer
+/// type in scope plus `GestureBinding.instance` itself.
+const _scopeLibrary = 'package:flutter/src/gestures/binding.dart';
+
+/// Printed by an injected event that throws, and grepped for by dev_input.sh.
+const _errorMarker = '[DEV_INPUT] ERROR';
+
+/// The pointer id every event in this invocation carries.
+///
+/// Never 0, and never the same twice. `handlePointerEvent` asserts that a
+/// pointer going down has no hit-test result recorded for it, and an
+/// interrupted sequence - a drag whose up never arrived - leaves one behind
+/// forever. Sharing the default id 0 means one failed drag makes every later
+/// tap assert, which reads as a broken script rather than as leftover state.
+/// A fresh id per run sidesteps it; a hot restart clears the strays.
+final int _pointerId = DateTime.now().millisecondsSinceEpoch % 1000000 + 1;
+
+Future<void> main(List<String> args) async {
+  if (args.length < 2) {
+    stderr.writeln('usage: dart dev_input.dart <ws-uri> <command> [args...]');
+    exit(2);
+  }
+  final client = await _VmClient.connect(args[0]);
+  try {
+    await client.run(args[1], args.sublist(2));
+  } on _InputError catch (e) {
+    stderr.writeln('ERROR: ${e.message}');
+    exit(1);
+  } finally {
+    await client.close();
+  }
+}
+
+class _InputError implements Exception {
+  _InputError(this.message);
+  final String message;
+}
+
+class _VmClient {
+  _VmClient(this._ws, this._isolateId, this._scopeId, this._call);
+
+  final WebSocket _ws;
+  final String _isolateId;
+  final String _scopeId;
+  final Future<Map<String, dynamic>> Function(String, Map<String, dynamic>)
+      _call;
+
+  /// Physical pixels per logical pixel.
+  ///
+  /// Coordinates on the command line are *screenshot* pixels, because a
+  /// screenshot is the only way to find a target. `bin/dev_screenshot.sh`
+  /// returns the rasterized frame, which is physical pixels, while
+  /// [GestureBinding.handlePointerEvent] wants logical ones - so everything
+  /// gets divided by this on the way in. It is 1.0 on the Crostini desktop,
+  /// which is exactly why getting it wrong here would go unnoticed.
+  late final double _dpr;
+
+  static Future<_VmClient> connect(String wsUri) async {
+    final WebSocket ws;
+    try {
+      ws = await WebSocket.connect(wsUri);
+    } on Exception catch (e) {
+      stderr.writeln('ERROR: cannot open $wsUri');
+      stderr.writeln('       $e');
+      stderr.writeln('       If the app is running, this is the agent sandbox '
+          'blocking localhost -');
+      stderr.writeln('       re-run with the sandbox disabled.');
+      exit(1);
+    }
+
+    var nextId = 0;
+    final pending = <int, Completer<Map<String, dynamic>>>{};
+    ws.listen(
+      (raw) {
+        final msg = jsonDecode(raw as String) as Map<String, dynamic>;
+        // Streamed events carry no id; only replies resolve a call.
+        if (msg['id'] == null) return;
+        pending.remove(int.parse('${msg['id']}'))?.complete(msg);
+      },
+      onDone: () {
+        for (final c in pending.values) {
+          c.completeError(_InputError('the VM service closed the connection'));
+        }
+        pending.clear();
+      },
+    );
+
+    Future<Map<String, dynamic>> call(
+        String method, Map<String, dynamic> params) {
+      final id = ++nextId;
+      final c = Completer<Map<String, dynamic>>();
+      pending[id] = c;
+      ws.add(jsonEncode(
+          {'jsonrpc': '2.0', 'id': id, 'method': method, 'params': params}));
+      return c.future;
+    }
+
+    final vm = await call('getVM', const {});
+    final isolates = vm['result']?['isolates'] as List?;
+    if (isolates == null || isolates.isEmpty) {
+      throw _InputError('the VM service reports no isolates');
+    }
+    final isolateId = isolates.first['id'] as String;
+
+    final iso = await call('getIsolate', {'isolateId': isolateId});
+    final libraries = iso['result']?['libraries'] as List? ?? const [];
+    final scope = libraries.cast<Map<String, dynamic>>().where(
+        (l) => l['uri'] == _scopeLibrary);
+    if (scope.isEmpty) {
+      throw _InputError(
+          'no $_scopeLibrary in the running isolate - is this a Flutter app?');
+    }
+
+    final client =
+        _VmClient(ws, isolateId, scope.first['id'] as String, call);
+
+    client._dpr = double.parse(await client._evaluateRaw(
+        'GestureBinding.instance.platformDispatcher.views.first'
+        '.devicePixelRatio.toString()'));
+
+    // Resampling batches pointer events against the frame clock instead of
+    // dispatching them, so injected events would be silently swallowed or
+    // reordered. It is off by default; say so loudly rather than let a tap
+    // vanish into the resampler and read as a broken hit test.
+    final resampling =
+        await client._evaluateRaw('GestureBinding.instance.resamplingEnabled');
+    if (resampling == 'true') {
+      stderr.writeln('WARNING: pointer resampling is enabled; injected events '
+          'may be delayed or dropped.');
+    }
+
+    return client;
+  }
+
+  /// Evaluates [expression] and returns its `valueAsString`.
+  Future<String> _evaluateRaw(String expression) async {
+    final reply = await _call('evaluate', {
+      'isolateId': _isolateId,
+      'targetId': _scopeId,
+      'expression': expression,
+    });
+
+    final error = reply['error'];
+    if (error != null) {
+      final details = error['data']?['details'] ?? error['message'];
+      throw _InputError('the VM service rejected the expression:\n$details');
+    }
+
+    final result = reply['result'] as Map<String, dynamic>;
+    // An expression that throws comes back as @Error with a real result field,
+    // so a bare "did we get a result" check would call a crash a success.
+    if (result['type'] == '@Error' || result['kind'] == 'Error') {
+      throw _InputError('the expression threw: ${result['message']}');
+    }
+    if (result['type'] == 'Sentinel') {
+      throw _InputError('the isolate went away mid-evaluation '
+          '(${result['valueAsString']})');
+    }
+    return result['valueAsString'] as String? ?? '';
+  }
+
+  /// Queues [body] onto the app's event loop and waits for it to be accepted.
+  ///
+  /// `evaluate` takes an expression, not statements, so the statements go in a
+  /// closure literal that is called on the spot.
+  ///
+  /// The `Timer.run` is the load-bearing part. The VM runs an evaluation at the
+  /// next safepoint, which can be *inside* whatever the isolate is doing -
+  /// including halfway through `drawFrame`. Dispatching a pointer event from
+  /// there reenters the framework during a build, and the scroll handler throws
+  /// `setState() called during build`. It only shows up once something is
+  /// animating, so a tap on an idle app looks perfectly fine and a drag blows
+  /// up on its second move. Handing the event to the event loop instead means
+  /// it is always delivered on a clean turn.
+  ///
+  /// Timers fire in the order they were created, so a down/move/up sequence
+  /// sent as separate calls still arrives in order.
+  ///
+  /// The cost of queueing is that a throw no longer comes back in the reply -
+  /// `evaluate` has already returned "ok" by then. Worse, the framework's own
+  /// error reporter cannot render it: an evaluated closure appears in the stack
+  /// as a bare `Eval ()` frame with no file or line, which fails an assertion
+  /// inside `StackFrame.fromStackTraceLine`, so the real exception is buried
+  /// under a regex-match assertion. Hence the try/catch and the marker - it is
+  /// the only legible report, and bin/dev_input.sh greps the log for it so a
+  /// failed injection cannot exit 0.
+  Future<void> _dispatch(String body) async {
+    final value = await _evaluateRaw('(() { Timer.run(() {'
+        ' try { $body } catch (e) { debugPrint("$_errorMarker \$e"); }'
+        ' }); return "ok"; })()');
+    if (value != 'ok') throw _InputError('unexpected reply: $value');
+  }
+
+  /// Converts screenshot pixels to the logical pixels the framework expects.
+  String _offset(double x, double y) =>
+      'Offset(${x / _dpr}, ${y / _dpr})';
+
+  Future<void> run(String command, List<String> args) async {
+    switch (command) {
+      case 'tap':
+        _expectArgs(command, args, 2, 'X Y');
+        await _tap(_num(args[0], 'X'), _num(args[1], 'Y'));
+      case 'scroll':
+        _expectArgs(command, args, 3, 'X Y DY');
+        await _scroll(
+            _num(args[0], 'X'), _num(args[1], 'Y'), _num(args[2], 'DY'));
+      case 'drag':
+        if (args.length < 4 || args.length > 5) {
+          throw _InputError('drag takes X1 Y1 X2 Y2 [MS], got ${args.length} '
+              'argument(s)');
+        }
+        await _drag(
+          _num(args[0], 'X1'),
+          _num(args[1], 'Y1'),
+          _num(args[2], 'X2'),
+          _num(args[3], 'Y2'),
+          args.length == 5 ? _num(args[4], 'MS').round() : 300,
+        );
+      default:
+        throw _InputError("unknown command '$command' "
+            '(expected tap, scroll or drag)');
+    }
+  }
+
+  void _expectArgs(String command, List<String> args, int n, String shape) {
+    if (args.length != n) {
+      throw _InputError(
+          '$command takes $shape, got ${args.length} argument(s)');
+    }
+  }
+
+  double _num(String raw, String name) =>
+      double.tryParse(raw) ??
+      (throw _InputError("$name must be a number, got '$raw'"));
+
+  Future<void> _tap(double x, double y) async {
+    final p = _offset(x, y);
+    // Down and up in one evaluation, so they land in a single event-loop turn:
+    // a tap recognizer wants both inside its deadline, and a second round trip
+    // can exceed it on a slow connection.
+    await _dispatch('final b = GestureBinding.instance;'
+        'b.handlePointerEvent(const PointerDownEvent(position: $p, '
+        'pointer: $_pointerId));'
+        'b.handlePointerEvent(const PointerUpEvent(position: $p, '
+        'pointer: $_pointerId));');
+  }
+
+  Future<void> _scroll(double x, double y, double dy) async {
+    // A wheel signal, not a drag: Scrollable hit-tests PointerScrollEvent
+    // directly and applies the delta at once, so it needs no slop, no
+    // intermediate frames, and produces no fling. Positive dy scrolls down.
+    await _dispatch('GestureBinding.instance.handlePointerEvent('
+        'const PointerScrollEvent(position: ${_offset(x, y)}, '
+        'kind: PointerDeviceKind.mouse, '
+        'scrollDelta: ${_offset(0, dy)}));');
+  }
+
+  Future<void> _drag(
+      double x1, double y1, double x2, double y2, int ms) async {
+    const steps = 10;
+    final clock = Stopwatch()..start();
+
+    Future<void> send(String event) =>
+        _dispatch('GestureBinding.instance.handlePointerEvent($event);');
+
+    // Timestamps are real elapsed time, not the requested duration. The
+    // velocity tracker reads them, so claiming a 300ms drag that actually took
+    // 2s over the wire would synthesise a fling that never happened.
+    String stamp() => 'timeStamp: Duration(microseconds: '
+        '${clock.elapsedMicroseconds})';
+
+    await send('PointerDownEvent(position: ${_offset(x1, y1)}, '
+        'pointer: $_pointerId, ${stamp()})');
+
+    var prevX = x1;
+    var prevY = y1;
+    for (var i = 1; i <= steps; i++) {
+      final t = i / steps;
+      final x = x1 + (x2 - x1) * t;
+      final y = y1 + (y2 - y1) * t;
+      // delta matters as much as position: DragGestureRecognizer accumulates
+      // event.delta, so moves with a correct position and a zero delta scroll
+      // nothing at all.
+      await send('PointerMoveEvent(position: ${_offset(x, y)}, '
+          'delta: ${_offset(x - prevX, y - prevY)}, '
+          'pointer: $_pointerId, ${stamp()})');
+      prevX = x;
+      prevY = y;
+      final target = Duration(milliseconds: (ms * t).round());
+      final remaining = target - clock.elapsed;
+      if (remaining > Duration.zero) await Future<void>.delayed(remaining);
+    }
+
+    await send('PointerUpEvent(position: ${_offset(x2, y2)}, '
+        'pointer: $_pointerId, ${stamp()})');
+  }
+
+  Future<void> close() => _ws.close();
+}

--- a/bin/dev_input.sh
+++ b/bin/dev_input.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Tap, scroll and drag the app running on Linux desktop, without touching the
+# compositor.
+#
+#   bin/dev_input.sh tap 598 1004              # tap the Log Book nav item
+#   bin/dev_input.sh scroll 478 500 900        # wheel down 900px at that point
+#   bin/dev_input.sh scroll 478 500 -900       # ... and back up
+#   bin/dev_input.sh drag 478 800 478 300 400  # drag up over 400ms
+#
+# Coordinates are SCREENSHOT pixels, straight off bin/dev_screenshot.sh - the
+# script divides by devicePixelRatio itself, so there is no conversion to get
+# wrong. Origin is top-left. Positive scroll dy moves content up (scrolls down).
+#
+# Needs an app started by bin/dev_run.sh (debug, and still attached to
+# `flutter run`). Run it with the sandbox disabled, like the rest of bin/.
+#
+# Why this is not just a curl, like bin/dev_screenshot.sh: there is no engine
+# service extension for pointer input - the engine registers _flutter.screenshot
+# and friends and nothing for events. So this evaluates Dart in the running
+# isolate instead, calling GestureBinding.handlePointerEvent, which is the same
+# entry point the widget-test framework drives and which does its own hit test.
+#
+# That needs the VM service's `evaluate`, and evaluate needs an expression
+# compiler, which `flutter run` registers as a compileExpression service. That
+# service is only reachable over the *websocket*: the same request over the HTTP
+# GET endpoint fails with "No compilation service available". Hence a websocket
+# client, hence dev_input.dart - dart:io has one built in, so it needs no
+# packages and no pubspec.
+#
+# Consequences worth knowing:
+#   - It dies with `flutter run`. Once dev_data/flutter.log shows the
+#     "--- flutter exited ---" marker there is no expression compiler any more,
+#     even if the app is still on screen.
+#   - It injects below the platform, so it drives Flutter's gesture path and not
+#     the window's: no IME text entry, no native menus, no platform views. Same
+#     trade bin/dev_screenshot.sh already makes, and free on Linux where the 3D
+#     map is a placeholder anyway.
+#   - Text entry is NOT supported. Tap a field and the caret moves, but there is
+#     no keyboard to type on - the engine owns that channel. Use the phone.
+#
+# On Android prefer `adb shell input tap/swipe`, which goes through the real
+# input stack. This is the desktop equivalent, not a replacement for it.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PID_FILE="$REPO_ROOT/dev_data/flutter.pid"
+LOG_FILE="$REPO_ROOT/dev_data/flutter.log"
+
+if [[ $# -eq 0 || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  # Print the header comment block, as bin/dev_screenshot.sh does.
+  awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
+  # No arguments at all is a usage error, not a request for help.
+  if [[ $# -eq 0 ]]; then exit 1; fi
+  exit 0
+fi
+
+# Liveness first, same check as bin/dev_screenshot.sh: flutter writes the pid
+# file only once the app is up and removes it on exit, so it *is* the readiness
+# check.
+if [[ ! -f "$PID_FILE" ]]; then
+  echo "ERROR: $PID_FILE not found - is the app running via bin/dev_run.sh?" >&2
+  exit 1
+fi
+pid="$(cat "$PID_FILE")"
+if ! kill -0 "$pid" 2>/dev/null; then
+  # Not necessarily a stale pid file: the agent sandbox runs in its own PID
+  # namespace, so a healthy app is invisible from in there and looks exactly
+  # like a dead one. Say both rather than guess.
+  echo "ERROR: flutter pid $pid is not visible from here. Either:" >&2
+  echo "       - the app has stopped, and $PID_FILE is stale; or" >&2
+  echo "       - you are in the agent sandbox, which hides host processes and blocks" >&2
+  echo "         localhost, so a running app looks exactly like a dead one." >&2
+  echo "       If the app is running, re-run with the sandbox disabled." >&2
+  exit 1
+fi
+
+# Anchor on the "Dart VM Service" line. A looser match for an http://127.0.0.1
+# URL also hits the DevTools line printed right after it.
+uri="$(sed -n 's#.*Dart VM Service.*available at: \(http://[^ ]*\)#\1#p' "$LOG_FILE" 2>/dev/null | tail -1)"
+if [[ -z "$uri" ]]; then
+  echo "ERROR: no VM service URL in $LOG_FILE." >&2
+  echo "       A release build has none; otherwise restart with bin/dev_run.sh --background." >&2
+  exit 1
+fi
+
+# No separate check that flutter is still attached: the pid file above is that
+# check. dev_run.sh removes it when flutter exits, which is exactly when the
+# expression compiler goes away, so a missing pid file already means "no input".
+ws="ws://${uri#http://}ws"
+
+# Prefer the dart beside the flutter that built the app, so this cannot pick up
+# a different SDK from PATH.
+if command -v flutter >/dev/null; then
+  DART="$(dirname "$(readlink -f "$(command -v flutter)")")/dart"
+fi
+if [[ ! -x "${DART:-}" ]]; then
+  DART="$(command -v dart || true)"
+fi
+if [[ -z "$DART" ]]; then
+  echo "ERROR: no dart executable found (looked beside flutter, then on PATH)" >&2
+  exit 1
+fi
+
+# Events are queued onto the app's event loop rather than run inline (see
+# dev_input.dart), so the dart process exits before they are handled and a throw
+# lands in the app's log instead of in our exit code. Watch the slice of log
+# this invocation produced, or a tap that asserted exits 0 and reads as working.
+log_before="$(wc -c <"$LOG_FILE")"
+
+# Capturing rc must not go through set -e, or a dart failure would skip the
+# log check below and lose the more useful error.
+rc=0
+"$DART" "$REPO_ROOT/bin/dev_input.dart" "$ws" "$@" || rc=$?
+
+# Let the queued events run and their output reach the log before judging.
+sleep 0.5
+if tail -c "+$((log_before + 1))" "$LOG_FILE" | grep -q '\[DEV_INPUT\] ERROR'; then
+  echo "ERROR: the injected event threw inside the app:" >&2
+  tail -c "+$((log_before + 1))" "$LOG_FILE" | grep '\[DEV_INPUT\] ERROR' >&2
+  exit 1
+fi
+exit "$rc"


### PR DESCRIPTION
Desktop verification could *see* any screen but only reach the ones the app opened on its own. Input injection has no path in this container: `xdotool` cannot reach native-Wayland windows, and sommelier exposes neither the virtual-pointer nor the virtual-keyboard protocol, so `wtype` and `ydotool` are out too — the same wall `dev_screenshot.sh` hit before it started asking the engine instead.

`bin/dev_input.sh` takes the same route: it evaluates Dart in the running isolate over the VM service and calls `GestureBinding.handlePointerEvent`, the entry point the widget-test framework drives. **Nothing is added to the app**, and nothing about how it launches changes.

```bash
bin/dev_input.sh tap 598 1004              # tap the Log Book nav item
bin/dev_input.sh scroll 478 500 900        # wheel down 900px at that point
bin/dev_input.sh drag 478 800 478 300 400  # drag up over 400ms
```

## Three findings, each of which failed silently first

- **`evaluate` only works over the websocket.** The same request to the HTTP GET endpoint fails with `No compilation service available`, because the `compileExpression` service `flutter run` registers is not reachable that way. Hence a `dart:io` websocket client rather than a `curl` one-liner.
- **Events are queued with `Timer.run`, not dispatched inline.** The VM runs an evaluation at the next safepoint, which can be *inside* `drawFrame`; dispatching from there reenters the framework mid-build and the scroll handler throws `setState() called during build`. It only bites once something is animating, so a tap on an idle app looked perfect and a drag failed on its second move.
- **Every event carries a unique pointer id.** With the default id 0, one interrupted sequence leaves a hit-test result behind and every later tap asserts `!_hitTests.containsKey(event.pointer)` — which reads as a broken script rather than as leftover state.

Queueing costs in-band error reporting, and the framework cannot render these stacks anyway: an evaluated closure appears as a bare `Eval ()` frame with no file or line, tripping an assertion inside `StackFrame.fromStackTraceLine`. So injected events catch and print a `[DEV_INPUT] ERROR` marker and the wrapper greps its own slice of the log for it — **that check was made to fail on purpose before being trusted.**

Coordinates are screenshot pixels; the script divides by `devicePixelRatio` itself. That ratio is 1.0 here, so leaving it to the caller would look correct on this box and break on any other.

## Verification

Against the running app, not just exit codes:

- tap on the bottom nav — `[ACTION:Navigation] bottom_nav_tap | destination=Log Book | from_index=0 | to_index=2`
- tap on a flight row — opened flight 149, 2D track map initialised
- wheel scroll down, then back to a **byte-identical** top of list
- two consecutive drags reaching different scroll positions (proves no stuck pointer)
- the `[DEV_INPUT] ERROR` guard forced to fail: exits 1 with the real message
- `dart analyze` clean, `bash -n` clean

## Not included

Text entry. Tapping a field moves the caret, but the engine owns the keyboard channel and there is nothing to type on. Documented as a gap rather than half-built; use the phone for typing.

## Docs

`run-app` skill: "Driving the UI" split into desktop and Android halves, and the frontmatter description updated so the skill is selected when someone asks to drive the UI. `CLAUDE.md`: command list, the "Debug UI (desktop)" row, and the bullet that said adb-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)