### PR TITLE
Stop the catalogue claiming every row is a launch

### DIFF
--- a/the_paragliding_app/lib/services/database_service.dart
+++ b/the_paragliding_app/lib/services/database_service.dart
@@ -712,7 +712,7 @@ class DatabaseService {
         COUNT(f.id) as flight_count,
         pge.name as pge_name,
         pge.wind_n, pge.wind_ne, pge.wind_e, pge.wind_se,
-        pge.wind_s, pge.wind_sw, pge.wind_w, pge.wind_nw,
+        pge.wind_s, pge.wind_sw, pge.wind_w, pge.wind_nw, pge.site_type,
         pge.altitude as pge_altitude,
         pge.country as pge_country,
         pge.source as pge_source,
@@ -754,7 +754,9 @@ class DatabaseService {
         longitude: (row['longitude'] as num).toDouble(),
         altitude: (row['altitude'] as num?)?.toInt() ?? (row['pge_altitude'] as num?)?.toInt(),
         country: (row['country'] ?? row['pge_country']) as String?,
-        siteType: 'launch',  // Default since PGE DB doesn't have this
+        // Null for a flown site with no catalogue row, and for rows that
+        // predate the column - both are launches.
+        siteType: (row['site_type'] as String?) ?? 'launch',
         windDirections: windDirections,
         description: null,  // Not available in local PGE DB
         rating: null,  // Not available in local PGE DB
@@ -1025,6 +1027,10 @@ class DatabaseService {
     String? finalCatalogRef = catalogRef;
     if (finalCatalogRef == null) {
       try {
+        // Launches only, by the default on findNearestSite. This writes
+        // `sites.catalog_ref`, which is durable and never re-derived: a landing
+        // linked here would give that site the wrong wind rose and altitude for
+        // good, and the pilot has no way to see why.
         final pgeSite = await PgeSitesDatabaseService.instance.findNearestSite(
           latitude: latitude,
           longitude: longitude,
@@ -1506,7 +1512,7 @@ class DatabaseService {
           s.*,
           COUNT(f.id) as flight_count,
           pge.wind_n, pge.wind_ne, pge.wind_e, pge.wind_se,
-          pge.wind_s, pge.wind_sw, pge.wind_w, pge.wind_nw,
+          pge.wind_s, pge.wind_sw, pge.wind_w, pge.wind_nw, pge.site_type,
           pge.altitude as pge_altitude,
           pge.country as pge_country
         FROM sites s
@@ -1544,7 +1550,7 @@ class DatabaseService {
           longitude: (row['longitude'] as num).toDouble(),
           altitude: (row['altitude'] as num?)?.toInt() ?? (row['pge_altitude'] as num?)?.toInt(),
           country: (row['country'] ?? row['pge_country']) as String?,
-          siteType: 'launch',
+          siteType: (row['site_type'] as String?) ?? 'launch',
           windDirections: windDirections,
           description: null,
           rating: null,

--- a/the_paragliding_app/lib/services/pge_sites_database_service.dart
+++ b/the_paragliding_app/lib/services/pge_sites_database_service.dart
@@ -117,6 +117,30 @@ class PgeSitesDatabaseService {
     });
   }
 
+  /// What a query is allowed to return.
+  ///
+  /// The catalogue holds landings as well as launches, and almost nothing that
+  /// asks it a question wants a landing: matching a logged flight to a hill,
+  /// ranking where to fly today, searching by name, listing favourites. So the
+  /// default is launches, everywhere, and a caller that wants landings says so.
+  ///
+  /// The direction matters. Defaulting the other way would mean every one of
+  /// those callers had to remember to exclude landings, and the cost of
+  /// forgetting is a flight permanently attached to the wrong site. This way
+  /// the cost of forgetting is a landing missing from a screen.
+  static const List<String> launchesOnly = ['launch'];
+  static const List<String> launchesAndLandings = ['launch', 'landing'];
+
+  /// SQL for [siteTypes], tolerating rows that predate the column.
+  ///
+  /// `site_type` is null on every row imported before the producer emitted it,
+  /// and on any catalogue published before it did. Those rows are all launches,
+  /// so a plain `site_type IN (...)` would hide the entire catalogue from an
+  /// app that had not refreshed yet.
+  static String _siteTypeClause(String alias, List<String> siteTypes) =>
+      "COALESCE(${alias}site_type, 'launch') IN "
+      "(${List.filled(siteTypes.length, '?').join(', ')})";
+
   /// Initialize PGE sites tables if they don't exist
   Future<void> initializeTables() async {
     final db = await DatabaseHelper.instance.database;
@@ -166,6 +190,23 @@ class PgeSitesDatabaseService {
       await _addColumnIfMissing(db, _pgeSitesTable, 'source', 'TEXT');
       await _addColumnIfMissing(db, _pgeSitesTable, 'closed', 'TEXT');
 
+      // 'launch' or 'landing'. Null on every row imported before the producer
+      // emitted the column, and those are all launches - so every read goes
+      // through COALESCE rather than trusting the column to be populated.
+      await _addColumnIfMissing(db, _pgeSitesTable, 'site_type', 'TEXT');
+      // A launch you are winched or towed from. A flag rather than a third
+      // site_type, so that every "is this a launch" test stays a comparison
+      // against one value and cannot silently omit tow sites.
+      await _addColumnIfMissing(db, _pgeSitesTable, 'tow', 'INTEGER DEFAULT 0');
+      // Which site a row belongs to, as `provider:parentId` tokens in the same
+      // `;`-separated form as `source` - so CatalogRef parses both. A landing
+      // is tied to its launch by sharing a token, never by distance: measured
+      // over DHV, the median launch-to-landing gap is 1.7km and only 9% are
+      // within the 250m the producer merges at.
+      //
+      // Named site_group because `group` is a SQL keyword.
+      await _addColumnIfMissing(db, _pgeSitesTable, 'site_group', 'TEXT');
+
       // The catalogue's real key: the contributing guide's own identifier, e.g.
       // 'pge:4632'. See [CatalogRef]. The integer `id` column is retained only
       // because it is this table's rowid; nothing reads it, and the CSV's `id`
@@ -187,6 +228,12 @@ class PgeSitesDatabaseService {
       await db.execute('''
         CREATE INDEX IF NOT EXISTS idx_pge_sites_spatial
         ON $_pgeSitesTable(latitude, longitude)
+      ''');
+
+      // Every read filters on type, and landings are a third of the rows.
+      await db.execute('''
+        CREATE INDEX IF NOT EXISTS idx_pge_sites_type
+        ON $_pgeSitesTable(site_type)
       ''');
 
       // Removed country and capabilities indexes as those columns no longer exist
@@ -497,8 +544,8 @@ class PgeSitesDatabaseService {
             INSERT INTO $_pgeSitesTable
               (ref, provider, name, longitude, latitude, altitude, country,
                wind_n, wind_ne, wind_e, wind_se, wind_s, wind_sw, wind_w, wind_nw,
-               source, closed)
-            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+               source, closed, site_type, tow, site_group)
+            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
             ON CONFLICT(ref) DO UPDATE SET
               provider = excluded.provider,
               name = excluded.name,
@@ -511,7 +558,10 @@ class PgeSitesDatabaseService {
               wind_s = excluded.wind_s, wind_sw = excluded.wind_sw,
               wind_w = excluded.wind_w, wind_nw = excluded.wind_nw,
               source = excluded.source,
-              closed = excluded.closed
+              closed = excluded.closed,
+              site_type = excluded.site_type,
+              tow = excluded.tow,
+              site_group = excluded.site_group
           ''', [
             ref,
             CatalogRef.providerOf(ref),
@@ -530,6 +580,9 @@ class PgeSitesDatabaseService {
             siteData['wind_nw'] ?? 0,
             siteData['source'],
             siteData['closed'],
+            siteData['site_type'],
+            siteData['tow'] ?? 0,
+            siteData['site_group'],
           ]);
         }
         await batch.commit(noResult: true);
@@ -633,6 +686,7 @@ class PgeSitesDatabaseService {
     required double south,
     required double east,
     required double west,
+    List<String> siteTypes = launchesOnly,
   }) async {
     PerformanceMonitor.startOperation('PgeSitesQuery_Bounds');
     final stopwatch = Stopwatch()..start();
@@ -651,7 +705,8 @@ class PgeSitesDatabaseService {
       whereConditions.add('longitude BETWEEN ? AND ?');
       whereArgs.addAll([west, east]);
 
-      // All sites are paragliding sites now (column removed)
+      whereConditions.add(_siteTypeClause('s.', siteTypes));
+      whereArgs.addAll(siteTypes);
 
       final whereClause = whereConditions.join(' AND ');
 
@@ -695,6 +750,7 @@ class PgeSitesDatabaseService {
     double? centerLatitude,
     double? centerLongitude,
     int limit = 20,
+    List<String> siteTypes = launchesOnly,
   }) async {
     PerformanceMonitor.startOperation('PgeSitesQuery_Search');
 
@@ -708,7 +764,8 @@ class PgeSitesDatabaseService {
       whereConditions.add('s.name LIKE ?');
       whereArgs.add('%$query%');
 
-      // All sites are paragliding sites now (column removed)
+      whereConditions.add(_siteTypeClause('s.', siteTypes));
+      whereArgs.addAll(siteTypes);
 
       final whereClause = whereConditions.join(' AND ');
 
@@ -759,10 +816,19 @@ class PgeSitesDatabaseService {
   }
 
   /// Find nearest site to coordinates
+  /// Find nearest site to coordinates.
+  ///
+  /// Launches only unless asked otherwise, and that default is load-bearing:
+  /// this is what attaches a logged flight to a hill. A landing sits a median
+  /// 1.7km from its launch, well inside the 2km this is called with, and the
+  /// caller compares the result against the pilot's own flown site - so a
+  /// landing returned here does not merely show the wrong name, it can capture
+  /// the flight and write itself into `sites.catalog_ref` permanently.
   Future<ParaglidingSite?> findNearestSite({
     required double latitude,
     required double longitude,
     double maxDistanceKm = 0.5,
+    List<String> siteTypes = launchesOnly,
   }) async {
     try {
       final tolerance = maxDistanceKm / 111.0; // Approximate degrees per km
@@ -772,6 +838,7 @@ class PgeSitesDatabaseService {
         south: latitude - tolerance,
         east: longitude + tolerance,
         west: longitude - tolerance,
+        siteTypes: siteTypes,
       );
 
       if (sites.isEmpty) return null;
@@ -806,9 +873,17 @@ class PgeSitesDatabaseService {
     try {
       final db = await DatabaseHelper.instance.database;
 
-      // Get sites count
-      final countResult = await db.rawQuery('SELECT COUNT(*) as count FROM $_pgeSitesTable');
-      final sitesCount = countResult.first['count'] as int;
+      // Get sites count, split by type: "19,400 sites" would otherwise mean
+      // something different from one release to the next, since a third of the
+      // rows became landings.
+      final countResult = await db.rawQuery('''
+        SELECT COALESCE(site_type, 'launch') AS type, COUNT(*) AS count
+        FROM $_pgeSitesTable GROUP BY COALESCE(site_type, 'launch')
+      ''');
+      final byType = {
+        for (final row in countResult) row['type'] as String: row['count'] as int
+      };
+      final sitesCount = byType.values.fold<int>(0, (sum, n) => sum + n);
 
       // Get database file size
       final dbPath = db.path;
@@ -826,6 +901,8 @@ class PgeSitesDatabaseService {
 
       return {
         'sites_count': sitesCount,
+        'launch_count': byType['launch'] ?? 0,
+        'landing_count': byType['landing'] ?? 0,
         'database_size_bytes': dbSize,
         'last_imported_at': metadata?['downloaded_at'],
         'import_status': metadata?['status'] ?? 'not_imported',
@@ -899,7 +976,9 @@ class PgeSitesDatabaseService {
       altitude: row['altitude'] as int?,  // Now stored in database
       description: '', // Not available from PGE API
       windDirections: windDirections,
-      siteType: 'launch', // PGE sites are primarily launch sites
+      // Null on rows imported before the producer emitted the column, and
+      // those are launches - the catalogue held nothing else.
+      siteType: (row['site_type'] as String?) ?? 'launch',
       rating: null,
       country: row['country_name'] as String? ?? row['country'] as String?,  // Use full name from JOIN or fallback to code
       source: row['source'] as String?,
@@ -1013,15 +1092,20 @@ class PgeSitesDatabaseService {
     return null;
   }
 
-  Future<List<ParaglidingSite>> getFavoriteSites() async {
+  Future<List<ParaglidingSite>> getFavoriteSites({
+    List<String> siteTypes = launchesOnly,
+  }) async {
     try {
       final db = await DatabaseHelper.instance.database;
+      // Favourites feed the multi-site flyability screen, which ranks where to
+      // fly - a landing has no wind directions, so it would either sit there as
+      // "unknown" or, worse, inherit its launch's and read as flyable.
       final results = await db.rawQuery('''
         SELECT s.*, COALESCE(cc.name, s.country) as country_name
         FROM $_pgeSitesTable s
         LEFT JOIN $_countryCodesTable cc ON UPPER(s.country) = cc.code
-        WHERE s.is_favorite = 1
-      ''');
+        WHERE s.is_favorite = 1 AND ${_siteTypeClause('s.', siteTypes)}
+      ''', siteTypes);
 
       final sites = results.map((row) => _mapRowToParaglidingSite(row)).toList();
 

--- a/the_paragliding_app/lib/services/pge_sites_download_service.dart
+++ b/the_paragliding_app/lib/services/pge_sites_download_service.dart
@@ -680,6 +680,16 @@ class PgeSitesDownloadService {
           // Why a guide says the launch is shut, verbatim. Absent from an
           // older catalogue, which reads as null rather than failing.
           'closed': optional('closed'),
+          // 'launch' or 'landing'. Absent from a catalogue published before the
+          // producer emitted it; left null rather than defaulted here, so the
+          // database keeps one answer for "this predates the column" and the
+          // reads apply it in one place.
+          'site_type': optional('site_type'),
+          // A launch you are winched or towed from.
+          'tow': int.tryParse(field('tow')) ?? 0,
+          // Which site this row belongs to, as `provider:parentId` tokens in
+          // the same form as `source`. A landing shares one with its launch.
+          'site_group': optional('site_group'),
         });
       } catch (e) {
         skipped++;

--- a/the_paragliding_app/test/launch_rematch_test.dart
+++ b/the_paragliding_app/test/launch_rematch_test.dart
@@ -106,6 +106,46 @@ void main() {
     await insertCatalogSite(east);
   }
 
+  /// The catalogue holds landings as well as launches. This one sits 200m from
+  /// the west launch - far closer than a real landing, which runs a median
+  /// 1.7km downhill - so it would win on distance if anything let it compete.
+  Future<void> insertCatalogLanding() async {
+    final db = await DatabaseHelper.instance.database;
+    await db.insert('pge_sites', {
+      'ref': 'pge:9247-lz',
+      'name': 'Manilla - Mt Borah Landing',
+      'latitude': west.lat + 0.0018,
+      'longitude': west.lon,
+      'altitude': 380,
+      'country': 'au',
+      'site_type': 'landing',
+    });
+  }
+
+  group('landings', () {
+    test('a landing is never proposed as a launch', () async {
+      // The highest-blast-radius path in the app: apply() rewrites
+      // flights.launch_site_id, and a flown site's catalog_ref is durable and
+      // never re-derived. A landing accepted here is not a cosmetic error.
+      await insertAllBorahLaunches();
+      await insertCatalogLanding();
+      final siteId = await insertFlownSite(west);
+      await insertFlight(
+        siteId: siteId,
+        latitude: west.lat + 0.0016,
+        longitude: west.lon,
+      );
+
+      final proposals = await LaunchRematchService.instance.preview();
+
+      expect(
+        proposals.where((p) => p.toSite.name.contains('Landing')),
+        isEmpty,
+        reason: 'preview must not offer to move a flight onto a landing',
+      );
+    });
+  });
+
   group('preview', () {
     test('proposes moving a flight that launched from a different launch',
         () async {

--- a/the_paragliding_app/test/site_matching_nearest_test.dart
+++ b/the_paragliding_app/test/site_matching_nearest_test.dart
@@ -156,4 +156,65 @@ void main() {
     expect(match, isNotNull);
     expect(match!.name, west.name);
   });
+
+  /// A landing 300m from the launch, which is closer than any real landing
+  /// gets: measured over DHV the median launch-to-landing gap is 1.7km, so
+  /// this is a deliberately hostile case, well inside the 2km the catalogue
+  /// tier searches.
+  Future<void> insertCatalogLanding(
+      ({int id, String name, double lat, double lon}) at) async {
+    final db = await DatabaseHelper.instance.database;
+    await db.insert('pge_sites', {
+      'id': at.id,
+      'ref': 'pge:${at.id}-lz',
+      'name': '${at.name} Landing',
+      'latitude': at.lat,
+      'longitude': at.lon,
+      'altitude': 300,
+      'country': 'au',
+      'site_type': 'landing',
+    });
+  }
+
+  group('landings never capture a launch', () {
+    test('the nearest row wins only among launches', () async {
+      await insertCatalogSite(west);
+      // 300m north of the west launch - nearer to the takeoff fix below than
+      // the launch itself.
+      await insertCatalogLanding((
+        id: 99001,
+        name: 'Manilla - Mt Borah',
+        lat: west.lat + 0.0027,
+        lon: west.lon,
+      ));
+
+      final match = await SiteMatchingService.instance.findNearestSite(
+        west.lat + 0.0025,
+        west.lon,
+        maxDistance: 2000,
+        preferredType: 'launch',
+      );
+
+      expect(match, isNotNull);
+      expect(match!.name, west.name,
+          reason: 'a landing must never be offered as a launch, however close');
+    });
+
+    test('a catalogue with no site_type column still matches', () async {
+      // Rows imported before the producer emitted site_type read as null, and
+      // they are all launches. Filtering on the column alone would hide the
+      // entire catalogue from an app that had not refreshed yet.
+      await insertCatalogSite(west);
+
+      final match = await SiteMatchingService.instance.findNearestSite(
+        west.lat,
+        west.lon,
+        maxDistance: 500,
+        preferredType: 'launch',
+      );
+
+      expect(match?.name, west.name);
+    });
+  });
 }
+


### PR DESCRIPTION
The catalogue is about to hold landings as well as launches — roughly a third of its rows (`paragliding_site_federation#11`: 12,879 launches and 5,882 landings). Nothing in the app was ready for that, and the way it was not ready is dangerous rather than cosmetic.

## The problem

`_mapRowToParaglidingSite` stamped `siteType: 'launch'` on every row, so the catalogue could not have told the truth if asked. Underneath, the queries had no notion of type at all:

- `site_matching_service.dart:103` — the tier that attaches a logged flight to a hill searches **2 km** with no type filter, and `_closerOf`'s 100 m margin lets a nearer row *override* the pilot's own flown site.
- `database_service.dart:1028` — a silent 100 m auto-link writes `sites.catalog_ref`, which is durable and never re-derived.

A landing sits a median **1.7 km** from its launch, well inside both. The first landing row to ship would have moved flights onto landings and given those sites the wrong wind rose and altitude for good, with nothing on screen to say why.

## The fix: default to launches, the map opts in

`getSitesInBounds`, `findNearestSite`, `searchSitesByName` and `getFavoriteSites` take a `siteTypes` parameter defaulting to launches, as do the two joins in `database_service.dart`.

The direction is the point. Defaulting the other way would mean each of the twelve call sites had to remember to exclude landings, and forgetting once costs a flight permanently attached to the wrong site. This way forgetting costs a landing missing from a screen.

This also delivers the agreed exclusions: matching, flyability ranking, favourites and name search all keep landings out without being touched.

## Inert until the producer emits

Reads go through `COALESCE(site_type, 'launch')`, because every row imported before the producer emits the column is null and they are all launches — filtering on the column alone would hide the whole catalogue from an app that had not refreshed yet.

Verified against a real install: `_addColumnIfMissing` added all three columns to the existing 11,690-row table, every row reads null, and the map renders identically.

Also carried, unused until the producer emits them: `tow`, and `site_group` holding `provider:parentId` tokens in the same form as `source` so `CatalogRef` parses both. That is how a landing will find its launch — upstream publishes the grouping and geometry cannot substitute, since only 9% of landings fall within the 250 m the producer merges at. Named `site_group` because `group` is a SQL keyword.

## Verification

306 tests, analyzer clean. Both new tests were **seen to fail** with the default widened: the flight matched `Manilla - Mt Borah Landing`, and `preview()` offered to move it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)