### PR TITLE
Release 1.0.8+20

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: release
+description: Cut and publish a release of this app to the Google Play internal track. Use when asked to create, cut or make a release, to ship or publish the app, to bump the version or versionCode, to write the release notes users see, or to push a release tag - and when asked whether a release actually shipped. Covers choosing the version numbers, writing distribution/whatsnew/whatsnew-en-GB, tagging, and checking the run really published.
+---
+
+# Releasing this app
+
+`GOOGLE_PLAY_DEPLOYMENT.md` (repo root) is the **reference**: CI job structure, secrets,
+signing, the troubleshooting table. This skill is the **sequence and the decisions**. When
+something fails, go to the troubleshooting table there rather than guessing.
+
+Pushing a `v*` tag builds a signed APK and AAB, verifies both, publishes the AAB to the Play
+**internal** track, and attaches the APK to a GitHub Release.
+
+## Mind the two working directories
+
+`pubspec.yaml` is under `the_paragliding_app/`; the release notes are repo-root-relative.
+All commands below are from the **repo root**.
+
+| | path |
+|---|---|
+| version | `the_paragliding_app/pubspec.yaml` |
+| release notes | `distribution/whatsnew/whatsnew-en-GB` |
+
+## 1. Read the range first
+
+```bash
+git fetch --tags
+LAST=$(git tag -l 'v*' | sort -V | tail -1)   # e.g. v1.0.7+19
+git log --oneline "$LAST"..origin/main
+```
+
+Classify every commit **user-visible** or **dev-only** before touching a number. Dev-only
+means tooling, CI, docs, test infrastructure, worktree lore - anything a pilot using the app
+cannot observe. That split drives both the version name and the notes.
+
+## 2. Choose the numbers
+
+`pubspec.yaml` holds both, as `version: <name>+<code>`.
+
+- **`versionCode`** (the `+N`) - always the previous one plus 1. Play never allows a reuse,
+  and CI refuses a tag whose code is not strictly greater than every existing `v*` tag.
+- **`versionName`** - bump the patch digit whenever the range contains user-visible change,
+  which it nearly always does. Builds 5 through 11 all shipped as `1.0.2`, and users could
+  not tell a months-old build from a current one. A dev-only range may keep the name and
+  bump only the code.
+
+## 3. Write the notes users see
+
+Rewrite `distribution/whatsnew/whatsnew-en-GB` wholesale - it holds the *previous* release's
+notes, and a stale file passes every CI check.
+
+- Group by **what a pilot notices**, not by PR. Several PRs usually collapse into one bullet.
+- Dev-only commits never appear.
+- Say what changed *for them*. 1.0.4 lowered every user's total hours by ~11% by measuring
+  takeoff-to-landing; shipped without explanation that reads as data loss, not a correction.
+- Bullets are `•` (U+2022), wrapped by hand, matching the existing file.
+
+**Hard limit 500 characters**, counted the way CI counts it:
+
+```bash
+LC_ALL=C.UTF-8 wc -m distribution/whatsnew/whatsnew-en-GB   # must be <= 500
+```
+
+`-m`, not `-c`: the bullets are multi-byte and `-c` overcounts.
+
+## 4. Get it onto main
+
+Both files go through a normal PR - branch, `flutter analyze`, `flutter test`, review, squash
+merge. Past release commits are titled `Release 1.0.7+19 (#326)` and say in the body **why**
+that version name was chosen. CI refuses to release from a commit that is not an ancestor of
+`main`, so there is no tag-a-branch shortcut.
+
+## 5. Tag - this is the moment of no return
+
+**Ask the user before pushing the tag.** The `play-internal` environment has no protection
+rules: the push publishes to the internal track with no human checkpoint, and a `versionCode`
+that reaches Play is burned whether or not the release was any good.
+
+```bash
+git switch main && git pull
+git tag -a v1.0.8+20 -m "Release 1.0.8+20" && git push origin v1.0.8+20
+```
+
+Four checks run in seconds before the ~15 minute build: tag matches pubspec, versionCode
+exceeds every existing tag, notes exist and fit, tagged commit is an ancestor of `main`.
+`flutter analyze` and the full suite run alongside them.
+
+## 6. Verify it shipped - check the step, not the run
+
+```bash
+gh run watch   # pick the run for the tag; do not hand-roll a poll loop
+```
+
+Then, in this order:
+
+- **A `cancelled` or `failed` run may still have published.** Check the *Publish to Play
+  internal track* step's own conclusion, not the run's. A cancel landing after the upload
+  stops later jobs while the publish already went through - that is how versionCode 13 was
+  burned, and re-tagging on the assumption it failed burns another.
+
+  ```bash
+  gh run view <run-id> --json jobs \
+    -q '.jobs[].steps[] | select(.name|test("Play")) | "\(.name): \(.conclusion)"'
+  ```
+
+- Confirm the GitHub Release exists with the APK attached: `gh release view v1.0.8+20`.
+- Optionally check provenance on the downloaded APK:
+  `gh attestation verify app-release.apk --repo Kevin-McIsaac/the_paragliding_app`.
+- Internal testers see it within minutes; there is no review delay.
+
+**Promotion to production is manual** in Play Console, deliberately outside CI. Do not
+promote without being asked.
+
+## Testing pipeline changes without publishing
+
+```bash
+gh workflow run build.yml --ref my-branch
+```
+
+Same tests, build, verification and attestation; no publish. It does **not** exercise the
+four tag-only checks, the Play upload or the GitHub release - those first run for real on the
+next tag.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -743,6 +743,14 @@ content landed by checking the PR is `MERGED`, not by whether `-d` is willing.
 5. **Quality**: `flutter analyze` before committing
 6. **Commit**: Only when user explicitly requests
 
+### Releasing
+
+**See the `release` skill** (`.claude/skills/release/`) for cutting a release: choosing the
+version numbers, writing the user-facing notes, tagging, and checking the run actually
+published. It is the single source of truth for the sequence, and defers to
+`GOOGLE_PLAY_DEPLOYMENT.md` for the reference detail (CI structure, secrets, signing,
+troubleshooting). Do not duplicate either one here.
+
 ### Common Task Patterns
 
 | Task | Commands | Notes |

--- a/distribution/whatsnew/whatsnew-en-GB
+++ b/distribution/whatsnew/whatsnew-en-GB
@@ -1,6 +1,7 @@
-• The site guide now merges several guides into one catalogue rather than
-  listing ParaglidingEarth alone, and no longer hides sites marked closed
-• Site details opens as a full page, so the wind, forecast and guide tabs have
-  room instead of sharing a cramped sheet
-• Each guide gets its own link, and those links open the site you tapped -
-  some previously opened an unrelated one
+• Flights now match the nearest launch rather than the first one found, and
+  Data Management can re-run that match across your whole log
+• Site altitudes say they are above sea level, the landing comes from the
+  site you opened, and duplicate markers on the map are gone
+• The site guide updates without an app update, and credits ParaglidingEarth's
+  licence and the Australian National Site Guide
+• Search fields in the top bar are readable again in the light theme

--- a/the_paragliding_app/lib/presentation/screens/data_management_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/data_management_screen.dart
@@ -76,6 +76,9 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
 
   // Scroll controller and keys for Premium Maps highlighting
   final ScrollController _scrollController = ScrollController();
+  // Separate from _scrollController, which is attached to the screen itself.
+  // Only one confirmation dialog is ever open at a time, so one is enough.
+  final ScrollController _dialogScrollController = ScrollController();
   final GlobalKey _premiumMapsKey = GlobalKey();
   late AnimationController _highlightController;
   late Animation<double> _highlightAnimation;
@@ -131,6 +134,7 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
   void dispose() {
     _downloadProgressSubscription?.cancel();
     _scrollController.dispose();
+    _dialogScrollController.dispose();
     _highlightController.dispose();
     // Save expansion states if the manager supports it
     super.dispose();
@@ -1315,7 +1319,17 @@ class _DataManagementScreenState extends State<DataManagementScreen> with Single
       context: context,
       builder: (context) => AlertDialog(
         title: Text(title),
-        content: Text(message),
+        // AlertDialog caps its content height and clips the overflow, so a
+        // long message (the re-match summary names up to 8 launches) lost its
+        // last paragraph mid-sentence with nothing to say more was there.
+        content: Scrollbar(
+          controller: _dialogScrollController,
+          thumbVisibility: true,
+          child: SingleChildScrollView(
+            controller: _dialogScrollController,
+            child: Text(message),
+          ),
+        ),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),

--- a/the_paragliding_app/pubspec.yaml
+++ b/the_paragliding_app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.7+19
+version: 1.0.8+20
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
Cuts 1.0.8+20, the first release since v1.0.7+19 on 8 August, and adds the skill that should have been driving this.

## Three commits

**`Add a release skill`** — `GOOGLE_PLAY_DEPLOYMENT.md` documents the pipeline well but nothing routes to it, and the judgement calls (which number to bump, how to write the notes, how to tell whether a run published) were written down nowhere. The skill carries the sequence and the decisions and defers to the runbook for everything else, with a pointer added to `CLAUDE.md` so the two do not drift.

**`Scroll the confirmation dialog`** — `AlertDialog` clips content that overruns and says nothing about it. The launch re-match summary can run to eight launches plus the "your IGC files are not modified" reassurance, so the pilot could be asked to approve a log rewrite with the explanation cut off mid-sentence.

**`Release 1.0.8+20`** — `pubspec.yaml` and the Play notes. `versionName` moves because the range contains real user-visible change; the notes are 470 of the 500 characters Play allows.

## Checks

- `flutter analyze` — no issues
- `flutter test` — 295 passed, 20 skipped. Ran three times: the first had one flake in `timezone_edge_cases_test.dart`, the next two were clean. Worth an eye on, not a blocker.
- Re-match driven end to end on Linux desktop against a 182-flight log: preview proposed 14 moves across 5 launches, the confirmation rendered whole, and applying moved all 14 (46 sites → 51).
- Notes length checked the way CI checks it: `LC_ALL=C.UTF-8 wc -m` → 470.

## Follow-up, not in this PR

`_showSuccessDialog` and `_showErrorDialog` in `data_management_screen.dart` clip exactly the same way, and the re-match outcome message can list every emptied site. Same three-line fix, left out to keep the release diff to what was asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)