### PR TITLE
Stop spending two seconds discovering the airspace cache is empty

### DIFF
--- a/the_paragliding_app/lib/presentation/widgets/common/base_map_widget.dart
+++ b/the_paragliding_app/lib/presentation/widgets/common/base_map_widget.dart
@@ -6,6 +6,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../../../data/models/paragliding_site.dart';
 import '../../../services/map_bounds_manager.dart';
 import '../../../services/logging_service.dart';
+import '../../../services/airspace_country_service.dart';
+import '../../../services/airspace_disk_cache.dart';
 import '../../../services/airspace_interaction_service.dart';
 import '../../../utils/airspace_overlay_manager.dart';
 import '../../../utils/map_provider.dart';
@@ -128,6 +130,32 @@ abstract class BaseMapState<T extends BaseMapWidget> extends State<T> {
     _mapController = widget.mapController ?? MapController();
     _loadMapProviderPreference();
     _loadLegendState();
+    _warmAirspaceCache();
+  }
+
+  /// Open the airspace cache database off the critical path.
+  ///
+  /// The open costs ~1.3s on a cold start and used to land inside the first viewport's
+  /// airspace query (#347). Unawaited, so it overlaps tile fetching and site loading
+  /// instead of delaying the first frame.
+  ///
+  /// Deliberately not warmed in main(): that would put the cost on the splash screen for
+  /// every user, including the majority who have downloaded no airspace at all. Gated on
+  /// the same selected-country check the query path uses, so an empty cache stays free.
+  void _warmAirspaceCache() {
+    if (!enableAirspace) return;
+    unawaited(() async {
+      try {
+        final countries =
+            await AirspaceCountryService.instance.getSelectedCountries();
+        if (countries.isEmpty) return;
+        await AirspaceDiskCache.instance.database;
+      } catch (e) {
+        // Warming is an optimisation; the query path opens the database itself if this
+        // fails, so a failure here must not surface to the user.
+        LoggingService.debug('Airspace cache warm-up skipped: $e');
+      }
+    }());
   }
 
   @override

--- a/the_paragliding_app/lib/services/airspace_disk_cache.dart
+++ b/the_paragliding_app/lib/services/airspace_disk_cache.dart
@@ -71,6 +71,11 @@ class AirspaceDiskCache {
   }
 
   Future<Database> _initDatabase() async {
+    // Timed in three phases because this open was billed to "database_query" and hid
+    // ~1.3s of the 2s in #347. Which phase dominates decides whether the version probe
+    // below is worth removing - measure it rather than guessing.
+    final phaseStopwatch = Stopwatch()..start();
+
     final documentsDirectory = await getApplicationDocumentsDirectory();
     final path = join(documentsDirectory.path, _databaseName);
     _databasePath = path;
@@ -84,8 +89,15 @@ class AirspaceDiskCache {
       LoggingService.error('Failed to create documents directory', e, null);
     }
 
+    LoggingService.performance(
+      '[AIRSPACE_DB_INIT] documents_dir',
+      phaseStopwatch.elapsed,
+      'platform channel + directory create',
+    );
+
     // PRE-RELEASE ONLY: Force recreation for schema changes
     // Remove this after v1.0 release and implement proper migrations
+    final probeStopwatch = Stopwatch()..start();
     try {
       final file = File(path);
       if (await file.exists()) {
@@ -106,13 +118,29 @@ class AirspaceDiskCache {
       LoggingService.info('Cannot access existing database (${e.toString()}), will create new one');
     }
 
+    // This phase opens the database read-only purely to read its version, then closes it,
+    // so the real open below is the second. If this number is material, collapse the two
+    // by letting sqflite do version detection (onUpgrade/onDatabaseDowngradeDelete).
+    LoggingService.performance(
+      '[AIRSPACE_DB_INIT] version_probe',
+      probeStopwatch.elapsed,
+      'read-only open + getVersion + close',
+    );
+
+    final openStopwatch = Stopwatch()..start();
     try {
-      return await openDatabase(
+      final db = await openDatabase(
         path,
         version: _databaseVersion,
         onCreate: _onCreate,
         onOpen: _onOpen,
       );
+      LoggingService.performance(
+        '[AIRSPACE_DB_INIT] open',
+        openStopwatch.elapsed,
+        'openDatabase + onCreate/onOpen pragmas',
+      );
+      return db;
     } catch (e, stackTrace) {
       LoggingService.error('Failed to initialize airspace cache database', e, stackTrace);
 
@@ -782,9 +810,9 @@ class AirspaceDiskCache {
 
       LoggingService.info('[SPATIAL_INDEX_QUERY] Found ${results.length} geometries in bounds | query_ms=${queryStopwatch.elapsedMilliseconds}');
 
-      if (results.isEmpty) {
-        return [];
-      }
+      // No early return on an empty result: it skipped [SPATIAL_QUERY_COMPLETE] below,
+      // so the zero-airspace case - the one that needed diagnosing in #347 - was the one
+      // case that logged no breakdown. Decoding an empty list costs nothing.
 
       // Decode geometries
       decodeStopwatch.start();

--- a/the_paragliding_app/lib/services/airspace_geojson_service.dart
+++ b/the_paragliding_app/lib/services/airspace_geojson_service.dart
@@ -468,6 +468,37 @@ class AirspaceGeoJsonService {
   ) async {
     final pipelineMetrics = AirspacePipelineMetrics();
     pipelineMetrics.startPipeline();
+
+    // Nothing is downloaded until the user picks a country, so the common case is an
+    // empty cache - and finding that out cost ~2s per viewport change, almost all of it
+    // opening a database with no rows in it (see issue #347).
+    //
+    // The selected-country list is the free way to know: it is SharedPreferences, already
+    // in memory on this path (airspace_overlay_manager.dart reads four other settings
+    // before this call). Deliberately re-read rather than cached - it costs nothing, and
+    // that means a country downloaded mid-session takes effect on the next viewport with
+    // no invalidation to get wrong.
+    //
+    // This relies on prefs and the database being emptied together: clearAllData() and
+    // the per-country delete in airspace_country_selector.dart both do so. Keep that true.
+    pipelineMetrics.startStage('country_check');
+    final selectedCountries =
+        await AirspaceCountryService.instance.getSelectedCountries();
+    if (selectedCountries.isEmpty) {
+      pipelineMetrics.endPipeline(
+        airspaceCount: 0,
+        bounds: '${bounds.west},${bounds.south},${bounds.east},${bounds.north}',
+        additionalData: {'skipped': 'no_countries_selected'},
+      );
+      return [];
+    }
+
+    // Opening the cache database is its own cost - a platform channel, a version probe
+    // and a second open - and it used to be billed to database_query, which is why the
+    // issue reported a 1974ms "query" that spent 612ms querying. Time it separately.
+    pipelineMetrics.startStage('database_open');
+    await AirspaceDiskCache.instance.database;
+
     pipelineMetrics.startStage('database_query');
 
     // Convert excluded types to integer codes for SQL filtering

--- a/the_paragliding_app/test/airspace_empty_cache_guard_test.dart
+++ b/the_paragliding_app/test/airspace_empty_cache_guard_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_map/flutter_map.dart' as fm;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:the_paragliding_app/services/airspace_geojson_service.dart';
+
+/// Airspace is only ever downloaded when the user picks a country, so an empty cache is
+/// the normal state - and finding that out used to cost ~2s on *every* viewport change
+/// (issue #347). Almost all of it was opening a database with no rows in it: ~1362ms in
+/// the lazy open, which the pipeline metrics billed to "database_query", and only 612ms
+/// in the query itself.
+///
+/// The guard reads the selected-country list from SharedPreferences - free, and already
+/// in memory on this path - and returns before the database is touched at all.
+///
+/// These tests work because path_provider has no implementation under `flutter test`:
+/// reaching the database means calling getApplicationDocumentsDirectory(), which throws.
+/// So "returns cleanly" and "touched the database" are directly distinguishable, with no
+/// mocking. Reverting the guard turns the first test red with a MissingPluginException.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // The bounds from the issue: Perth, Western Australia.
+  final perth = fm.LatLngBounds(
+    const LatLng(-32.36228712305954, 115.58068411690849),
+    const LatLng(-31.549561021093186, 116.14569527762279),
+  );
+
+  Future<List<fm.Polygon>> fetchForPerth() {
+    return AirspaceGeoJsonService.instance.fetchAirspacePolygonsDirect(
+      perth,
+      0.5,
+      const {},
+      const {},
+      10000.0,
+      true,
+    );
+  }
+
+  group('empty airspace cache', () {
+    test('no countries selected returns nothing without opening the database', () async {
+      SharedPreferences.setMockInitialValues({});
+
+      // Without the guard this throws instead of returning: the call reaches
+      // `await database`, which needs path_provider.
+      expect(await fetchForPerth(), isEmpty);
+    });
+
+    test('an empty country list is treated the same as no key at all', () async {
+      SharedPreferences.setMockInitialValues({
+        'airspace_selected_countries': <String>[],
+      });
+
+      expect(await fetchForPerth(), isEmpty);
+    });
+  });
+
+  group('the guard does not over-block', () {
+    test('a selected country still reaches the database', () async {
+      SharedPreferences.setMockInitialValues({
+        'airspace_selected_countries': <String>['AU'],
+      });
+
+      // The complement of the tests above, and the reason they prove anything: with a
+      // country selected the guard must fall through to the real path. Under
+      // `flutter test` that means path_provider throws - which is exactly the signal
+      // that the database was reached rather than skipped.
+      //
+      // Without this, a guard that returned [] unconditionally would pass every other
+      // test in this file while silently blanking the overlay for real users.
+      await expectLater(fetchForPerth(), throwsA(anything));
+    });
+  });
+}


### PR DESCRIPTION
Fixes #347.

Every viewport change on the Sites map spent ~1982ms in the airspace pipeline and returned zero airspaces, which the app flagged itself with a `[PERF WARNING]`.

**Zero was the correct answer.** Airspace is only downloaded when the user picks a country, so an empty cache is the normal state — the device's cache was 32 KB of schema with no rows. The bug was that finding this out cost two seconds, on every pan.

## The reported number was also misattributed

`database_query_ms=1974` covered one call, and only 612ms of it was the query. `getGeometriesInBounds` awaits the lazy database open on the line *before* its own stopwatch starts (`airspace_disk_cache.dart:726`, stopwatch at `:727`), so ~1362ms of *opening* a database was billed to *querying* it.

## The guard

Reads the selected-country list instead of asking the database. That list is SharedPreferences and already in memory on this path — `airspace_overlay_manager` reads four other settings before the database is touched.

Deliberately **not** cached: re-reading costs nothing, so a country downloaded mid-session takes effect on the next viewport with no invalidation to get wrong. Prefs and the database are emptied together by `clearAllData()` and by the per-country delete; the code says so, because that invariant is what makes this safe.

> `hasLoadedCountries()` looks like the obvious guard and is not — it calls `getGeometryCount()`, whose first line opens the database. Using it would have *moved* the 1.3s, not removed it. It remains unused.

## Also here, so the next person reads honest numbers

- `database_open` is its own pipeline stage, separate from `database_query`.
- `_initDatabase` logs its three phases.
- Dropped the early return on an empty result set — it skipped `[SPATIAL_QUERY_COMPLETE]`, so the zero-airspace case was the only one that logged no breakdown.
- The database is warmed unawaited from `BaseMapWidget.initState`, gated on the same country check. Deliberately **not** in `main()` — that would put the cost on the splash for the majority of users who have no airspace data at all.

## Verification

**Regression test proven to fail without the fix:** disabling the guard turns both empty-cache tests red with `MissingPluginException` — they reach `path_provider`, which is exactly the signal the database was touched. A third test is the complement (a selected country *must* fall through to the database); it caught a real mistake while being written — a wrong prefs key that had made another test pass vacuously.

**In the running app (Linux desktop):**

| case | result |
|---|---|
| no country selected | `pipeline_total_ms=1 \| skipped=no_countries_selected`, **no** database-init line at all, no PERF WARNING |
| country selected, first build | `database_open_ms=417 \| database_query_ms=13` — open now attributed separately |
| country selected, second build | `pipeline_total_ms=6 \| database_open_ms=0` |
| zero-result query | `[SPATIAL_QUERY_COMPLETE] \| query_results=0` now fires |

The open's breakdown was `documents_dir 81ms + version_probe 4ms + open 328ms`, which **answers a question the plan had deferred**: the read-only version probe is only 4ms, so collapsing the double-open is not worth doing. The cost is `openDatabase` itself.

`flutter analyze` clean; 298 tests pass, 20 skipped.

Android timings to follow as a comment — desktop uses sqflite FFI, so it cannot stand in for the platform-channel cost that produced the 1982ms.

## Deliberately not in scope

Index and query work. The four-column index is only usable to its first column, `SELECT *` makes it non-covering and the `ORDER BY` is unindexed — but with zero rows there is nothing to measure, and after this change the query is not reached at all on an empty cache. Recorded on #347 for when data exists. Any index change also needs an `onUpgrade` path first, since the current policy deletes the whole database on a version bump and users download airspace over mobile data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)