### PR TITLE
Write down what the Bash sandbox needs to run and build this app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,8 @@ lib/
 | Hot reload fails | State corruption | Use `R` (hot restart) instead of `r` |
 | App won't start | Already running | `kill "$(cat dev_data/flutter.pid)"`, then start again |
 | Hot reload does nothing | App not actually running | `kill -0 "$(cat dev_data/flutter.pid)"` - no pid file means it exited |
+| `Gtk-WARNING cannot open display: :0` | Bash sandbox has no X11 display - the machine is not headless | Add `bin/dev_*.sh` to `sandbox.excludedCommands` (see "The Bash sandbox") |
+| Build dies on `Read-only file system` in `/tmp` or `~/.local/share/kotlin` | Bash sandbox filesystem policy | Add the path to `sandbox.filesystem.allowWrite` (see "The Bash sandbox") |
 | `Unable to create '.git/index.lock': File exists` | An index-writing git command was killed and left its lock | Check it is stale - `stat -c %y .git/index.lock` and `pgrep -a git` - then `rm -f .git/index.lock`. Never delete one while a git process is alive |
 
 ## Project Overview
@@ -164,6 +166,31 @@ The Paragliding App is a free, Android-first, cross-platform application for log
 **Documentation**: [Architecture](docs/TECHNICAL_DESIGN.md) | [Requirements](docs/FUNCTIONAL_SPECIFICATION.md)
 
 ## Claude Code Integration
+
+### The Bash sandbox (per-developer, not configured in this repo)
+
+Claude Code's Bash sandbox is set up in each developer's `~/.claude/settings.json`, so nothing
+in this repo turns it on and you will not see it in a diff. If yours is enabled, three things
+about *this* project need configuration that is not obvious. Each was found by a failed run.
+
+- **`bin/dev_*.sh`, `adb` and `flutter devices` belong in `sandbox.excludedCommands`.** A
+  sandboxed shell gets no X11 display and no network interface at all (`ip addr` shows only
+  `lo`), so a desktop launch dies with `Gtk-WARNING cannot open display: :0`, adb-over-Wi-Fi
+  fails with "Network is unreachable", and `flutter devices` lists only Linux and Chrome.
+  Those commands have to run outside the sandbox. It reads exactly like a headless machine
+  and is not one - that misdiagnosis once led to hunting for `Xvfb`.
+- **Android builds need three extra `filesystem.allowWrite` paths**: `/tmp` (Gradle's
+  `mergeDebugJavaResource` writes via Java's `java.io.tmpdir`, which is hardcoded to `/tmp`
+  and **ignores `TMPDIR`**), `~/.local/share/kotlin` (the Kotlin compile daemon), and
+  `~/.config/.android` (the debug keystore - *not* `~/.android`, which is a different path).
+- **With `network.strictAllowlist` on, every missing host is a hard failure.** Gradle needs
+  `dl.google.com`, `maven.google.com`, `repo.maven.apache.org`, `repo1.maven.org`,
+  `services.gradle.org` and `plugins.gradle.org` (`android/build.gradle.kts` declares
+  `google()` and `mavenCentral()`); `flutter test --tags network` needs `storage.openaip.net`.
+
+A sandboxed build only works in the session's own working directory. Building in a *different*
+checkout fails early at `Cannot open file, path = '.dart_tool/package_graph.json' (OS Error:
+Read-only file system)` - that is a wrong-directory error, not a missing permission.
 
 ### Log Files for Monitoring
 


### PR DESCRIPTION
Claude Code's Bash sandbox is configured per-developer in `~/.claude/settings.json`, so it
never appears in a diff in this repo — and every session rediscovers the same traps from
scratch. This records them next to the commands they break.

Three things this project needs from a sandboxed setup, each found by a failed run:

- **`bin/dev_*.sh`, `adb` and `flutter devices` need `sandbox.excludedCommands`.** A sandboxed
  shell has no X11 display and no network interface (`ip addr` shows only `lo`), so the desktop
  launch dies with `Gtk-WARNING cannot open display: :0`, adb-over-Wi-Fi reports "Network is
  unreachable", and `flutter devices` sees only Linux and Chrome.
- **Android builds need three extra `allowWrite` paths** — `/tmp` (Gradle's `java.io.tmpdir` is
  hardcoded to `/tmp` and ignores `TMPDIR`), `~/.local/share/kotlin`, and `~/.config/.android`
  (the debug keystore, which is *not* `~/.android`).
- **`network.strictAllowlist` makes any missing host a hard failure** — the six Gradle hosts
  behind `google()`/`mavenCentral()`, plus `storage.openaip.net` for the `network`-tagged tests.

Also adds two rows to the Common Error Patterns table, since a symptom is what you actually
search for. The display one matters most: it reads exactly like a headless machine and isn't
one, which previously sent a session looking for `Xvfb` and substituting a test for the
desktop run.

Docs only — no code or behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)