### PR TITLE
Say that the worktree tooling asks the same question `git branch -d` does

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -790,6 +790,25 @@ the branch's own commits are never ancestors of `main` and `git branch -d` refus
 "not fully merged" - which is true of the commits and false of the content. Confirm the
 content landed by checking the PR is `MERGED`, not by whether `-d` is willing.
 
+**The EnterWorktree/ExitWorktree tooling asks that same question**, and refuses to remove a
+merged worktree - "Removing will discard this work permanently" - until told
+`discard_changes: true`. It is the same false negative rather than a second problem; it
+fired on 2026-08-15 for the already-merged `network.yml` branch. Answer it the same way, and
+prove the content landed by comparing trees instead of trusting either tool:
+
+```bash
+gh pr view <n> --json state                       # MERGED is the authority
+git diff --stat <branch> origin/main -- <paths>   # empty output means nothing is lost
+```
+
+Changing merge strategy does not avoid this, and **rebase merge especially does not** -
+GitHub re-parents each commit onto `main`, so the SHAs change and ancestry breaks exactly as
+it does under squash. Only a real merge commit preserves it, at the cost of the squash body,
+which is where the PR description on most of these commits comes from. Running
+`git reset --hard origin/main` in the worktree first silences both prompts, but it discards
+the local commit for real - on a branch that did *not* merge that destroys the work, which
+is precisely the case the prompt exists to catch. Confirm the prompt instead.
+
 ### Standard Development Process
 
 1. **Start**: `bin/dev_run.sh --background` (add `-d "<device>"` for a phone)


### PR DESCRIPTION
The Worktrees section already explains why `git branch -d` refuses a squash-merged
branch, and says to trust the PR state rather than the refusal. This extends that to
the worktree tooling, which asks the same ancestry question and phrases the answer far
more alarmingly: `ExitWorktree` will not remove a merged worktree without
`discard_changes: true`, warning that the work will be "discarded permanently".

That happened on 2026-08-15 with the `network.yml` branch, an hour after it merged as
`cb5957c`. The commit really was absent from `main` — squashing had rewritten it — and
the content really was already there. Nothing was lost, but the prompt cannot tell you
that, and this is the one moment where getting it wrong is unrecoverable.

So the note records how to settle the question, using the two checks that were actually
run before deleting that branch: `gh pr view <n> --json state`, and a tree diff against
`origin/main` restricted to the touched paths, which came back empty.

It also closes off the two fixes that look right and are not:

- **Rebase merge does not preserve ancestry.** GitHub re-parents each commit onto `main`,
  so the SHAs change and the branch's own commits are no more ancestors than under
  squash. Only a real merge commit avoids it, and that costs the squash body — which on
  this repo is where most of the commit message comes from.
- **`git reset --hard origin/main` in the worktree silences both prompts**, and destroys
  the work outright on a branch that did *not* merge. That is precisely the case the
  prompt exists to catch, so the note recommends confirming the prompt rather than
  removing it.

Documentation only — no code, no test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
