### PR TITLE
Quieten the phone's logcat before flutter starts writing to it

### DIFF
--- a/bin/dev_run.sh
+++ b/bin/dev_run.sh
@@ -19,6 +19,10 @@
 # XDG_DOCUMENTS_DIR into dev_data/app_documents. A device uses its own sandbox instead,
 # so seeding is skipped there and --reset refuses rather than pretending to work.
 #
+# Android only: the phone's logcat ring is quietened and resized first, or the app's own
+# startup lines age out of it within ~30 seconds (see tune_device_logging below).
+# DEV_RUN_SKIP_LOG_TUNING=1 leaves the device's logging config untouched.
+#
 # Note: the 3D map needs Android/iOS - on desktop it shows a placeholder.
 
 set -euo pipefail
@@ -84,6 +88,46 @@ done
 is_desktop=false
 [[ "$device" == "linux" ]] && is_desktop=true
 
+# Make the phone's logcat usable before flutter starts writing to it.
+#
+# The Pixel thermal HAL logs one `I pixel-thermal:` line per sensor per poll: measured
+# at 84.5 lines/s, 79% of the main buffer, leaving ~30s of retention in the 256 KiB
+# default. That is short enough that the app's own startup lines are gone before you can
+# read them - and it was long misread as adbd flooding the buffer. Silencing it and
+# raising the ring measured 9.5 lines/s and ~65 min.
+#
+# None of this needs root, and it is all reversible (`setprop <name> ""`, or a reboot for
+# the size). Set DEV_RUN_SKIP_LOG_TUNING=1 to leave the device alone - worth it if you
+# are actually debugging thermal or USB behaviour, which is what these tags are for.
+tune_device_logging() {
+  local dev="$1"
+
+  command -v adb >/dev/null 2>&1 || return 0
+
+  # Only Android has logcat. `is_desktop` is false for `-d chrome` too, so testing for
+  # a real adb transport is what keeps this from firing at the web build.
+  adb devices | awk '$2 == "device" { print $1 }' | grep -qxF "$dev" || return 0
+
+  # Both forms: persist.* survives reboot, the bare one is what an already-running HAL
+  # picks up now. Never fail the run over log tuning - warn and carry on.
+  local tag
+  for tag in pixel-thermal libPixelUsbOverheat; do
+    adb -s "$dev" shell setprop "persist.log.tag.$tag" S 2>/dev/null || true
+    adb -s "$dev" shell setprop "log.tag.$tag" S 2>/dev/null || true
+  done
+
+  # -G resets on reboot, so this runs every launch. Raise only from a KiB-sized ring:
+  # matching on the unit rather than parsing a number keeps a buffer someone deliberately
+  # set larger from being shrunk back to 4 MiB.
+  local size
+  size="$(adb -s "$dev" shell logcat -g 2>/dev/null | grep '^main:' || true)"
+  if [[ "$size" != *MiB* ]]; then
+    adb -s "$dev" shell logcat -G 4M 2>/dev/null || true
+  fi
+
+  echo "Quietened pixel-thermal/libPixelUsbOverheat and sized the logcat ring for '$dev' (DEV_RUN_SKIP_LOG_TUNING=1 to skip)."
+}
+
 if $reset && ! $is_desktop; then
   cat >&2 <<EOF
 ERROR: --reset only deletes host-side desktop state ($APP_DOCUMENTS).
@@ -138,6 +182,8 @@ if $is_desktop; then
   )
 else
   echo "Device '$device' is not the Linux desktop: dev seeding is off, and the app uses whatever data is already on the device."
+  # Before flutter starts, so the app's own startup lines land in a ring that keeps them.
+  [[ -n "${DEV_RUN_SKIP_LOG_TUNING:-}" ]] || tune_device_logging "$device"
 fi
 
 mode_args=()


### PR DESCRIPTION
Follow-up to #344, which documented the setprops that make logcat readable on the Pixel but left them as something you remember to run by hand. `logcat -G` resets on every reboot, so the part that needs repeating was the easiest to forget. `dev_run.sh` now applies them before flutter starts, so the app's own startup lines land in a ring that still holds them.

## Behaviour

| | |
|---|---|
| Trigger | Android targets only |
| Guard | a real adb transport in `adb devices` — `is_desktop` is false for `-d chrome` too, so "not linux" would have fired at the web build |
| Failure | never fatal; no adb, or a refused setprop, and the run carries on |
| Opt out | `DEV_RUN_SKIP_LOG_TUNING=1` |

The ring is raised **only from a KiB-sized one**. Matching on the unit rather than parsing a number leaves a buffer someone deliberately set to 8 MiB alone, instead of shrinking it to 4 MiB on every launch.

The opt-out is not ceremony: `pixel-thermal` and `libPixelUsbOverheat` are exactly the tags you want if you are debugging thermal or USB behaviour, and a dev script that silently suppresses them needs a way to stop.

## Verification

The phone was first put **back into its flooding state**, and the flood confirmed to return (807 `pixel-thermal` lines in 12s), so none of the below could pass vacuously:

| check | result |
|---|---|
| main buffer rate | 958 → **56** lines/12s |
| `pixel-thermal` lines | 807 → **0** |
| ring size | 256 KiB → **4 MiB** |
| `-d chrome` / `-d linux` | skipped, no output |
| `DEV_RUN_SKIP_LOG_TUNING=1` | tuning suppressed, run still Ready |
| run twice | idempotent |
| pre-set 8 MiB ring | left at 8 MiB, not shrunk |
| end-to-end on the Pixel | Ready, **522-line session captured** that would previously have aged out |

One run during testing failed with `Error connecting to the service protocol` — that is the wireless-adb VM service flakiness with the screen off, not this change: a control run with `DEV_RUN_SKIP_LOG_TUNING=1` and a re-run with tuning under the same awake conditions both came up Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)