### PR TITLE
Show the rules a landing comes with

### DIFF
--- a/the_paragliding_app/lib/presentation/screens/site_details_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/site_details_screen.dart
@@ -377,10 +377,29 @@ class SiteDetailsScreenState extends State<SiteDetailsScreen> with SingleTickerP
                         fontWeight: FontWeight.w500,
                       ),
                 ),
-                Text(
-                  landing.name,
-                  style: Theme.of(context).textTheme.bodySmall,
+                // Tappable, because the rules live on the landing's own page
+                // and a name alone does not say there is more to read.
+                InkWell(
+                  onTap: () => Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (context) => SiteDetailsScreen(
+                        site: null,
+                        paraglidingSite: landing,
+                        maxWindSpeed: widget.maxWindSpeed,
+                        cautionWindSpeed: widget.cautionWindSpeed,
+                      ),
+                    ),
+                  ),
+                  child: Text(
+                    landing.name,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Colors.blue,
+                          decoration: TextDecoration.underline,
+                        ),
+                  ),
                 ),
+                if ((landing.description ?? '').isNotEmpty)
+                  const Icon(Icons.notes, size: 14, color: Colors.blue),
                 if (landing.altitude != null)
                   _iconFact(
                     Icons.terrain,
@@ -1094,6 +1113,18 @@ class SiteDetailsScreenState extends State<SiteDetailsScreen> with SingleTickerP
                 ),
               ],
             ),
+
+            // What the guide says about this landing. Shown in the header
+            // rather than behind a tab: it is the reason the page exists, and
+            // "only land on the leased paddock" is not something to make a
+            // pilot go looking for.
+            if (_isLanding && (_effectiveSite?.description ?? '').isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Text(
+                _effectiveSite!.description ?? '',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
 
             // Landing information, from the catalogue.
             //

--- a/the_paragliding_app/lib/services/pge_sites_database_service.dart
+++ b/the_paragliding_app/lib/services/pge_sites_database_service.dart
@@ -206,6 +206,10 @@ class PgeSitesDatabaseService {
       //
       // Named site_group because `group` is a SQL keyword.
       await _addColumnIfMissing(db, _pgeSitesTable, 'site_group', 'TEXT');
+      // What a guide says about a landing, verbatim - the rules a visiting
+      // pilot cannot infer. Populated for landings only; a launch's prose is
+      // long and is still looked up live when the site is opened.
+      await _addColumnIfMissing(db, _pgeSitesTable, 'notes', 'TEXT');
 
       // The catalogue's real key: the contributing guide's own identifier, e.g.
       // 'pge:4632'. See [CatalogRef]. The integer `id` column is retained only
@@ -544,8 +548,8 @@ class PgeSitesDatabaseService {
             INSERT INTO $_pgeSitesTable
               (ref, provider, name, longitude, latitude, altitude, country,
                wind_n, wind_ne, wind_e, wind_se, wind_s, wind_sw, wind_w, wind_nw,
-               source, closed, site_type, tow, site_group)
-            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+               source, closed, site_type, tow, site_group, notes)
+            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
             ON CONFLICT(ref) DO UPDATE SET
               provider = excluded.provider,
               name = excluded.name,
@@ -561,7 +565,8 @@ class PgeSitesDatabaseService {
               closed = excluded.closed,
               site_type = excluded.site_type,
               tow = excluded.tow,
-              site_group = excluded.site_group
+              site_group = excluded.site_group,
+              notes = excluded.notes
           ''', [
             ref,
             CatalogRef.providerOf(ref),
@@ -583,6 +588,7 @@ class PgeSitesDatabaseService {
             siteData['site_type'],
             siteData['tow'] ?? 0,
             siteData['site_group'],
+            siteData['notes'],
           ]);
         }
         await batch.commit(noResult: true);
@@ -1017,7 +1023,9 @@ class PgeSitesDatabaseService {
       latitude: (row['latitude'] as num?)?.toDouble() ?? 0.0,
       longitude: (row['longitude'] as num?)?.toDouble() ?? 0.0,
       altitude: row['altitude'] as int?,  // Now stored in database
-      description: '', // Not available from PGE API
+      // What the guide says about this place. Populated for landings; a
+      // launch's prose still comes from the live lookup when one is opened.
+      description: row['notes'] as String? ?? '',
       windDirections: windDirections,
       // Null on rows imported before the producer emitted the column, and
       // those are launches - the catalogue held nothing else.

--- a/the_paragliding_app/lib/services/pge_sites_download_service.dart
+++ b/the_paragliding_app/lib/services/pge_sites_download_service.dart
@@ -690,6 +690,8 @@ class PgeSitesDownloadService {
           // Which site this row belongs to, as `provider:parentId` tokens in
           // the same form as `source`. A landing shares one with its launch.
           'site_group': optional('site_group'),
+          // What a guide says about a landing, verbatim.
+          'notes': optional('notes'),
         });
       } catch (e) {
         skipped++;

--- a/the_paragliding_app/test/site_details_layout_test.dart
+++ b/the_paragliding_app/test/site_details_layout_test.dart
@@ -158,4 +158,36 @@ void main() {
     expect(find.text('847 m AMSL'), findsOneWidget);
     expect(find.byTooltip('Altitude above mean sea level'), findsOneWidget);
   });
+
+  group('a landing', () {
+    final landing = ParaglidingSite(
+      name: 'Rofan Feldererfeld Landeplatz',
+      latitude: 47.423078,
+      longitude: 11.74615,
+      siteType: 'landing',
+      altitude: 560,
+      source: 'dhv:1234-rofan-feldererfeld-landeplatz',
+      description:
+          'LZ at the lake is reserved for SIV seminars! Use only official LZ.',
+    );
+
+    testWidgets('shows what the guide says about it', (tester) async {
+      // The reason the page exists. A landing point answers "where"; this
+      // answers "and what am I allowed to do there", which a visiting pilot
+      // cannot infer and which keeps them out of trouble with a landowner.
+      await pumpPage(tester, which: landing);
+
+      expect(find.textContaining('reserved for SIV seminars'), findsOneWidget);
+    });
+
+    testWidgets('offers no forecast, because it has no wind', (tester) async {
+      // Shown anyway, a forecast built from no wind directions does not read
+      // as "this question does not apply" - it reads as "we checked, and it
+      // is unflyable".
+      await pumpPage(tester, which: landing);
+
+      expect(find.text('Forecast'), findsNothing);
+    });
+  });
 }
+


### PR DESCRIPTION
Consumes `paragliding_site_federation#12`, which carries landing text for 2,892 of 5,882 landings.

A landing point answers "where". It does not answer "and what am I allowed to do there" — the part a visiting pilot cannot infer, and the part that keeps them out of trouble with a landowner: *"LZ at the lake is reserved for SIV seminars"*, *"only land on SAHPGA Inc leased land"*.

## What changes

- Notes land in `description`, which the model already had and which was empty for every catalogue row. A launch's prose is long and still comes from the live lookup, so nothing changes there.
- Shown in the landing's **header**, not behind a guide tab. It is the reason the page exists, and a rule a pilot has to go looking for is a rule they will not read.
- A launch's Landing rows are now **tappable through** to that page, with a small notes icon where there is something to read. That closes the loop the map opened: find the hill, see where you are expected to land, read what the guide says — offline, and for guides that could not answer at all before.

## One rough edge, deliberately left

Notes render as plain text. 2,646 of the 2,892 come from ParaglidingEarth and are prose, but Site Guide's carry markdown, which will show its markup until something renders it. Visible and unpolished, and better than silently dropping the words. Nothing in `lib/` renders markdown today, so adding it is its own change.

## Verification

313 tests, analyzer clean. Both new widget tests were seen red without the rendering. Driven in the running app with the real catalogue: 2,892 landings hold notes, and the landing page shows the guide's text with no forecast tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)