### PR TITLE
Record the two git-workflow traps that cost time on #334

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,7 @@ lib/
 | Hot reload fails | State corruption | Use `R` (hot restart) instead of `r` |
 | App won't start | Already running | `kill "$(cat dev_data/flutter.pid)"`, then start again |
 | Hot reload does nothing | App not actually running | `kill -0 "$(cat dev_data/flutter.pid)"` - no pid file means it exited |
+| `Unable to create '.git/index.lock': File exists` | An index-writing git command was killed and left its lock | Check it is stale - `stat -c %y .git/index.lock` and `pgrep -a git` - then `rm -f .git/index.lock`. Never delete one while a git process is alive |
 
 ## Project Overview
 
@@ -712,6 +713,21 @@ Neither omission fails loudly, and the signing one is dangerous:
 
 Also absent: `.dart_tool/`, `build/`, and `dev_data/` — re-seed `dev_data/igc` only if the
 task needs the app to actually run.
+
+**Merging from a worktree: `gh pr merge <n> --squash`, without `-d`.** The repo has
+*Automatically delete head branches* enabled, so GitHub removes the branch server-side and
+gh runs no local git at all. Passing `-d` asks gh to delete the **local** branch too, which
+makes it run `git checkout main` - and that fails from a worktree, because `main` is checked
+out in the shared checkout. It fails *after* the API merge has already gone through, so the
+PR is merged while the command exits 1: check `gh pr view <n> --json state` before assuming
+it did not land. Clean up locally instead:
+
+```bash
+git worktree remove .claude/worktrees/<name>
+git branch -d <name>
+git fetch --prune origin
+git merge --ff-only origin/main    # from the shared checkout
+```
 
 ### Standard Development Process
 


### PR DESCRIPTION
Two failures during the #334 merge, both of which reported something other than what had happened. Documenting them in `CLAUDE.md` rather than leaving them to be rediscovered.

## `gh pr merge -d` exits 1 from a worktree — after merging

`-d/--delete-branch` deletes the **local** branch as well as the remote one, so gh runs `git checkout main`, which cannot work while `main` is checked out in the shared checkout. This project does every task in a worktree, so it would fail every time.

The API merge has already gone through when it fails, so the PR is merged while the command exits 1 — the same "a failing run can still have shipped" pattern already in CLAUDE.md.

**Fix:** the repo now has *Automatically delete head branches* enabled, so `-d` is unnecessary. Plain `gh pr merge <n> --squash` runs no local git at all; local cleanup is explicit (`git worktree remove`, `git branch -d`, `git fetch --prune`).

*This PR is being merged that way, as the test of it.*

## A stale `.git/index.lock` reads as a broken merge

Git never clears one by design — it cannot distinguish a stale lock from a live one — so a killed index-writing command blocks the shared checkout indefinitely. This one sat there 14 hours before surfacing as a failed `git merge --ff-only`.

Worth knowing: `git status` takes the index lock too (to refresh cached stat info), so read-only-looking commands are also a source. Linked worktrees have their own index, which is why this stayed invisible through every worktree commit and only appeared at the final fast-forward.

**Recovery, now in the error table:** prove it is stale first — `stat -c %y .git/index.lock` plus `pgrep -a git` — and only then remove it. Never delete one while a git process is alive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)