### PR TITLE
Credit ParaglidingEarth's licence, and add ANSG, to the attribution

### DIFF
--- a/the_paragliding_app/lib/presentation/screens/about_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/about_screen.dart
@@ -251,6 +251,23 @@ class _AboutScreenState extends State<AboutScreen> {
                       icon: Icons.web,
                       text: 'ParaglidingEarth.com',
                     ),
+                    // ParaglidingEarth states its licence; the Australian
+                    // National Site Guide publishes none, so it is credited
+                    // without one rather than being given a licence it has
+                    // never claimed.
+                    Padding(
+                      padding: const EdgeInsets.only(left: 28, top: 4),
+                      child: AppAttributionLink.compact(
+                        url: 'https://creativecommons.org/licenses/by-sa/3.0/',
+                        icon: Icons.copyright,
+                        text: 'Database licensed CC BY-SA 3.0',
+                      ),
+                    ),
+                    AppAttributionLink.standard(
+                      url: 'https://siteguide.org.au',
+                      icon: Icons.web,
+                      text: 'Australian National Site Guide',
+                    ),
                   ],
                 ),
               ),

--- a/the_paragliding_app/lib/presentation/screens/site_details_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/site_details_screen.dart
@@ -1349,6 +1349,32 @@ class SiteDetailsScreenState extends State<SiteDetailsScreen> with SingleTickerP
           ] else
             const Center(child: Text('No takeoff information available')),
 
+          // ParaglidingEarth publishes its database under CC BY-SA 3.0, which
+          // permits this use on condition the source is credited wherever the
+          // content is shown. Outside the _detailedData branch for the same
+          // reason as the link below: the tab is ParaglidingEarth's either way.
+          const SizedBox(height: 16),
+          Text.rich(
+            TextSpan(
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Colors.grey,
+                  ),
+              children: [
+                const TextSpan(text: 'Site data © ParaglidingEarth, licensed '),
+                TextSpan(
+                  text: 'CC BY-SA 3.0',
+                  style: const TextStyle(
+                    color: Colors.blue,
+                    decoration: TextDecoration.underline,
+                  ),
+                  recognizer: TapGestureRecognizer()
+                    ..onTap = () => _launchUrl(
+                        'https://creativecommons.org/licenses/by-sa/3.0/'),
+                ),
+              ],
+            ),
+          ),
+
           // Link out from the tab, matching the other guides. It sits outside
           // the _detailedData branch so it is still there when the fetch
           // failed or the site has no detail - which is when you most want to


### PR DESCRIPTION
ParaglidingEarth publishes its database under CC BY-SA 3.0, which permits this
use on condition the source is credited where the content is shown. Two places
said nothing.

**Site details, PGE tab** — a line under "Last updated" and above the "Open in
PGE" button: *Site data © ParaglidingEarth, licensed CC BY-SA 3.0*, the licence
linking out to creativecommons.org. It sits outside the `_detailedData` branch
for the same reason the button does: the tab is ParaglidingEarth's whether or
not the detail fetch returned anything.

**About screen, Site Data card** — the PGE licence under the existing
ParaglidingEarth.com link, plus the Australian National Site Guide, which
contributes the launches the federated catalogue carries as `ansg:` refs and was
uncredited entirely.

ANSG publishes no licence of its own — siteguide.org.au offers a disclaimer and
nothing else, and the Downloads page states no terms — so it is credited with a
link and no licence claim rather than being given one it has never made.

Verified on Linux desktop by navigating to a site's PGE tab and reading the
rendered line, not only by `flutter analyze` (which is clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)