### PR TITLE
Name the German guide, and notice one this app cannot key on

### DIFF
--- a/the_paragliding_app/lib/presentation/screens/about_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/about_screen.dart
@@ -268,6 +268,11 @@ class _AboutScreenState extends State<AboutScreen> {
                       icon: Icons.web,
                       text: 'Australian National Site Guide',
                     ),
+                    AppAttributionLink.standard(
+                      url: 'https://service.dhv.de/db3/gelaende',
+                      icon: Icons.web,
+                      text: 'DHV Geländedatenbank',
+                    ),
                   ],
                 ),
               ),

--- a/the_paragliding_app/lib/presentation/screens/site_details_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/site_details_screen.dart
@@ -133,12 +133,14 @@ class SiteDetailsScreenState extends State<SiteDetailsScreen> with SingleTickerP
   static String _sourceLabel(String provider) => switch (provider) {
         'pge' => 'PGE',
         'ansg' => 'ANSG',
+        'dhv' => 'DHV',
         _ => provider,
       };
 
   static String _sourceFullName(String provider) => switch (provider) {
         'pge' => 'ParaglidingEarth',
         'ansg' => 'Australian National Site Guide',
+        'dhv' => 'DHV Geländedatenbank',
         _ => provider,
       };
 
@@ -152,6 +154,11 @@ class SiteDetailsScreenState extends State<SiteDetailsScreen> with SingleTickerP
         'pge' => 'https://www.paraglidingearth.com/?site=$id',
         // Site Guide ids are "<siteId>-<launchId>"; the page is per site.
         'ansg' => 'https://siteguide.org.au/sites/details/${id.split('-').first}',
+        // DHV ids are "<Gelände>-<slug of the launch name>". DHV has no page
+        // per launch - every takeoff and landing on a hill shares one - so
+        // the Gelände half is the whole address.
+        'dhv' =>
+          'https://service.dhv.de/db2/details.php?qi=glp_details&item=${id.split('-').first}',
         _ => null,
       };
 

--- a/the_paragliding_app/lib/utils/catalog_ref.dart
+++ b/the_paragliding_app/lib/utils/catalog_ref.dart
@@ -40,8 +40,9 @@ class CatalogRef {
   /// 89 rows carry two at all.
   ///
   /// A provider is the guide's own abbreviation, lowercased - `pge` for
-  /// ParaglidingEarth, `ansg` for the Australian National Site Guide, `ffvl` for
-  /// the Fédération Française de Vol Libre when it arrives. Whatever the guide
+  /// ParaglidingEarth, `ansg` for the Australian National Site Guide, `dhv` for
+  /// the DHV Geländedatenbank, `ffvl` for the Fédération Française de Vol Libre
+  /// when it arrives. Whatever the guide
   /// is actually called, rather than a fixed width: the prefix is carried in
   /// every stored ref, so it wants to be short, but a recognisable acronym beats
   /// a letter saved.
@@ -49,7 +50,7 @@ class CatalogRef {
   /// The only hard rule is that it cannot contain `:` or `;` - those separate the
   /// id and the tokens, so a prefix holding either would not survive a round
   /// trip through `source`.
-  static const List<String> providerPrecedence = ['pge', 'ansg'];
+  static const List<String> providerPrecedence = ['pge', 'ansg', 'dhv'];
 
   /// The ref for a catalogue row, from its `source` column.
   ///

--- a/the_paragliding_app/test/federated_catalog_test.dart
+++ b/the_paragliding_app/test/federated_catalog_test.dart
@@ -29,6 +29,33 @@ void main() {
 
     String field(CsvRow row, String name) => (row[name] ?? '').toString();
 
+    test('names no guide this app cannot key on', () {
+      // `providerPrecedence` is one of three hand-written copies of the same
+      // list - the others are KEY_PRECEDENCE and APP_PRECEDENCE, both in the
+      // producer's repo, in Python. The producer asserts two of the three
+      // agree; nothing here noticed if the app's copy fell behind.
+      //
+      // It matters because an unranked provider falls through to
+      // `tokens.first`, so the app and the producer can key the same launch
+      // differently - a fresh install and an upgraded one then disagree about
+      // which site the pilot's flight is on.
+      final providers = <String>{};
+      for (final row in rows) {
+        for (final token in CatalogRef.tokensOf(field(row, 'source'))) {
+          final provider = CatalogRef.providerOf(token);
+          if (provider != null) providers.add(provider);
+        }
+      }
+
+      expect(providers, isNotEmpty, reason: 'a sweep over nothing is not coverage');
+      expect(
+        providers.difference(CatalogRef.providerPrecedence.toSet()),
+        isEmpty,
+        reason: 'add the guide to CatalogRef.providerPrecedence, in lockstep '
+            'with KEY_PRECEDENCE in the producer',
+      );
+    });
+
     test('carries every column the app reads by name', () {
       expect(
         rows.first.headerMap.keys,

--- a/the_paragliding_app/test/site_source_tabs_test.dart
+++ b/the_paragliding_app/test/site_source_tabs_test.dart
@@ -37,6 +37,16 @@ void main() {
       expect(sources.any((s) => s.provider == 'pge'), isFalse);
     });
 
+    test('a DHV id keeps the hyphens inside it', () {
+      // DHV refs are "<Gelände>-<slug of the launch name>", so the id half is
+      // full of hyphens and the site page is addressed by the Gelände alone.
+      // Splitting on the wrong separator would point five Loser takeoffs at
+      // one page, or at none.
+      final sources = site('dhv:1416-loser-startplatz-3').sources;
+      expect(sources, [(provider: 'dhv', id: '1416-loser-startplatz-3')]);
+      expect(sources.first.id.split('-').first, '1416');
+    });
+
     test('a catalogue predating source tracking yields nothing', () {
       // The dialog falls back to a single PGE tab rather than none.
       expect(site(null).sources, isEmpty);


### PR DESCRIPTION
The site catalogue is gaining DHV (Kevin-McIsaac/paragliding_site_federation#9), which takes Germany from 595 launches to 1,355 and its wind coverage from 36% to 81%, plus Austria and Switzerland. This is the app's side of that: four touch points, because the import path is provider-agnostic by construction.

- `dhv` ranked in `CatalogRef.providerPrecedence`, in lockstep with `KEY_PRECEDENCE` in the producer.
- Label, full name and link for its tab in `site_details_screen.dart`. DHV has no page per launch — every takeoff and landing on a hill shares one — so the Gelände half of the ref is the whole address, the same shape `ansg` already uses.
- Attribution in `about_screen.dart`.
- A test that the shipped catalogue names no guide this app has no precedence entry for.

## Why the guard test

`providerPrecedence` is one of three hand-written copies of one decision, in two repositories and two languages (`KEY_PRECEDENCE` and `APP_PRECEDENCE` are the others). The producer asserts two of the three agree; nothing here noticed if the app's copy fell behind. `SITE_CATALOGUE_REQUIREMENTS.md:141-143` asks exactly this question and had no answer.

It matters because an unranked provider falls through to `tokens.first`, so the app and the producer can key the same launch differently — a fresh install and an upgraded one then disagree about which site a flight is on. Proven by removing `ansg` and watching it go red, and it fails rather than passes on an empty sweep.

## Not urgent for an older install

An unknown provider already degrades gracefully: `CatalogRef.fromSource` falls back and `_sourceUrl` has a `_ =>` fallthrough. So this does not need to ship before the catalogue does.

## Verification

305 tests, `flutter analyze` clean. Separately, the real `importSitesData` was driven with the actual before/after catalogues on a database holding the old one: 1 withdrawal (PGE's own upstream deletion), 1,207 `dhv:`-keyed rows added, favourites held 3/3 across DE/AT/CH, flown-site links 3/3 with none dangling.

The bundled asset is not regenerated here — that belongs with a release, and the app follows the published feed in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)