### PR TITLE
Show a pilot where they are expected to land

### DIFF
--- a/the_paragliding_app/lib/data/models/paragliding_site.dart
+++ b/the_paragliding_app/lib/data/models/paragliding_site.dart
@@ -27,6 +27,12 @@ class ParaglidingSite {
   /// Which guides contributed this launch, e.g. "pge:4632;ansg:106-28".
   /// Drives the per-source tabs in the site details dialog.
   final String? source;
+
+  /// Which site this row belongs to, as `provider:parentId` tokens in the same
+  /// `;`-separated form as [source]. A landing shares a token with every launch
+  /// it serves, and that is the only way to relate them: measured over DHV, the
+  /// median gap from a landing to its launch is 1.7km.
+  final String? siteGroup;
   /// Why a guide says this launch is shut, verbatim. Null when open.
   final String? closed;
 
@@ -47,6 +53,7 @@ class ParaglidingSite {
     this.isFromLocalDb = false,
     this.catalogRef,
     this.source,
+    this.siteGroup,
     this.closed,
   });
 
@@ -260,6 +267,7 @@ class ParaglidingSite {
     bool? isFromLocalDb,
     String? catalogRef,
     String? source,
+    String? siteGroup,
     String? closed,
   }) {
     return ParaglidingSite(
@@ -279,6 +287,7 @@ class ParaglidingSite {
       isFromLocalDb: isFromLocalDb ?? this.isFromLocalDb,
       catalogRef: catalogRef ?? this.catalogRef,
       source: source ?? this.source,
+      siteGroup: siteGroup ?? this.siteGroup,
       closed: closed ?? this.closed,
     );
   }

--- a/the_paragliding_app/lib/presentation/models/site_marker_presentation.dart
+++ b/the_paragliding_app/lib/presentation/models/site_marker_presentation.dart
@@ -56,6 +56,19 @@ class SiteMarkerPresentation {
     required bool forecastEnabled,
     WindForecast? forecast, // Optional forecast for daylight times
   }) {
+    // Landings answer a different question, so they never enter the
+    // flyability switch below. Left to fall through, one would be coloured by
+    // whatever wind data happened to be cached for its position - blue at best,
+    // and green if a guide ever attaches wind to a landing, which reads as
+    // "you can fly from here".
+    if (site.siteType == 'landing') {
+      return SiteMarkerPresentation(
+        color: SiteMarkerUtils.landingSiteColor,
+        tooltip: 'Landing site',
+        opacity: 1.0,
+      );
+    }
+
     // Determine flyability status if not provided
     final effectiveStatus = status ?? FlyabilityStatus.unknown;
 

--- a/the_paragliding_app/lib/presentation/screens/site_details_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/site_details_screen.dart
@@ -88,6 +88,13 @@ class SiteDetailsScreenState extends State<SiteDetailsScreen> with SingleTickerP
   /// the catalogue entry was passed in already.
   ParaglidingSite? _catalogSite;
 
+  /// The landings that serve this launch, from the catalogue.
+  ///
+  /// Held rather than derived at build time because the join is a query. Empty
+  /// for a landing's own page, and for a catalogue published before the
+  /// producer emitted the grouping.
+  List<ParaglidingSite> _landings = const [];
+
   /// Whichever record actually describes this launch: the catalogue entry
   /// passed in, or the one a flown site is linked to.
   ParaglidingSite? get _effectiveSite => widget.paraglidingSite ?? _catalogSite;
@@ -97,6 +104,15 @@ class SiteDetailsScreenState extends State<SiteDetailsScreen> with SingleTickerP
   /// Falls back to a single ParaglidingEarth tab when the catalogue predates
   /// source tracking, so an older database still shows what it always did
   /// rather than losing the tab entirely.
+  /// A landing is reference information, not a site to assess.
+  ///
+  /// It has no wind directions, so the forecast table, the wind rose and the
+  /// flyability verdict have nothing to work from - shown anyway they would
+  /// read as "we checked and it is unflyable" rather than "this question does
+  /// not apply". What is left is what a pilot actually wants: where it is, how
+  /// high, and what the guide says about it.
+  bool get _isLanding => _effectiveSite?.siteType == 'landing';
+
   List<({String provider, String id})> get _sourceTabs {
     final sources = _effectiveSite?.sources ?? const [];
     return sources.isEmpty ? const [(provider: 'pge', id: '')] : sources;
@@ -154,7 +170,7 @@ class SiteDetailsScreenState extends State<SiteDetailsScreen> with SingleTickerP
     setState(() {
       _catalogSite = site;
       _tabController?.dispose();
-      _tabController = TabController(length: 1 + _sourceTabs.length, vsync: this);
+      _tabController = TabController(length: (_isLanding ? 0 : 1) + _sourceTabs.length, vsync: this);
     });
   }
 
@@ -168,10 +184,13 @@ class SiteDetailsScreenState extends State<SiteDetailsScreen> with SingleTickerP
   void initState() {
     super.initState();
     // Weather, plus one tab per contributing guide.
-    _tabController = TabController(length: 1 + _sourceTabs.length, vsync: this);
+    _tabController = TabController(length: (_isLanding ? 0 : 1) + _sourceTabs.length, vsync: this);
     // Resolve the catalogue entry first: it decides how many tabs there are,
     // and supplies the guide's own coordinates for the detail lookup.
-    _loadCatalogSite().then((_) => _loadSiteDetails());
+    _loadCatalogSite().then((_) {
+      _loadLandings();
+      return _loadSiteDetails();
+    });
     _loadWindData();
     _loadWindForecast();
     _loadFavoriteStatus();
@@ -319,6 +338,75 @@ class SiteDetailsScreenState extends State<SiteDetailsScreen> with SingleTickerP
       ),
     );
   }
+
+  /// The landings serving this launch, from the catalogue.
+  ///
+  /// Cheap and local, so it runs alongside the network fetch rather than after
+  /// it - a pilot at a launch site with no signal still gets this.
+  Future<void> _loadLandings() async {
+    final site = _effectiveSite;
+    if (site == null || site.siteType == 'landing') return;
+
+    final landings =
+        await PgeSitesDatabaseService.instance.getLandingsForSite(site);
+    if (mounted && landings.isNotEmpty) {
+      setState(() => _landings = landings);
+    }
+  }
+
+  /// The landings serving this launch, listed nearest first.
+  ///
+  /// Distance and bearing are shown because the landing is not in sight of the
+  /// launch - the median gap is 1.7km - so "where is it" is the first question
+  /// and a name alone does not answer it.
+  Widget _buildLandingsSection(double latitude, double longitude) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (final landing in _landings)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 4),
+            child: Wrap(
+              crossAxisAlignment: WrapCrossAlignment.center,
+              spacing: 12,
+              runSpacing: 4,
+              children: [
+                Text(
+                  _landings.length > 1 ? 'Landing:' : 'Landing:',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        fontWeight: FontWeight.w500,
+                      ),
+                ),
+                Text(
+                  landing.name,
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+                if (landing.altitude != null)
+                  _iconFact(
+                    Icons.terrain,
+                    '${landing.altitude} m AMSL',
+                    tooltip: 'Altitude above mean sea level',
+                  ),
+                _iconFact(
+                  Icons.straighten,
+                  _formatDistance(
+                      landing.distanceTo(latitude, longitude)),
+                  tooltip: 'Distance from the launch',
+                ),
+                InkWell(
+                  onTap: () => _launchMap(landing.latitude, landing.longitude),
+                  child: const Icon(Icons.map, size: 16, color: Colors.blue),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+
+  static String _formatDistance(double metres) => metres < 1000
+      ? '${metres.round()} m'
+      : '${(metres / 1000).toStringAsFixed(1)} km';
 
   Future<void> _loadSiteDetails() async {
     // The catalogue entry is the only thing that can answer this: a flown
@@ -575,7 +663,8 @@ class SiteDetailsScreenState extends State<SiteDetailsScreen> with SingleTickerP
     final bool showTabs = _tabController != null &&
         (_detailedData != null || widget.paraglidingSite != null);
 
-    final flyabilityLine = _buildFlyabilityLine(windDirections);
+    final flyabilityLine =
+        _isLanding ? null : _buildFlyabilityLine(windDirections);
     final characteristicsLine = _buildCharacteristicsLine();
 
     return Scaffold(
@@ -665,12 +754,13 @@ class SiteDetailsScreenState extends State<SiteDetailsScreen> with SingleTickerP
                   // why these did not read as tabs.
                   indicatorSize: TabBarIndicatorSize.tab,
                   tabs: [
-                    const Tab(
-                      child: Tooltip(
-                        message: 'Flyability forecast by hour by day',
-                        child: Text('Forecast', style: TextStyle(fontSize: 12)),
+                    if (!_isLanding)
+                      const Tab(
+                        child: Tooltip(
+                          message: 'Flyability forecast by hour by day',
+                          child: Text('Forecast', style: TextStyle(fontSize: 12)),
+                        ),
                       ),
-                    ),
                     // One tab per contributing guide, named. The old single
                     // unlabelled tab held ParaglidingEarth data without saying
                     // so, and a launch can now come from more than one guide -
@@ -691,7 +781,7 @@ class SiteDetailsScreenState extends State<SiteDetailsScreen> with SingleTickerP
                   child: TabBarView(
                     controller: _tabController,
                     children: [
-                      _buildWeatherTab(windDirections),
+                      if (!_isLanding) _buildWeatherTab(windDirections),
                       for (final source in _sourceTabs) _buildSourceTab(source),
                     ],
                   ),
@@ -1005,8 +1095,19 @@ class SiteDetailsScreenState extends State<SiteDetailsScreen> with SingleTickerP
               ],
             ),
 
+            // Landing information, from the catalogue.
+            //
+            // This works offline and for launches PGE has never described - the
+            // block below it can only speak for a launch with a `pge:` token,
+            // which is why a DHV-only or ANSG-only site showed no landing at
+            // all before. Shown in place of that block, never beside it, so one
+            // field is not listed twice at two different altitudes.
+            if (_landings.isNotEmpty) ...[
+              const SizedBox(height: 6),
+              _buildLandingsSection(latitude, longitude),
+            ]
             // Landing information row (if available)
-            if (_detailedData?['landing_altitude'] != null || _detailedData?['landing_description'] != null || _detailedData?['landing_lat'] != null) ...[
+            else if (_detailedData?['landing_altitude'] != null || _detailedData?['landing_description'] != null || _detailedData?['landing_lat'] != null) ...[
               const SizedBox(height: 6),
               // Wrap for the same reason as the launch line above, which was
               // fixed for this and left its sibling as a Row - and a Row
@@ -1099,7 +1200,7 @@ class SiteDetailsScreenState extends State<SiteDetailsScreen> with SingleTickerP
               ),
               const SizedBox(height: 4),
               Text(
-                'This launch as $fullName records it.',
+                'This ${_isLanding ? 'landing' : 'launch'} as $fullName records it.',
                 style: TextStyle(fontSize: 12, color: Colors.grey[400]),
               ),
               const SizedBox(height: 16),

--- a/the_paragliding_app/lib/presentation/widgets/nearby_sites_map.dart
+++ b/the_paragliding_app/lib/presentation/widgets/nearby_sites_map.dart
@@ -274,9 +274,13 @@ class _NearbySitesMapState extends BaseMapState<NearbySitesMap> {
                 message: presentation.tooltip ?? '',
                 child: Opacity(
                   opacity: presentation.opacity,
-                  child: SiteMarkerUtils.buildSiteMarkerIcon(
-                    color: presentation.color,
-                  ),
+                  child: site.siteType == 'landing'
+                      ? SiteMarkerUtils.buildLandingSiteMarkerIcon(
+                          color: presentation.color,
+                        )
+                      : SiteMarkerUtils.buildSiteMarkerIcon(
+                          color: presentation.color,
+                        ),
                 ),
               ),
               SiteMarkerUtils.buildSiteLabel(
@@ -325,11 +329,15 @@ class _NearbySitesMapState extends BaseMapState<NearbySitesMap> {
       return false;
     });
 
-    // Check if any sites have no wind directions defined
+    // Check if any sites have no wind directions defined.
+    //
+    // Landings never have any, and are a third of the catalogue - counted here
+    // they would fade almost every cluster on the map, turning a signal that
+    // means "this cluster hides a site we know nothing about" into background.
     final hasNoWindDirectionsSites = markers.any((marker) {
       if (marker.key is ValueKey<ParaglidingSite>) {
         final site = (marker.key as ValueKey<ParaglidingSite>).value;
-        return site.windDirections.isEmpty;
+        return site.siteType != 'landing' && site.windDirections.isEmpty;
       }
       return false;
     });
@@ -477,6 +485,15 @@ class _NearbySitesMapState extends BaseMapState<NearbySitesMap> {
         Icons.location_on,
         SiteMarkerUtils.unknownFlyabilitySiteColor,
         'Unknown',
+      ),
+      const SizedBox(height: 4),
+      // Last, and with a different icon: the four above are one scale - can I
+      // fly here now - and a landing is not a point on it.
+      SiteMarkerUtils.buildLegendItem(
+        context,
+        Icons.flag,
+        SiteMarkerUtils.landingSiteColor,
+        'Landing',
       ),
     ];
   }

--- a/the_paragliding_app/lib/services/pge_sites_database_service.dart
+++ b/the_paragliding_app/lib/services/pge_sites_database_service.dart
@@ -816,6 +816,49 @@ class PgeSitesDatabaseService {
   }
 
   /// Find nearest site to coordinates
+  /// The landings that serve a launch, nearest first.
+  ///
+  /// Joined on the group the guides publish, never on distance. A landing sits
+  /// a median 1.7km from its launch and only 9% fall within 250m, so proximity
+  /// would attach almost none of them and would attach the wrong ones - a
+  /// neighbouring hill's field is often closer than your own.
+  ///
+  /// One landing commonly serves several launches (28.5% of DHV's do), and one
+  /// launch can have several: the tokens are a set intersection, not a key.
+  Future<List<ParaglidingSite>> getLandingsForSite(ParaglidingSite site) async {
+    final tokens = CatalogRef.tokensOf(site.siteGroup);
+    if (tokens.isEmpty) return const [];
+
+    try {
+      final db = await DatabaseHelper.instance.database;
+      // `;a;b;` LIKE `%;token;%` - the delimiters are added on both sides so a
+      // token cannot match a longer one it is a prefix of (`pge:463` against
+      // `pge:4632`).
+      final clause = List.filled(
+        tokens.length,
+        "(';' || s.site_group || ';') LIKE ?",
+      ).join(' OR ');
+
+      final results = await db.rawQuery('''
+        SELECT s.*, COALESCE(cc.name, s.country) as country_name
+        FROM $_pgeSitesTable s
+        LEFT JOIN $_countryCodesTable cc ON UPPER(s.country) = cc.code
+        WHERE COALESCE(s.site_type, 'launch') = 'landing' AND ($clause)
+      ''', [for (final token in tokens) '%;$token;%']);
+
+      final landings =
+          results.map((row) => _mapRowToParaglidingSite(row)).toList()
+            ..sort((a, b) => a
+                .distanceTo(site.latitude, site.longitude)
+                .compareTo(b.distanceTo(site.latitude, site.longitude)));
+      return landings;
+    } catch (error, stackTrace) {
+      LoggingService.error(
+          '[PGE_SITES_DB] Landings query failed', error, stackTrace);
+      return const [];
+    }
+  }
+
   /// Find nearest site to coordinates.
   ///
   /// Launches only unless asked otherwise, and that default is load-bearing:
@@ -982,6 +1025,7 @@ class PgeSitesDatabaseService {
       rating: null,
       country: row['country_name'] as String? ?? row['country'] as String?,  // Use full name from JOIN or fallback to code
       source: row['source'] as String?,
+      siteGroup: row['site_group'] as String?,
       closed: row['closed'] as String?,
       region: null,
       popularity: null,

--- a/the_paragliding_app/lib/services/site_bounds_loader_v2.dart
+++ b/the_paragliding_app/lib/services/site_bounds_loader_v2.dart
@@ -46,11 +46,16 @@ class SiteBoundsLoaderV2 {
 
       // 2. Always load PGE sites from local database
       // The database will return empty list if no sites exist
+      //
+      // The one place that asks for landings. Everything else - matching,
+      // flyability ranking, search, favourites - takes the launches-only
+      // default, so a landing can be drawn without being mistaken for a hill.
       futures.add(PgeSitesDatabaseService.instance.getSitesInBounds(
         north: bounds.north,
         south: bounds.south,
         east: bounds.east,
         west: bounds.west,
+        siteTypes: PgeSitesDatabaseService.launchesAndLandings,
       ));
 
       final results = await Future.wait(futures);

--- a/the_paragliding_app/lib/utils/site_marker_utils.dart
+++ b/the_paragliding_app/lib/utils/site_marker_utils.dart
@@ -20,7 +20,15 @@ class SiteMarkerUtils {
   static const Color notFlyableSiteColor = Colors.red;   // Not flyable with current wind
   static const Color unknownFlyabilitySiteColor = Colors.blue; // No wind directions or wind data not available - same as new sites
 
-  // Launch/landing colors
+  // Landing sites in the catalogue.
+  //
+  // Slate rather than a colour from the flyability palette above: green,
+  // orange, red and blue all mean "can I fly here today", and a landing has no
+  // wind directions to answer that with. It is told apart by *shape* - a flag
+  // rather than a pin - so its colour is free to say nothing at all.
+  static const Color landingSiteColor = Color(0xFF455A64);
+
+  // Launch/landing colors (flight track endpoints, not catalogue rows)
   static const Color launchColor = Colors.green;
   static const Color landingColor = Colors.red;
   static const Color selectedPointColor = Colors.amber;
@@ -147,6 +155,24 @@ class SiteMarkerUtils {
     );
   }
   
+  /// A catalogue landing site, as drawn on the sites map.
+  ///
+  /// A flag, so it reads as somewhere to put down rather than another hill to
+  /// launch from. Landings are a third of the catalogue and sit a median 1.7km
+  /// from their launch, so at any useful zoom they are mixed in with launches
+  /// and have to be distinguishable at a glance.
+  static Widget buildLandingSiteMarkerIcon({
+    Color color = landingSiteColor,
+  }) {
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        const Icon(Icons.flag, color: Colors.white, size: siteMarkerSize),
+        Icon(Icons.flag, color: color, size: siteMarkerIconSize - 6),
+      ],
+    );
+  }
+
   /// Create a launch marker with consistent styling
   static Widget buildLaunchMarkerIcon({
     Color color = launchColor,
@@ -333,6 +359,8 @@ class SiteMarkerUtils {
               buildLegendItem(context, Icons.location_on, flownSiteColor, 'Flown Sites'),
               const SizedBox(height: 4),
               buildLegendItem(context, Icons.location_on, newSiteColor, 'New Sites'),
+              const SizedBox(height: 4),
+              buildLegendItem(context, Icons.flag, landingSiteColor, 'Landings'),
             ],
             // Add additional legend items if provided
             if (additionalLegendItems != null && additionalLegendItems.isNotEmpty) ...[

--- a/the_paragliding_app/test/federated_catalog_upgrade_test.dart
+++ b/the_paragliding_app/test/federated_catalog_upgrade_test.dart
@@ -71,8 +71,11 @@ void main() {
 
     // Coordinates, not row counts. Longitude precedes latitude in the file,
     // so an off-by-one would still parse and still count 11,672 rows.
+    // Launches only: the catalogue also holds this takeoff's landing, keyed
+    // `pge:4632-lz`, which the LIKE matches as happily as the launch.
     final borah = (await db.rawQuery(
-      "SELECT * FROM pge_sites WHERE source LIKE '%pge:4632%'",
+      "SELECT * FROM pge_sites WHERE source LIKE '%pge:4632%'"
+      " AND COALESCE(site_type, 'launch') = 'launch'",
     )).single;
     expect(borah['latitude'] as double, closeTo(-30.68, 0.05));
     expect(borah['longitude'] as double, closeTo(150.61, 0.05));
@@ -104,7 +107,11 @@ void main() {
       // `ansg:` since the producer emits the guide's own acronym natively. This
       // read the old prefix while the rewrite existed to translate it; with the
       // rewrite gone, the asset and this query have to agree.
-      "SELECT * FROM pge_sites WHERE source LIKE 'ansg:%' AND source NOT LIKE '%pge:%'",
+      // Launches only. The catalogue now carries landings too, and a landing
+      // has no wind by design - counted here they dragged this ratio from 90%
+      // to 61% and failed a test that was measuring the prose parser.
+      "SELECT * FROM pge_sites WHERE source LIKE 'ansg:%' AND source NOT LIKE '%pge:%'"
+      " AND COALESCE(site_type, 'launch') = 'launch'",
     );
 
     expect(guideOnly.length, greaterThan(50));

--- a/the_paragliding_app/test/landing_join_test.dart
+++ b/the_paragliding_app/test/landing_join_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:the_paragliding_app/data/datasources/database_helper.dart';
+import 'package:the_paragliding_app/data/models/paragliding_site.dart';
+import 'package:the_paragliding_app/services/pge_sites_database_service.dart';
+
+import 'helpers/test_helpers.dart';
+
+/// A landing is tied to its launch by the group the guides publish, never by
+/// distance.
+///
+/// Measured over DHV's export the median gap from a landing to its own takeoff
+/// is 1,672m and only 9% fall within 250m, so proximity would attach almost
+/// none of them - and would attach the wrong ones, since a neighbouring hill's
+/// field is often nearer than your own.
+void main() {
+  setUpAll(() async {
+    await TestHelpers.initializeDatabaseForTesting();
+  });
+
+  setUp(() async {
+    await DatabaseHelper.instance.close();
+    await DatabaseHelper.instance.database;
+    await PgeSitesDatabaseService.instance.initializeTables();
+  });
+
+  tearDown(() async => DatabaseHelper.instance.close());
+
+  Future<void> insert({
+    required String ref,
+    required String name,
+    required String type,
+    required String group,
+    double lat = 47.46,
+    double lon = 12.20,
+  }) async {
+    final db = await DatabaseHelper.instance.database;
+    await db.insert('pge_sites', {
+      'ref': ref, 'name': name, 'latitude': lat, 'longitude': lon,
+      'country': 'at', 'site_type': type, 'site_group': group,
+    });
+  }
+
+  ParaglidingSite launch(String group, {double lat = 47.46}) => ParaglidingSite(
+        name: 'A launch', latitude: lat, longitude: 12.20,
+        siteType: 'launch', siteGroup: group,
+      );
+
+  test('a launch finds the landings sharing its group', () async {
+    await insert(ref: 'dhv:1-lz', name: 'Landeplatz 1', type: 'landing',
+        group: 'dhv:1', lat: 47.50);
+    await insert(ref: 'dhv:2-lz', name: 'Another hill Landeplatz',
+        type: 'landing', group: 'dhv:2', lat: 47.47);
+
+    final landings = await PgeSitesDatabaseService.instance
+        .getLandingsForSite(launch('dhv:1'));
+
+    // The one 4km away belongs to this launch; the one 1km away does not.
+    expect(landings.map((l) => l.name), ['Landeplatz 1']);
+  });
+
+  test('a landing serving several launches is found from each', () async {
+    // 28.5% of DHV landings sit under a Gelände with more than one launch, and
+    // PGE republishes one field on every takeoff it serves.
+    await insert(ref: 'pge:9-lz', name: 'Shared field', type: 'landing',
+        group: 'dhv:266;pge:22752');
+
+    for (final group in ['dhv:266', 'pge:22752']) {
+      final landings = await PgeSitesDatabaseService.instance
+          .getLandingsForSite(launch(group));
+      expect(landings.map((l) => l.name), ['Shared field'], reason: group);
+    }
+  });
+
+  test('a token is not matched by a longer one it prefixes', () async {
+    // `pge:463` must not find a landing grouped under `pge:4632`.
+    await insert(ref: 'pge:4632-lz', name: 'Not mine', type: 'landing',
+        group: 'pge:4632');
+
+    final landings = await PgeSitesDatabaseService.instance
+        .getLandingsForSite(launch('pge:463'));
+
+    expect(landings, isEmpty);
+  });
+
+  test('a launch with no group has no landings', () async {
+    await insert(ref: 'dhv:1-lz', name: 'Landeplatz', type: 'landing',
+        group: 'dhv:1');
+
+    expect(
+      await PgeSitesDatabaseService.instance.getLandingsForSite(launch('')),
+      isEmpty,
+    );
+  });
+
+  test('only landings are returned, never another launch', () async {
+    await insert(ref: 'dhv:1-a', name: 'Sibling launch', type: 'launch',
+        group: 'dhv:1');
+    await insert(ref: 'dhv:1-lz', name: 'Landeplatz', type: 'landing',
+        group: 'dhv:1');
+
+    final landings = await PgeSitesDatabaseService.instance
+        .getLandingsForSite(launch('dhv:1'));
+
+    expect(landings.map((l) => l.name), ['Landeplatz']);
+  });
+}


### PR DESCRIPTION
Stacked on `site-type-safety` (#355), which must merge first — this is the UI half; that one is the safety half. Consumes `paragliding_site_federation#11`, which carries 5,882 landings against 12,879 launches.

Landing information previously came from one live ParaglidingEarth lookup when a site was opened: absent offline, and absent entirely for the DHV-only and ANSG-only launches that are a third of the German catalogue.

## Three things, in the order a pilot meets them

**On the map** — a landing is a slate flag, not a coloured pin. Colour already carries flyability (green/orange/red/blue answer "can I fly here today") and a landing has no wind directions to answer it with, so it is told apart by shape and its colour says nothing. `forFlyability` returns *before* the flyability switch: left to fall through a landing would be blue at best, and green if a guide ever attached wind to one — which reads as "you can take off here".

**On a launch's page** — a Landing section, with each landing's altitude, distance and a map link. Works offline and for launches PGE has never described. It replaces the live block rather than sitting beside it, so one field is never listed twice at two different altitudes.

**Tapping a landing** — a compact page: name, altitude, position, and what the guide says. No forecast tab, no wind rose, no flyability verdict; with no Startrichtung behind them they would read as "we checked and it is unflyable" rather than "this question does not apply".

## The join is the group, never distance

Measured over DHV: the median gap from a landing to its own launch is **1,672 m**, and only **9%** fall within 250 m. Proximity would attach almost none of them and would prefer a neighbouring hill's field to your own.

Tokens intersect rather than match, because one landing commonly serves several launches (28.5% of DHV's) and one launch can have several. Verified in the running app: `Hohe Salve Startplatz 2` lists two landings, 4.0 km away and 1.1 km below.

## Two latent breaks, found rather than waited for

Two tests were asserting properties of a launch-only catalogue and would have broken the first time the bundled asset was regenerated. Running them against the real landing catalogue surfaced both now:

- `LIKE '%pge:4632%'` matches the landing `pge:4632-lz` as happily as the launch, so `.single` threw.
- The Site Guide wind-coverage ratio fell from 90% to 61% once rows that have no wind *by design* were counted in it.

Both now say launches, which is what they always meant. Verified green against both the shipped asset and the landing catalogue.

## Verification

311 tests, analyzer clean. Driven in the running app on Linux with the real catalogue imported (`rows_inserted=7072, rows_deleted=1, site_links_dangling=0`): landings draw as flags, a DHV-only launch lists its two landings, and the landing page shows no forecast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)