### PR TITLE
Use git branch -D in the worktree cleanup, and say why

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -724,10 +724,15 @@ it did not land. Clean up locally instead:
 
 ```bash
 git worktree remove .claude/worktrees/<name>
-git branch -d <name>
+git branch -D <name>               # -D, not -d: see below
 git fetch --prune origin
 git merge --ff-only origin/main    # from the shared checkout
 ```
+
+`-D` is not carelessness. A squash merge rewrites the work into a single new commit, so
+the branch's own commits are never ancestors of `main` and `git branch -d` refuses it as
+"not fully merged" - which is true of the commits and false of the content. Confirm the
+content landed by checking the PR is `MERGED`, not by whether `-d` is willing.
 
 ### Standard Development Process
 


### PR DESCRIPTION
Follow-up to #335, which I got wrong in the writing and caught while using it.

The cleanup snippet said `git branch -d <name>`. That refuses on **every** branch this repo merges: a squash merge rewrites the work into a single new commit, so the branch's own commits are never ancestors of `main` and `-d` reports "not fully merged". True of the commits, false of the content.

Left alone it is the worst kind of doc bug — a command that errors in a way suggesting the merge did not land, right next to a note about merges that look like they did not land.

Changed to `-D`, with a sentence on why, and a pointer to check the PR state rather than trusting `-d`'s willingness as the signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)