### PR TITLE
Run the live-service tests on a schedule, since nothing else does

### DIFF
--- a/.github/workflows/network.yml
+++ b/.github/workflows/network.yml
@@ -1,0 +1,114 @@
+name: Live services
+
+# The tests that call a live third-party service, on a schedule.
+#
+# They are tagged `network` and skipped by default (see dart_test.yaml), so
+# `flutter test` in ci.yml never runs them - deliberately, because a stalled
+# network test holds a concurrency slot long enough to push unrelated files past
+# the 30s timeout, and a PR should not go red because someone else's server is
+# down.
+#
+# The cost of that is a set of guards nothing fires. They are the only checks on
+# things that change without anyone here touching the repository:
+#
+#   * the bundled catalogue drifting behind what the producer publishes - it sat
+#     at 11,690 rows against 18,761 for long enough to lose every DHV launch and
+#     every landing, and the test that should have caught it stayed green;
+#   * the OpenAIP export bucket being locked down again, as it was in July 2026;
+#   * the published catalogue changing a launch's name, altitude, wind or which
+#     guide it is named by, under a baseline that pins all four.
+#
+# None of those is a pull request. A schedule is what notices them.
+#
+# Separate from ci.yml on purpose. A failure here means the world moved, not that
+# the branch is broken, and adding a `schedule` trigger to ci.yml would re-run the
+# whole analyze-and-test job weekly to reach four tests.
+
+# Actions are pinned to commit SHAs, with the release they came from in a trailing
+# comment. See the note at the top of build.yml for why.
+
+on:
+  schedule:
+    # Tuesday, a day after the producer's own weekly run (Monday 02:00 UTC in
+    # paragliding_site_federation/.github/workflows/sync.yml), which opens a pull
+    # request a human then merges. A day's margin usually covers that; when it
+    # does not, the drift is caught the following week, which is soon enough for
+    # a file that only needs to be current at release time.
+    #
+    # 04:23 rather than the top of an hour: GitHub queues scheduled jobs and
+    # drops the ones it cannot run, and round times on the hour are the most
+    # contended.
+    - cron: "23 4 * * 2"
+  # So it can be run on demand - before cutting a release, or to prove it still
+  # works. A scheduled job nobody has ever watched run is the thing this
+  # workflow exists to argue against.
+  workflow_dispatch: {}
+
+# Superseded runs have nothing left to prove.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+# Declared rather than inherited, so a job gaining write access has to be a
+# visible edit here. Nothing in this workflow writes to the repository.
+permissions:
+  contents: read
+
+env:
+  FLUTTER_VERSION: "3.41.6"
+
+jobs:
+  live-services:
+    name: Test against live services
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: the_paragliding_app
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Get dependencies
+        run: flutter pub get
+
+      - name: Test against live services
+        # No secrets. Every service these reach is public - the OpenAIP export
+        # bucket, the published catalogue on raw.githubusercontent.com - so this
+        # needs no env.json and would not benefit from one.
+        #
+        # The "No tests ran" check is not belt and braces. `flutter test` exits
+        # **0** when a tag selector matches nothing, printing only "No tests
+        # ran.", so if the `network` tag were renamed or dropped this workflow
+        # would go on reporting success weekly while testing nothing at all -
+        # which is the same shape of failure it was added to catch.
+        run: |
+          set -o pipefail
+          flutter test --concurrency=1 --tags network --run-skipped 2>&1 \
+            | tee live-services.log
+          if grep -q "No tests ran" live-services.log; then
+            echo "::error::No network-tagged tests ran. The tag has been renamed or dropped - this job has been testing nothing."
+            exit 1
+          fi
+
+      # A failure above is one of two things and they are not equally urgent, so
+      # the log is kept rather than left to scrollback.
+      #
+      #   * an assertion failed - something upstream moved, and the message says
+      #     what and names the tool that fixes it;
+      #   * a request timed out or returned 5xx - a service is down. Re-run it.
+      - name: Keep the log
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: live-services-log
+          path: the_paragliding_app/live-services.log
+          retention-days: 30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,15 @@ flutter test --tags network --run-skipped  # Live-API tests, skipped by default
 kill "$(cat dev_data/flutter.pid)"    # Stop a running app
 ```
 
+**The `network` tests run weekly in CI**, on their own schedule
+(`.github/workflows/network.yml`, Tuesdays), not on pushes or pull requests. They are the
+only checks on things that move without anyone touching this repository - the bundled
+catalogue falling behind what the producer publishes, the OpenAIP export bucket being locked
+down, a launch changing its name, altitude, wind or guide under the baseline that pins them.
+A red run there means the world moved, not that your branch is broken; the log is kept as an
+artifact, and a timeout or 5xx just wants re-running. Run it on demand from the Actions tab
+before cutting a release.
+
 **Plain `flutter test` is fine locally.** It used to fail about 1 run in 3, so this file
 told you to always pass `--concurrency=1`. Issue #280 fixed the underlying test problems;
 measured over 16 consecutive runs on an 8-core dev box, parallel is now 0/16 failures and


### PR DESCRIPTION

The `network` tests are skipped by default and CI runs plain `flutter test`, so
nothing has ever run them but a person deciding to. That is fine for the ones
that merely confirm a URL still works, and not fine for the rest: they are the
only checks on things that move without anyone touching this repository.

The bundled catalogue is the case in point. It drifted to 11,690 rows against
18,761 published - losing every DHV launch and every landing - and the guard
added for exactly that is `network`-tagged, so it would have gone on not
running. A guard nobody fires is a guard.

Weekly, Tuesdays, a day after the producer's own Monday run so the published
catalogue has usually been reviewed and merged by then. Separate from ci.yml
because a failure here means the world moved rather than the branch being
broken, and because putting a schedule on ci.yml would re-run the whole
analyze-and-test job to reach thirteen tests. On demand too, which is how to use
it before cutting a release.

It also checks that it ran anything. `flutter test` exits **0** when a tag
selector matches nothing, printing only "No tests ran." - so had the tag ever
been renamed this workflow would have reported success weekly while testing
nothing, which is the same shape of failure it was added to catch. Both branches
were driven before committing: thirteen tests pass in 3m19s, and a deliberately
wrong tag trips the check.

No secrets. Every service reached is public, so this needs no env.json.

## Verification

Both branches of the job were driven locally before committing:

| | result |
|---|---|
| `flutter test --concurrency=1 --tags network --run-skipped` | 13 tests pass, 3m19s |
| same with a deliberately wrong tag | `No tests ran.` → guard prints `::error::` and exits 1 |

The workflow YAML was parsed rather than eyeballed (triggers, cron, permissions, working-directory, all five steps), and the `upload-artifact` pin is the SHA this repo already uses in `build.yml` — my first attempt used one from memory, which was wrong.

**Not yet verified:** GitHub itself has not run it. `workflow_dispatch` only works once the file is on the default branch, so the first real run has to be after merge — happy to trigger and watch it then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)