### PR TITLE
Say which datum a site altitude is, and take the landing from the right site

### DIFF
--- a/the_paragliding_app/lib/presentation/screens/site_details_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/site_details_screen.dart
@@ -20,6 +20,28 @@ import '../widgets/wind_rose_widget.dart';
 import '../widgets/site_forecast_table.dart';
 import '../widgets/forecast_attribution_bar.dart';
 
+/// How far a launch stands above its landing area, in whole metres.
+///
+/// Neither guide publishes this. ParaglidingEarth carries a takeoff and a
+/// landing altitude and no drop between them; the Australian Site Guide has no
+/// landing altitude at all, only prose. So it is the subtraction, and it means
+/// something only when both figures are real and the landing is below.
+///
+/// Returns null rather than a negative number when it is not. A landing above
+/// its launch is a winch or flatland site, or an altitude nobody filled in -
+/// and "-401 m" printed beside a launch reads as a bug in the app rather than
+/// as the gap in the data that it is.
+///
+/// Takes [Object?] because these arrive as XML element text, not numbers.
+int? heightAboveLanding(Object? takeoffAltitude, Object? landingAltitude) {
+  final takeoff = double.tryParse(takeoffAltitude?.toString() ?? '');
+  final landing = double.tryParse(landingAltitude?.toString() ?? '');
+  if (takeoff == null || landing == null) return null;
+
+  final drop = takeoff - landing;
+  return drop > 0 ? drop.round() : null;
+}
+
 class SiteDetailsScreen extends StatefulWidget {
   final Site? site;
   final ParaglidingSite? paraglidingSite;
@@ -775,8 +797,13 @@ class SiteDetailsScreenState extends State<SiteDetailsScreen> with SingleTickerP
   /// The point is the mainAxisSize.min Row: inside a Wrap these must be a
   /// single child, or a line break can put the glyph on one line and its
   /// value on the next - a terrain icon alone, then "150m" underneath.
-  Widget _iconFact(IconData icon, String value, {bool bold = false}) {
-    return Row(
+  ///
+  /// A [tooltip] wraps the pair rather than either half, for the same reason.
+  /// It only ever elaborates on what the text already says - nothing on this
+  /// row may depend on a hover, which a phone does not have.
+  Widget _iconFact(IconData icon, String value,
+      {bool bold = false, String? tooltip}) {
+    final fact = Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         Icon(icon, size: 16, color: Colors.grey),
@@ -789,6 +816,8 @@ class SiteDetailsScreenState extends State<SiteDetailsScreen> with SingleTickerP
         ),
       ],
     );
+
+    return tooltip == null ? fact : Tooltip(message: tooltip, child: fact);
   }
 
   /// Wind rose on the left, whatever facts belong beside it on the right.
@@ -894,6 +923,16 @@ class SiteDetailsScreenState extends State<SiteDetailsScreen> with SingleTickerP
   }
 
   List<Widget> _buildOverviewContent(String name, double latitude, double longitude, int? altitude, String? country, String? region, int? rating, String? siteType, List<String> windDirections, int? flightCount, String? distanceText, String? thermalFlag, String? soaringFlag, String? xcFlag) {
+    // Both altitudes have to come from ParaglidingEarth. The catalogue's own
+    // figure is the fallback for the launch line below, but subtracting a PGE
+    // landing from it would mix two guides' numbers - and until the producer
+    // stops publishing Site Guide's above-ground heights, sometimes two
+    // different datums. A drop is only worth showing when it is one guide's.
+    final drop = heightAboveLanding(
+      _detailedData?['takeoff_altitude'],
+      _detailedData?['landing_altitude'],
+    );
+
     return [
             // Site Type + Altitude + Wind directions + map link.
             //
@@ -923,11 +962,29 @@ class SiteDetailsScreenState extends State<SiteDetailsScreen> with SingleTickerP
                       fontWeight: FontWeight.w500,
                     ),
                   ),
-                // Show altitude (prefer takeoff_altitude from API, fallback to general altitude)
+                // Altitude, above mean sea level and said so. AGL at a launch
+                // is zero by definition, so an unlabelled figure invites the
+                // reading it cannot have - and the guides do publish both:
+                // Site Guide's height for Mt Bakewell is 255m above the
+                // valley where PGE's is 436m AMSL. The unit is written out
+                // rather than left to the tooltip, which a phone cannot hover.
+                //
+                // Prefer takeoff_altitude from the API, fall back to the
+                // catalogue.
                 if (_detailedData?['takeoff_altitude'] != null || altitude != null)
                   _iconFact(
                     Icons.terrain,
-                    '${_detailedData?['takeoff_altitude'] ?? altitude}m',
+                    '${_detailedData?['takeoff_altitude'] ?? altitude} m AMSL',
+                    tooltip: 'Altitude above mean sea level',
+                  ),
+                // How far the launch stands above its landing - the number a
+                // pilot sizes up a site with, and the one neither guide
+                // publishes. See heightAboveLanding.
+                if (drop != null)
+                  _iconFact(
+                    Icons.height,
+                    '$drop m',
+                    tooltip: 'Height above the landing area',
                   ),
                 // Wind directions (compact)
                 if (windDirections.isNotEmpty)
@@ -965,11 +1022,12 @@ class SiteDetailsScreenState extends State<SiteDetailsScreen> with SingleTickerP
                       fontWeight: FontWeight.w500,
                     ),
                   ),
-                  // Landing altitude
+                  // Landing altitude, same datum and same label as the launch
                   if (_detailedData?['landing_altitude'] != null)
                     _iconFact(
                       Icons.terrain,
-                      '${_detailedData!['landing_altitude']}m',
+                      '${_detailedData!['landing_altitude']} m AMSL',
+                      tooltip: 'Altitude above mean sea level',
                     ),
                   // Map icon for landing - uses landing coordinates if available
                   InkWell(

--- a/the_paragliding_app/lib/services/paragliding_earth_api.dart
+++ b/the_paragliding_app/lib/services/paragliding_earth_api.dart
@@ -570,108 +570,14 @@ class ParaglidingEarthApi {
       _requestCount++;
 
       if (response.statusCode == 200) {
-        // Parse XML response
-        final document = XmlDocument.parse(response.body);
-        final takeoffElements = document.findAllElements('takeoff').toList();
+        final properties = parseSiteDetails(response.body, siteId: siteId);
+        if (properties == null) return null;
 
-        LoggingService.info('ParaglidingEarthApi: Found ${takeoffElements.length} site(s) in bounding box');
+        // Store in cache for future use
+        _siteDetailsCache[cacheKey] = properties;
+        _siteDetailsCacheExpiry[cacheKey] = now.add(_cacheTimeout);
 
-        // Match on the id whenever we have one. The box is wide enough to
-        // span a whole cluster of launches, so which element is "first" means
-        // nothing.
-        XmlElement? takeoffElement;
-        if (siteId != null) {
-          for (final element in takeoffElements) {
-            // The element is <pge_site_id>. This looked for <id>, which does
-            // not exist in ParaglidingEarth's schema, so the match never once
-            // succeeded and every lookup fell through to "use the first
-            // result" - picking by position in a bounding box, silently.
-            final idElement = element.findElements('pge_site_id').firstOrNull;
-            if (idElement != null && idElement.innerText.trim() == siteId.toString()) {
-              takeoffElement = element;
-              LoggingService.info('ParaglidingEarthApi: Matched site by ID: $siteId');
-              break;
-            }
-          }
-
-          if (takeoffElement == null) {
-            // Returning the nearest instead would put another launch's
-            // takeoff notes, rules and hazards under this site's name, with
-            // nothing to say they belong elsewhere. An empty tab is honest.
-            LoggingService.warning(
-                'ParaglidingEarthApi: No site matching id $siteId in ${takeoffElements.length} result(s)');
-            return null;
-          }
-        }
-
-        // No id to match on - fall back to the only sensible candidate.
-        if (takeoffElement == null && takeoffElements.isNotEmpty) {
-          takeoffElement = takeoffElements.first;
-          if (takeoffElements.length > 1) {
-            LoggingService.warning('ParaglidingEarthApi: Multiple sites found but using first one (no ID given)');
-          }
-        }
-
-        if (takeoffElement != null) {
-          final Map<String, dynamic> properties = {};
-          
-          // Extract all child elements
-          for (final element in takeoffElement.children.whereType<XmlElement>()) {
-            final text = element.innerText.trim();
-            if (text.isNotEmpty) {
-              properties[element.name.local] = text;
-            }
-          }
-          
-          // Also extract orientations
-          final orientationsElement = takeoffElement.findElements('orientations').firstOrNull;
-          if (orientationsElement != null) {
-            final Map<String, dynamic> orientations = {};
-            for (final element in orientationsElement.children.whereType<XmlElement>()) {
-              orientations[element.name.local] = element.innerText;
-            }
-            properties['orientations'] = orientations;
-          }
-
-          // Extract landing information (landing is a sibling of takeoff in the XML structure)
-          final landingElement = document.findAllElements('landing').firstOrNull;
-          if (landingElement != null) {
-            final Map<String, dynamic> landing = {};
-            for (final element in landingElement.children.whereType<XmlElement>()) {
-              final text = element.innerText.trim();
-              if (text.isNotEmpty) {
-                landing[element.name.local] = text;
-              }
-            }
-            properties['landing'] = landing;
-
-            // Also flatten landing info for easy access
-            if (landing['landing_altitude'] != null) {
-              properties['landing_altitude'] = landing['landing_altitude'];
-            }
-            if (landing['landing_description'] != null) {
-              properties['landing_description'] = landing['landing_description'];
-            }
-            if (landing['landing_lat'] != null) {
-              properties['landing_lat'] = landing['landing_lat'];
-            }
-            if (landing['landing_lng'] != null) {
-              properties['landing_lng'] = landing['landing_lng'];
-            }
-          }
-          
-          LoggingService.info('ParaglidingEarthApi: Found detailed data for site');
-          LoggingService.info('ParaglidingEarthApi: Parsed fields: ${properties.keys.toList()}');
-          
-          // Store in cache for future use
-          _siteDetailsCache[cacheKey] = properties;
-          _siteDetailsCacheExpiry[cacheKey] = now.add(_cacheTimeout);
-          
-          return properties;
-        }
-        
-        LoggingService.warning('ParaglidingEarthApi: No detailed data found for site');
-        return null;
+        return properties;
       } else {
         LoggingService.warning('ParaglidingEarthApi: HTTP ${response.statusCode} for site details');
         return null;
@@ -680,6 +586,144 @@ class ParaglidingEarthApi {
       LoggingService.error('ParaglidingEarthApi: Error getting site details', e);
       return null;
     }
+  }
+
+  /// The `<takeoff>` for [siteId], with its own `<landing>`, as a flat map.
+  ///
+  /// Split out from the fetch so a fixture can drive it. The only other test of
+  /// this path is network-tagged, and a live query usually returns one site -
+  /// which is exactly the case where picking the wrong landing cannot show up.
+  @visibleForTesting
+  static Map<String, dynamic>? parseSiteDetails(String xml, {int? siteId}) {
+    final document = XmlDocument.parse(xml);
+    final takeoffElements = document.findAllElements('takeoff').toList();
+
+    LoggingService.info('ParaglidingEarthApi: Found ${takeoffElements.length} site(s) in bounding box');
+
+    // Match on the id whenever we have one. The box is wide enough to
+    // span a whole cluster of launches, so which element is "first" means
+    // nothing.
+    XmlElement? takeoffElement;
+    if (siteId != null) {
+      for (final element in takeoffElements) {
+        // The element is <pge_site_id>. This looked for <id>, which does
+        // not exist in ParaglidingEarth's schema, so the match never once
+        // succeeded and every lookup fell through to "use the first
+        // result" - picking by position in a bounding box, silently.
+        final idElement = element.findElements('pge_site_id').firstOrNull;
+        if (idElement != null && idElement.innerText.trim() == siteId.toString()) {
+          takeoffElement = element;
+          LoggingService.info('ParaglidingEarthApi: Matched site by ID: $siteId');
+          break;
+        }
+      }
+
+      if (takeoffElement == null) {
+        // Returning the nearest instead would put another launch's
+        // takeoff notes, rules and hazards under this site's name, with
+        // nothing to say they belong elsewhere. An empty tab is honest.
+        LoggingService.warning(
+            'ParaglidingEarthApi: No site matching id $siteId in ${takeoffElements.length} result(s)');
+        return null;
+      }
+    }
+
+    // No id to match on - fall back to the only sensible candidate.
+    if (takeoffElement == null && takeoffElements.isNotEmpty) {
+      takeoffElement = takeoffElements.first;
+      if (takeoffElements.length > 1) {
+        LoggingService.warning('ParaglidingEarthApi: Multiple sites found but using first one (no ID given)');
+      }
+    }
+
+    if (takeoffElement == null) {
+      LoggingService.warning('ParaglidingEarthApi: No detailed data found for site');
+      return null;
+    }
+
+    final Map<String, dynamic> properties = {};
+
+    // Extract all child elements
+    for (final element in takeoffElement.children.whereType<XmlElement>()) {
+      final text = element.innerText.trim();
+      if (text.isNotEmpty) {
+        properties[element.name.local] = text;
+      }
+    }
+
+    // Also extract orientations
+    final orientationsElement = takeoffElement.findElements('orientations').firstOrNull;
+    if (orientationsElement != null) {
+      final Map<String, dynamic> orientations = {};
+      for (final element in orientationsElement.children.whereType<XmlElement>()) {
+        orientations[element.name.local] = element.innerText;
+      }
+      properties['orientations'] = orientations;
+    }
+
+    // The landing has to be this takeoff's, not whichever came back first.
+    //
+    // <takeoff> and <landing> are flat siblings under <search>, and only
+    // <landing_pge_site_id> ties one to the other. Taking the document's first
+    // landing answered a lookup for Montmin (3046, landing 467m) with Annecy -
+    // Planfait's 555m, and put Planfait's coordinates behind the map button: a
+    // 12km query there returns nine takeoffs and two landings. The 0.5km search
+    // radius makes that rarer, not impossible - several launches inside 500m is
+    // the normal case this catalogue is built around.
+    final takeoffId = properties['pge_site_id']?.toString();
+    final landingElement = (takeoffId == null || takeoffId.isEmpty)
+        ? null
+        : document.findAllElements('landing').where((element) {
+            final id = element.findElements('landing_pge_site_id').firstOrNull;
+            return id != null && id.innerText.trim() == takeoffId;
+          }).firstOrNull;
+
+    if (landingElement != null) {
+      final Map<String, dynamic> landing = {};
+      for (final element in landingElement.children.whereType<XmlElement>()) {
+        final text = element.innerText.trim();
+        if (text.isNotEmpty) {
+          landing[element.name.local] = text;
+        }
+      }
+      properties['landing'] = landing;
+
+      // Also flatten landing info for easy access
+      if (landing['landing_altitude'] != null) {
+        properties['landing_altitude'] = landing['landing_altitude'];
+      }
+      if (landing['landing_description'] != null) {
+        properties['landing_description'] = landing['landing_description'];
+      }
+      if (landing['landing_lat'] != null) {
+        properties['landing_lat'] = landing['landing_lat'];
+      }
+      if (landing['landing_lng'] != null) {
+        properties['landing_lng'] = landing['landing_lng'];
+      }
+    }
+
+    // PGE writes a negative altitude where it has none - mostly -1, sometimes
+    // -2 - and the screen rendered that as "-1m". France alone carries 8 in
+    // 1081 sites. Dropping the key lets the caller fall back to the catalogue
+    // the same way a missing element already does.
+    //
+    // Zero is left alone. It is a plausible altitude for the coastal launches
+    // this app is used at, and the catalogue holds 89 of them; treating it as a
+    // sentinel would hide real sites to catch a few unfilled ones.
+    for (final key in const ['takeoff_altitude', 'landing_altitude']) {
+      final metres = double.tryParse(properties[key]?.toString() ?? '');
+      if (metres != null && metres < 0) {
+        properties.remove(key);
+        LoggingService.info(
+            'ParaglidingEarthApi: Dropped $key "$metres" - no altitude recorded');
+      }
+    }
+
+    LoggingService.info('ParaglidingEarthApi: Found detailed data for site');
+    LoggingService.info('ParaglidingEarthApi: Parsed fields: ${properties.keys.toList()}');
+
+    return properties;
   }
 
   /// Convert ISO country code to full country name
@@ -821,8 +865,21 @@ class ParaglidingEarthApi {
   /// Check if API is currently in offline mode
   static bool get isOfflineMode => _isOfflineMode;
 
-  /// Drive the breaker directly - the HTTP client is not injectable, so this is
-  /// how the cooldown behaviour is covered without a network call.
+  /// Swap in a stub client; pass null to go back to the real one.
+  ///
+  /// The site details path is otherwise only reachable over the network, which
+  /// is why the one test that covers it end to end is network-tagged. A stub
+  /// lets the screen be driven against a known response instead - the landing
+  /// row and the drop beside the launch altitude are rendered from a shape a
+  /// live query rarely returns.
+  @visibleForTesting
+  static set debugHttpClient(http.Client? client) {
+    _httpClient = client;
+    _requestCount = 0;
+    _clientCreatedAt = client == null ? null : DateTime.now();
+  }
+
+  /// Drive the breaker directly, without waiting on a real request to fail.
   @visibleForTesting
   static void debugSetOfflineMode({required bool offline, DateTime? enteredAt}) {
     _isOfflineMode = offline;

--- a/the_paragliding_app/test/launch_landing_altitude_test.dart
+++ b/the_paragliding_app/test/launch_landing_altitude_test.dart
@@ -1,0 +1,305 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:the_paragliding_app/data/models/paragliding_site.dart';
+import 'package:the_paragliding_app/presentation/screens/site_details_screen.dart';
+import 'package:the_paragliding_app/services/paragliding_earth_api.dart';
+import 'package:the_paragliding_app/services/pge_sites_database_service.dart';
+
+/// The site details header states a launch altitude, a landing altitude and the
+/// drop between them. All three come out of one ParaglidingEarth response, and
+/// all three were wrong in a way a live single-result query cannot show:
+///
+///  * the landing was `findAllElements('landing').first` over the whole
+///    document while the takeoff beside it was matched by id. One launch's
+///    altitude and map pin under another's name.
+///  * PGE writes a negative altitude where it has none, and "-1m" was rendered
+///    as if it were one.
+///
+/// Driven through the parser directly rather than over the network: the only
+/// other test of this path is `pge_api_site_lookup_test.dart`, which is
+/// network-tagged, and a real 0.5km query usually returns a single site - the
+/// one case where picking the wrong landing looks identical to picking the
+/// right one.
+
+/// Two launches around Annecy, each with its own landing, in the flat
+/// takeoff/landing sibling layout the API actually returns. Trimmed from a live
+/// `getAroundLatLngSites.php?lat=45.90&lng=6.20&distance=12` response.
+const _twoLaunchesEachWithALanding = '''
+<?xml version="1.0"?>
+<search>
+  <results>2</results>
+  <takeoff>
+    <name>Annecy - Planfait</name>
+    <pge_site_id>21842</pge_site_id>
+    <takeoff_altitude>956</takeoff_altitude>
+    <lat>45.8271</lat>
+    <lng>6.20166</lng>
+    <orientations><N>0</N><NE>0</NE><E>0</E><SE>0</SE><S>0</S><SW>1</SW><W>2</W><NW>1</NW></orientations>
+  </takeoff>
+  <landing>
+    <site>Annecy - Planfait</site>
+    <landing_name>Talloires</landing_name>
+    <landing_lat>45.8486</landing_lat>
+    <landing_lng>6.21407</landing_lng>
+    <landing_altitude>555</landing_altitude>
+    <landing_pge_site_id>21842</landing_pge_site_id>
+  </landing>
+  <takeoff>
+    <name>Montmin (Col de la Forclaz)</name>
+    <pge_site_id>3046</pge_site_id>
+    <takeoff_altitude>1265</takeoff_altitude>
+    <lat>45.8161</lat>
+    <lng>6.24222</lng>
+  </takeoff>
+  <landing>
+    <site>Montmin (Col de la Forclaz)</site>
+    <landing_name>Doussard</landing_name>
+    <landing_lat>45.7889</landing_lat>
+    <landing_lng>6.21639</landing_lng>
+    <landing_altitude>467</landing_altitude>
+    <landing_pge_site_id>3046</landing_pge_site_id>
+  </landing>
+</search>
+''';
+
+/// Two launches on one hill where only the second has a landing - the shape
+/// that made a landing appear under a site that has none. Mt Bakewell is the
+/// real case: PGE records no landing for it, and the Australian Site Guide
+/// publishes landings as prose with no coordinates or altitude at all.
+const _onlyTheSecondLaunchHasALanding = '''
+<?xml version="1.0"?>
+<search>
+  <results>2</results>
+  <takeoff>
+    <name>Mt Bakewell (top launches)</name>
+    <pge_site_id>6724</pge_site_id>
+    <takeoff_altitude>436</takeoff_altitude>
+  </takeoff>
+  <takeoff>
+    <name>Somewhere else entirely</name>
+    <pge_site_id>9999</pge_site_id>
+    <takeoff_altitude>800</takeoff_altitude>
+  </takeoff>
+  <landing>
+    <site>Somewhere else entirely</site>
+    <landing_lat>1.0</landing_lat>
+    <landing_lng>2.0</landing_lng>
+    <landing_altitude>300</landing_altitude>
+    <landing_pge_site_id>9999</landing_pge_site_id>
+  </landing>
+</search>
+''';
+
+void main() {
+  group('landing belongs to the takeoff it was asked for', () {
+    test('takes the matching landing, not the document\'s first', () {
+      final details = ParaglidingEarthApi.parseSiteDetails(
+        _twoLaunchesEachWithALanding,
+        siteId: 3046,
+      );
+
+      expect(details, isNotNull);
+      // 555 is Planfait's, and is what the first-in-document lookup returned.
+      expect(details!['landing_altitude'], '467');
+      expect(details['landing_lat'], '45.7889');
+      expect(details['landing_lng'], '6.21639');
+    });
+
+    test('a launch with no landing of its own gets none', () {
+      final details = ParaglidingEarthApi.parseSiteDetails(
+        _onlyTheSecondLaunchHasALanding,
+        siteId: 6724,
+      );
+
+      expect(details, isNotNull);
+      expect(details!['takeoff_altitude'], '436');
+      expect(details.containsKey('landing_altitude'), isFalse,
+          reason: 'the only landing here belongs to another site');
+      expect(details.containsKey('landing_lat'), isFalse);
+      expect(details.containsKey('landing'), isFalse);
+    });
+
+    test('still matches the takeoff itself by id', () {
+      final details = ParaglidingEarthApi.parseSiteDetails(
+        _twoLaunchesEachWithALanding,
+        siteId: 3046,
+      );
+
+      expect(details!['name'], 'Montmin (Col de la Forclaz)');
+      expect(details['takeoff_altitude'], '1265');
+    });
+  });
+
+  group('altitudes PGE does not actually have', () {
+    String withTakeoffAltitude(String value) => '''
+<?xml version="1.0"?>
+<search>
+  <results>1</results>
+  <takeoff>
+    <name>Lancrenaz</name>
+    <pge_site_id>21827</pge_site_id>
+    <takeoff_altitude>$value</takeoff_altitude>
+  </takeoff>
+</search>
+''';
+
+    test('a negative altitude is dropped rather than shown', () {
+      // France alone carries 8 of these in 1081 sites; the header rendered
+      // them as "-1m".
+      for (final sentinel in ['-1', '-2']) {
+        final details = ParaglidingEarthApi.parseSiteDetails(
+          withTakeoffAltitude(sentinel),
+          siteId: 21827,
+        );
+
+        expect(details, isNotNull);
+        expect(details!.containsKey('takeoff_altitude'), isFalse,
+            reason: '$sentinel means "not recorded", not an altitude');
+        expect(details['name'], 'Lancrenaz',
+            reason: 'the rest of the site must survive');
+      }
+    });
+
+    test('zero is kept - a sea-level launch is a real thing', () {
+      final details = ParaglidingEarthApi.parseSiteDetails(
+        withTakeoffAltitude('0'),
+        siteId: 21827,
+      );
+
+      expect(details!['takeoff_altitude'], '0');
+    });
+
+    test('a negative landing altitude is dropped too', () {
+      const xml = '''
+<?xml version="1.0"?>
+<search>
+  <results>1</results>
+  <takeoff>
+    <name>Somewhere</name>
+    <pge_site_id>1</pge_site_id>
+    <takeoff_altitude>900</takeoff_altitude>
+  </takeoff>
+  <landing>
+    <landing_altitude>-1</landing_altitude>
+    <landing_lat>45.0</landing_lat>
+    <landing_pge_site_id>1</landing_pge_site_id>
+  </landing>
+</search>
+''';
+
+      final details = ParaglidingEarthApi.parseSiteDetails(xml, siteId: 1);
+
+      expect(details!.containsKey('landing_altitude'), isFalse);
+      expect(details['landing_lat'], '45.0',
+          reason: 'the landing still exists, only its altitude is unknown');
+    });
+  });
+
+  group('heightAboveLanding', () {
+    test('is the drop between the two altitudes', () {
+      expect(heightAboveLanding('956', '555'), 401);
+      expect(heightAboveLanding(1265, 467), 798);
+    });
+
+    test('needs both figures', () {
+      expect(heightAboveLanding('956', null), isNull);
+      expect(heightAboveLanding(null, '555'), isNull);
+      expect(heightAboveLanding(null, null), isNull);
+      expect(heightAboveLanding('', ''), isNull);
+    });
+
+    test('gives nothing when the landing is not below the launch', () {
+      // A winch or flatland site, or an altitude nobody filled in. "-401 m"
+      // beside a launch reads as a bug rather than as the gap it is.
+      expect(heightAboveLanding('555', '956'), isNull);
+      expect(heightAboveLanding('600', '600'), isNull);
+    });
+
+    test('rounds to whole metres', () {
+      expect(heightAboveLanding('956.4', '555.1'), 401);
+    });
+  });
+
+  group('the header as a pilot reads it', () {
+    setUp(() async {
+      // The page reads favourites out of the catalogue table on open.
+      await PgeSitesDatabaseService.instance.initializeTables();
+      ParaglidingEarthApi.debugSetOfflineMode(offline: false);
+      ParaglidingEarthApi.debugHttpClient = MockClient(
+        (request) async => http.Response(_brauneckWithItsLanding, 200,
+            headers: {'content-type': 'application/xml; charset=utf-8'}),
+      );
+    });
+
+    tearDown(() {
+      ParaglidingEarthApi.debugHttpClient = null;
+    });
+
+    testWidgets('launch and landing state the datum, with the drop between',
+        (tester) async {
+      // A Pixel 9 in logical pixels, as in site_details_layout_test.
+      tester.view.physicalSize = const Size(411, 923);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(MaterialApp(
+        home: SiteDetailsScreen(
+          paraglidingSite: ParaglidingSite(
+            id: 10727,
+            name: 'Brauneck',
+            latitude: 47.6634,
+            longitude: 11.5233,
+            altitude: 1541,
+            siteType: 'launch',
+            windDirections: const ['N', 'NE'],
+            source: 'pge:8612',
+          ),
+          maxWindSpeed: 25,
+          cautionWindSpeed: 15,
+        ),
+      ));
+
+      // The weather fetches fail in a test binding and spin forever, so
+      // pumpAndSettle is no use - the frames are pumped by hand.
+      for (var i = 0; i < 10; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+
+      expect(find.text('1541 m AMSL'), findsOneWidget);
+      expect(find.text('718 m AMSL'), findsOneWidget);
+      expect(find.text('823 m'), findsOneWidget,
+          reason: 'the drop belongs on the launch line');
+      expect(find.text('Landing:'), findsOneWidget);
+      expect(find.byTooltip('Height above the landing area'), findsOneWidget);
+      expect(find.byTooltip('Altitude above mean sea level'), findsNWidgets(2));
+    });
+  });
+}
+
+/// Brauneck, above Lenggries - launch 1541m, landing 718m, so an 823m drop.
+/// Trimmed from the live response for `lat=47.6634&lng=11.5233&distance=0.5`.
+const _brauneckWithItsLanding = '''
+<?xml version="1.0"?>
+<search>
+  <results>1</results>
+  <takeoff>
+    <name>Brauneck</name>
+    <pge_site_id>8612</pge_site_id>
+    <takeoff_altitude>1541</takeoff_altitude>
+    <lat>47.6634</lat>
+    <lng>11.5233</lng>
+    <countryCode>de</countryCode>
+    <orientations><N>1</N><NE>1</NE><E>0</E><SE>0</SE><S>0</S><SW>0</SW><W>0</W><NW>1</NW></orientations>
+  </takeoff>
+  <landing>
+    <site>Brauneck</site>
+    <landing_name>Hangglider Landing</landing_name>
+    <landing_lat>47.6798</landing_lat>
+    <landing_lng>11.5641</landing_lng>
+    <landing_altitude>718</landing_altitude>
+    <landing_pge_site_id>8612</landing_pge_site_id>
+  </landing>
+</search>
+''';

--- a/the_paragliding_app/test/site_details_layout_test.dart
+++ b/the_paragliding_app/test/site_details_layout_test.dart
@@ -134,4 +134,28 @@ void main() {
     expect(find.text('PGE'), findsOneWidget);
     expect(find.text('ANSG'), findsOneWidget);
   });
+
+  testWidgets('the launch altitude says which datum it is', (tester) async {
+    // Above ground level at a launch is zero by definition, so an unlabelled
+    // figure invites the one reading it cannot have - and the guides really do
+    // publish both. Site Guide's height for Mt Bakewell is 255m above the
+    // valley; PGE's is 436m AMSL. The unit is in the text rather than only in
+    // the tooltip because this row must not depend on a hover.
+    await pumpPage(
+      tester,
+      which: ParaglidingSite(
+        id: 9247,
+        name: 'Manilla - Mt Borah - West launch',
+        latitude: -30.6792,
+        longitude: 150.6086,
+        altitude: 847,
+        siteType: 'launch',
+        windDirections: const ['W', 'NW'],
+        source: 'pge:4632;ansg:136-20',
+      ),
+    );
+
+    expect(find.text('847 m AMSL'), findsOneWidget);
+    expect(find.byTooltip('Altitude above mean sea level'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
Mount Bakewell's details screen showed `Launch: 436m` in the header and `Altitude 255 m` in the ANSG tab, 181 m apart, with nothing to say why. Neither is mislabelled by the app — they are different quantities. PGE's 436 m is AMSL; ANSG's is `840ft / 255m agl`, the hill's relief above the valley. Six IGC tracks from that site settle which one "altitude" means: launch measured 413–430 m AMSL, descent to landing 200–270 m.

AGL at a launch is zero by definition, so the figure can only sensibly be AMSL — and now says so.

## What the sources actually carry

Verified against both live APIs, not assumed:

| | launch altitude | landing altitude | height drop |
|---|---|---|---|
| **PGE** (`getAroundLatLngSites.php`, XML) | `takeoff_altitude`, AMSL | `landing_altitude` in a sibling `<landing>` | **none — computed** |
| **ANSG** (`/api/Export`, JSON) | `height` free text, often AGL | `landing` is **prose only** | none |
| **Catalogue** (`sites.csv` → `pge_sites`) | one `altitude` column | none | none |

So landing and drop come only from the live PGE fetch. Bakewell shows neither, which is correct; ANSG-primary launches never will.

## Changes

**The datum is stated.** `1541 m AMSL` on both the launch and landing rows, with an `Altitude above mean sea level` tooltip. The unit is in the text and not only in the tooltip because `site_details_screen.dart:916` already records that a hover-only affordance was removed from this row — a phone has no hover. `_iconFact` gained an optional `tooltip:` that wraps the icon+text pair as one `Wrap` child, preserving the no-orphaned-glyph invariant the surrounding comment protects.

**The landing now belongs to the site asked for.** It was `document.findAllElements('landing').firstOrNull` — the first in the whole response — while the takeoff beside it was carefully matched by `pge_site_id`. `<takeoff>` and `<landing>` are flat siblings and only `<landing_pge_site_id>` ties one to the other. A lookup for Montmin (3046, landing 467 m) was answered with Annecy - Planfait's 555 m, and Planfait's coordinates behind the map button. A 12 km query there returns nine takeoffs and two landings; the 0.5 km search radius makes this rarer, not impossible — several launches inside 500 m is the normal case this catalogue is built around.

**Negative altitudes are dropped.** PGE writes `-1` (sometimes `-2`) where it has none — 8 of France's 1081 sites — and the header rendered `-1m`. The key is now removed at parse time so the caller falls back to the catalogue exactly as a missing element already does. Zero is kept: a sea-level coastal launch is real, and the catalogue holds 89.

**Height above landing.** No source publishes it, so `heightAboveLanding()` subtracts, returning null unless both figures are real and the landing is below — a landing above its launch is a winch/flatland site or an unfilled altitude, and `-401 m` beside a launch reads as a bug rather than as the gap it is. It requires both altitudes from PGE; subtracting a PGE landing from a catalogue launch would mix two guides and, until the producer fix lands, sometimes two datums.

Rejected: deriving the drop from `flights.launch_altitude - flights.landing_altitude`. Available for every flown site, but it measures where the pilot happened to land — an XC flight makes it meaningless as a site attribute.

## Testing

The XML mapping is now a `@visibleForTesting` function and the HTTP client is injectable. It could not be tested before: the one test covering this path is network-tagged, and a live query returns a single site — the one case where picking the wrong landing looks exactly like picking the right one.

- **Both landing tests and both sentinel tests were confirmed red against the unfixed code**, returning `555` where `467` belongs and attaching a landing to a site that has none. Each change was reverted and the failure observed.
- A widget test drives the real screen against Brauneck's actual response: `1541 m AMSL`, `823 m`, `718 m AMSL`, two AMSL tooltips, one drop tooltip.
- `flutter analyze` clean; 295 tests pass, 20 network-skipped.
- Checked in the running app on Linux desktop. Brauneck renders all three, cross-checked against the live XML for `pge_site_id=8612`. Mount Bakewell correctly shows the AMSL label with no landing row and no drop.

```
Launch:  ⛰ 1541 m AMSL   ↕ 823 m   💨 N, NE, E, SE, S, SW, NW   🗺
Landing: ⛰ 718 m AMSL   🗺
```

## Known gap

Labelling the catalogue's own figure AMSL is a claim the data does not yet back for ANSG-primary launches read **offline** — Bakewell would read `255 m AMSL`, which is wrong. Online is unaffected, because the header prefers PGE's `takeoff_altitude`. Closing it is Kevin-McIsaac/paragliding_site_federation#8, where 43 of 219 Site Guide sites publish an AGL height as an altitude. This was a deliberate call rather than an oversight: the alternative was preferring the pilot's measured IGC launch altitude, which was considered and left out of scope.

Also out of scope: the six other places that hand-roll a site altitude string while `map_calculation_utils.dart:215` has an unused `formatAltitude`, and `igc_import_service.dart:267` preferring the catalogue over the pilot's own measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
