### PR TITLE
Store each airspace country once, so removing one actually removes it

### DIFF
--- a/the_paragliding_app/lib/services/airspace_country_service.dart
+++ b/the_paragliding_app/lib/services/airspace_country_service.dart
@@ -94,22 +94,34 @@ class AirspaceCountryService {
     'MX': CountryInfo(code: 'MX', name: 'Mexico', estimatedSizeMB: 12),
   };
 
-  /// Get list of selected countries
+  /// Get list of selected countries, without duplicates.
+  ///
+  /// Deduplicated on the way out as well as the way in, because installs already carry
+  /// duplicates from before the write-side fix - one real prefs file held
+  /// ['AU','AT','AT','BE','AU']. Healing on read means those installs behave correctly
+  /// immediately, with no migration; storage tidies itself the next time a selection
+  /// changes.
   Future<List<String>> getSelectedCountries() async {
     final prefs = await SharedPreferences.getInstance();
     final countries = prefs.getStringList(_selectedCountriesKey) ?? [];
 
     // Only log when countries list changes, not on every call
-    return countries;
+    return countries.toSet().toList();
   }
 
-  /// Set selected countries
+  /// Set selected countries, storing each at most once.
+  ///
+  /// Duplicates are not merely untidy: the callers remove a country with `List.remove`,
+  /// which drops only the *first* occurrence. A country selected twice therefore survived
+  /// being removed - it stayed in the list, kept the airspace query on its slow path
+  /// instead of the empty-cache skip, and reappeared as selected in the UI.
   Future<void> setSelectedCountries(List<String> countryCodes) async {
+    final unique = countryCodes.toSet().toList();
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setStringList(_selectedCountriesKey, countryCodes);
+    await prefs.setStringList(_selectedCountriesKey, unique);
 
     LoggingService.info(
-      'Updated selected countries: ${countryCodes.join(", ")}',
+      'Updated selected countries: ${unique.join(", ")}',
     );
   }
 

--- a/the_paragliding_app/test/airspace_country_duplicates_test.dart
+++ b/the_paragliding_app/test/airspace_country_duplicates_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:the_paragliding_app/services/airspace_country_service.dart';
+
+/// The airspace country selector appended the country code without checking whether it
+/// was already there, so a real prefs file ended up holding ['AU','AT','AT','BE','AU'].
+///
+/// That is not merely untidy. Every caller removes a country with `List.remove`, which
+/// drops only the *first* occurrence, so a country selected twice survived being removed:
+/// it stayed selected in the UI, and it kept the airspace overlay on its slow path
+/// instead of the empty-cache skip added in #351.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const key = 'airspace_selected_countries';
+  final service = AirspaceCountryService.instance;
+
+  group('reading', () {
+    test('duplicates already on disk are not returned twice', () async {
+      // The exact contents of the prefs file that exposed this.
+      SharedPreferences.setMockInitialValues({
+        key: <String>['AU', 'AT', 'AT', 'BE', 'AU'],
+      });
+
+      expect(await service.getSelectedCountries(), ['AU', 'AT', 'BE']);
+    });
+
+    test('an unduplicated list is returned unchanged, in order', () async {
+      SharedPreferences.setMockInitialValues({
+        key: <String>['AU', 'AT', 'BE'],
+      });
+
+      expect(await service.getSelectedCountries(), ['AU', 'AT', 'BE']);
+    });
+  });
+
+  group('writing', () {
+    test('a country selected twice is stored once', () async {
+      SharedPreferences.setMockInitialValues({});
+
+      await service.setSelectedCountries(['AU', 'AU', 'AT']);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getStringList(key), ['AU', 'AT']);
+    });
+  });
+
+  group('the symptom this caused', () {
+    test('a duplicated country can actually be removed', () async {
+      SharedPreferences.setMockInitialValues({
+        key: <String>['AU', 'AT', 'AU'],
+      });
+
+      // Exactly what airspace_country_selector.dart does when you remove a country:
+      // read, List.remove, write back. With duplicates present, `remove` dropped only
+      // the first 'AU' and the second one silently kept the country selected.
+      final selected = await service.getSelectedCountries();
+      selected.remove('AU');
+      await service.setSelectedCountries(selected);
+
+      expect(await service.getSelectedCountries(), isNot(contains('AU')));
+    });
+
+    test('removing the last country leaves an empty list, so the skip can fire', () async {
+      // #351 skips the whole airspace pipeline when no country is selected. A surviving
+      // duplicate defeated that, which is why this is worth asserting directly.
+      SharedPreferences.setMockInitialValues({
+        key: <String>['AU', 'AU'],
+      });
+
+      final selected = await service.getSelectedCountries();
+      selected.remove('AU');
+      await service.setSelectedCountries(selected);
+
+      expect(await service.getSelectedCountries(), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Found while verifying #351: a real prefs file held `['AU','AT','AT','BE','AU']`. The country selector appends the code without checking whether it is already present (`airspace_country_selector.dart:142`), so re-selecting an already-selected country stored it twice.

## Why this is a bug, not just untidiness

Every caller removes a country with `List.remove`, which drops only the **first** occurrence. So a duplicated country survived being removed:

- it stayed ticked in the UI, and
- since #351, it kept the airspace overlay on its **slow path** instead of taking the empty-cache skip.

Removing your last country could leave the list non-empty — exactly the state that skip exists to detect.

## Approach

Deduplicated **in the service**, not at the call sites. All three writers go through `setSelectedCountries`, so one choke point fixes them all and leaves nothing to remember when someone adds a fourth.

Also deduplicated **on read**, because installs already carry duplicates. That heals them immediately with no migration, and storage tidies itself the next time a selection changes. The read side deliberately does *not* write back — the airspace guard calls `getSelectedCountries()` on every viewport change, and that is no place for a write.

## Verification

Removing both dedupes turns **4 of the 5 tests red**:

| test | without the fix |
|---|---|
| duplicates on disk not returned twice | `['AU','AT','AT','BE','AU']` |
| a country selected twice is stored once | `['AU','AU','AT']` |
| **a duplicated country can actually be removed** | comes back as `['AT','AU']` |
| **removing the last country leaves an empty list** | `['AU']` — the skip never fires |
| an already-unique list is unchanged | passes either way — the control |

The two bolded ones assert the real user-visible symptom rather than the data shape, and the fifth is a deliberate control that should pass in both directions.

`flutter analyze` clean; 303 tests pass, 20 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)