### PR TITLE
Say what a landing is for, not just that something is there

### DIFF
--- a/the_paragliding_app/lib/presentation/screens/edit_site_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/edit_site_screen.dart
@@ -537,9 +537,15 @@ class _EditSiteScreenState extends State<EditSiteScreen> {
         ),
         const SizedBox(height: 4),
       ],
-      SiteMarkerUtils.buildLegendItem(context, Icons.location_on, SiteMarkerUtils.flownSiteColor, 'Flown Sites'),
+      SiteMarkerUtils.buildLegendItem(context, null, SiteMarkerUtils.flownSiteColor, 'Flown Sites',
+          swatch: SiteMarkerUtils.siteSymbol('launch',
+              color: SiteMarkerUtils.flownSiteColor,
+              size: SiteMarkerUtils.legendSymbolSize)),
       const SizedBox(height: 4),
-      SiteMarkerUtils.buildLegendItem(context, Icons.location_on, SiteMarkerUtils.newSiteColor, 'New Sites'),
+      SiteMarkerUtils.buildLegendItem(context, null, SiteMarkerUtils.newSiteColor, 'New Sites',
+          swatch: SiteMarkerUtils.siteSymbol('launch',
+              color: SiteMarkerUtils.newSiteColor,
+              size: SiteMarkerUtils.legendSymbolSize)),
     ];
     
     return Positioned(

--- a/the_paragliding_app/lib/presentation/widgets/nearby_sites_map.dart
+++ b/the_paragliding_app/lib/presentation/widgets/nearby_sites_map.dart
@@ -467,42 +467,57 @@ class _NearbySitesMapState extends BaseMapState<NearbySitesMap> {
       const SizedBox(height: 4),
       SiteMarkerUtils.buildLegendItem(
         context,
-        Icons.location_on,
+        null,
         SiteMarkerUtils.flyableSiteColor,
         'Flyable',
+        swatch: SiteMarkerUtils.siteSymbol('launch',
+            color: SiteMarkerUtils.flyableSiteColor,
+            size: SiteMarkerUtils.legendSymbolSize),
       ),
       const SizedBox(height: 4),
       SiteMarkerUtils.buildLegendItem(
         context,
-        Icons.location_on,
+        null,
         SiteMarkerUtils.strongWindSiteColor,
         'Strong',
+        swatch: SiteMarkerUtils.siteSymbol('launch',
+            color: SiteMarkerUtils.strongWindSiteColor,
+            size: SiteMarkerUtils.legendSymbolSize),
       ),
       const SizedBox(height: 4),
       SiteMarkerUtils.buildLegendItem(
         context,
-        Icons.location_on,
+        null,
         SiteMarkerUtils.notFlyableSiteColor,
         'Not Flyable',
+        swatch: SiteMarkerUtils.siteSymbol('launch',
+            color: SiteMarkerUtils.notFlyableSiteColor,
+            size: SiteMarkerUtils.legendSymbolSize),
       ),
       const SizedBox(height: 4),
       SiteMarkerUtils.buildLegendItem(
         context,
-        Icons.location_on,
+        null,
         SiteMarkerUtils.unknownFlyabilitySiteColor,
         'Unknown',
+        swatch: SiteMarkerUtils.siteSymbol('launch',
+            color: SiteMarkerUtils.unknownFlyabilitySiteColor,
+            size: SiteMarkerUtils.legendSymbolSize),
       ),
       const SizedBox(height: 4),
-      // Last, and with a different icon: the four above are one scale - can I
-      // fly here now - and a landing is not a point on it.
+      // Last, and with a different symbol: the four above are one scale - can
+      // I fly here now - and a landing is not a point on it.
       //
-      // Glyph taken from markerShapeFor rather than named here, so the legend
-      // cannot end up describing a marker the map no longer draws.
+      // Symbol from siteSymbol rather than named here, so the legend cannot
+      // end up describing a marker the map no longer draws.
       SiteMarkerUtils.buildLegendItem(
         context,
-        SiteMarkerUtils.markerShapeFor('landing').glyph,
+        null,
         SiteMarkerUtils.landingSiteColor,
         'Landing',
+        swatch: SiteMarkerUtils.siteSymbol('landing',
+            color: SiteMarkerUtils.landingSiteColor,
+            size: SiteMarkerUtils.legendSymbolSize),
       ),
     ];
   }

--- a/the_paragliding_app/lib/presentation/widgets/windsock_marker.dart
+++ b/the_paragliding_app/lib/presentation/widgets/windsock_marker.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+
+/// A windsock, drawn for catalogue landing sites.
+///
+/// Painted rather than set from the icon font because Material has no windsock:
+/// `Icons.wind_power` is a turbine and `Icons.air` is three motion lines. Both
+/// name the wind; neither names a place to land.
+///
+/// The palette is fixed - orange and white bands on a slate mast, the real
+/// windsock livery - so there is deliberately no `color` parameter. A landing
+/// has no wind directions to be graded against, which is why the flag it
+/// replaces was slate rather than a colour from the flyability scale, and the
+/// same reasoning applies here: the symbol says what the place is, not whether
+/// you can fly today.
+class WindsockMarker extends StatelessWidget {
+  /// The box the sock is drawn in. Defaults to the landing marker size, which
+  /// is two thirds of a launch pin - a landing is supporting information.
+  final double size;
+
+  static const double markerSize = 28.0;
+
+  const WindsockMarker({super.key, this.size = markerSize});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: size,
+      height: size,
+      child: CustomPaint(painter: const _WindsockPainter()),
+    );
+  }
+}
+
+/// Draws the windsock on Material's 24x24 icon grid, scaled to fit.
+///
+/// Working on the same grid as the stock glyphs is what lets the sock sit
+/// beside a `location_on` pin without looking like it came from somewhere else.
+class _WindsockPainter extends CustomPainter {
+  const _WindsockPainter();
+
+  // Blue Grey 400 - the colour the landing flag used, kept for the mast so the
+  // marker still reads as the same family of thing on the map.
+  static const Color _mast = Color(0xFF78909C);
+  static const Color _band = Color(0xFFF4511E); // Deep Orange 600
+  static const Color _outline = Color(0xFF546E7A); // Blue Grey 600
+
+  /// The four bands, wide mouth to narrow tip.
+  ///
+  /// Listed as corner quads rather than computed from a taper, because the
+  /// numbers came off a drawing and reproducing them exactly matters more than
+  /// showing the arithmetic.
+  static const List<List<Offset>> _bands = [
+    [Offset(5, 5), Offset(9, 5.875), Offset(9, 12.625), Offset(5, 13)],
+    [Offset(9, 5.875), Offset(13, 6.75), Offset(13, 12.25), Offset(9, 12.625)],
+    [Offset(13, 6.75), Offset(17, 7.625), Offset(17, 11.875), Offset(13, 12.25)],
+    [Offset(17, 7.625), Offset(21, 8.5), Offset(21, 11.5), Offset(17, 11.875)],
+  ];
+
+  /// The three lines between the bands, so the outline can draw them.
+  static const List<List<Offset>> _dividers = [
+    [Offset(9, 5.875), Offset(9, 12.625)],
+    [Offset(13, 6.75), Offset(13, 12.25)],
+    [Offset(17, 7.625), Offset(17, 11.875)],
+  ];
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final scale = size.width / 24.0;
+    Offset p(Offset o) => Offset(o.dx * scale, o.dy * scale);
+
+    final mastRect = Rect.fromLTWH(3.2 * scale, 3 * scale, 1.8 * scale, 18 * scale);
+    final hoopRect = Rect.fromLTWH(5 * scale, 4.4 * scale, 1.4 * scale, 9.2 * scale);
+
+    final sock = Path()
+      ..moveTo(5 * scale, 5 * scale)
+      ..lineTo(21 * scale, 8.5 * scale)
+      ..lineTo(21 * scale, 11.5 * scale)
+      ..lineTo(5 * scale, 13 * scale)
+      ..close();
+
+    // A white keyline under everything else. Dropping it was tried on screen:
+    // over Esri satellite imagery of dry paddock the slate mast and the slate
+    // outline both fall to about the same value as the ground, and the sock
+    // goes from a marker you can pick out to a smudge you have to look for.
+    // This is the job the flag's white halo did, in one paint pass rather than
+    // a second larger copy of the whole marker stacked underneath.
+    final keyline = Paint()
+      ..color = Colors.white
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2.2 * scale
+      ..strokeJoin = StrokeJoin.round;
+    canvas.drawRect(mastRect, keyline);
+    canvas.drawPath(sock, keyline);
+
+    canvas.drawRect(mastRect, Paint()..color = _mast);
+    canvas.drawRect(hoopRect, Paint()..color = _band);
+
+    // Alternating orange and white, starting orange at the mouth.
+    for (var i = 0; i < _bands.length; i++) {
+      final corners = _bands[i];
+      final path = Path()..moveTo(p(corners[0]).dx, p(corners[0]).dy);
+      for (final corner in corners.skip(1)) {
+        path.lineTo(p(corner).dx, p(corner).dy);
+      }
+      path.close();
+      canvas.drawPath(path, Paint()..color = i.isEven ? _band : Colors.white);
+    }
+
+    // The outline is the sock's only edge, and it is load-bearing rather than
+    // decoration: without it the two white bands bleed into any pale ground -
+    // dry paddock, snow, the Street Map's paper - and what is left reads as two
+    // orange chunks adrift of a mast.
+    final stroke = Paint()
+      ..color = _outline
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 0.9 * scale
+      ..strokeJoin = StrokeJoin.round;
+    canvas.drawPath(sock, stroke);
+    for (final divider in _dividers) {
+      canvas.drawLine(p(divider[0]), p(divider[1]), stroke);
+    }
+
+  }
+
+  @override
+  bool shouldRepaint(_WindsockPainter oldDelegate) => false;
+}

--- a/the_paragliding_app/lib/utils/site_marker_utils.dart
+++ b/the_paragliding_app/lib/utils/site_marker_utils.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
+import '../presentation/widgets/windsock_marker.dart';
 import '../services/airspace_geojson_service.dart';
 
 /// Shared utilities for creating consistent site markers across different map views
@@ -18,7 +19,10 @@ class SiteMarkerUtils {
   // size, and the muted slate below, is enough to say "supporting information"
   // without making it hard to find when you are looking for one.
   static const double landingMarkerSize = 28.0;
-  static const double landingMarkerIconSize = 22.0;
+
+  // A legend row's symbol, small enough to sit on a text line. The same
+  // symbols the map draws, only smaller - see siteSymbol.
+  static const double legendSymbolSize = 18.0;
   
   // Site status colors (for other screens)
   static const Color flownSiteColor = Color(0xFF0047AB);     // Sites with logged flights (cobalt blue)
@@ -58,29 +62,46 @@ class SiteMarkerUtils {
   // Static methods for commonly used non-const objects
   static Border get _whiteCircleBorder => Border.all(color: Colors.white, width: 2);
   
-  /// How a site type is drawn: glyph, and the two sizes of the stacked pair.
+  /// The symbol a site type is drawn with, at whatever size is asked for.
   ///
-  /// One answer in one place. The glyph, the sizes and the colour used to be
-  /// spread over two icon builders, an `if` at the map's call site, and a
-  /// hand-written legend row that repeated all three a third time - so
-  /// "landings are flags" was stated four times and could have been changed in
+  /// One answer in one place, for the map and its legend alike - they differ
+  /// only in size. The symbol used to be stated separately by two icon
+  /// builders, an `if` at the map's call site, and a hand-written legend row,
+  /// so "landings are flags" was said four times and could have been changed in
   /// three of them without the fourth noticing.
   ///
-  /// A landing is smaller because it is supporting information: you choose a
-  /// launch, and its landing follows from that choice.
-  static ({IconData glyph, double size, double iconSize}) markerShapeFor(
-      String? siteType) {
-    return siteType == 'landing'
-        ? (
-            glyph: Icons.flag,
-            size: landingMarkerSize,
-            iconSize: landingMarkerIconSize
-          )
-        : (
-            glyph: Icons.location_on,
-            size: siteMarkerSize,
-            iconSize: siteMarkerIconSize
-          );
+  /// Returning the widget rather than a glyph is what lets the two site types
+  /// be drawn differently - a launch is a character from the icon font, a
+  /// landing is painted, because Material has no windsock - without any caller
+  /// having to know which it got.
+  ///
+  /// A landing is drawn smaller because it is supporting information: you
+  /// choose a launch, and its landing follows from that choice.
+  static Widget siteSymbol(
+    String? siteType, {
+    required Color color,
+    double? size,
+  }) {
+    if (siteType == 'landing') {
+      // The windsock carries its own palette - a landing has no wind
+      // directions to be graded against - so [color] is deliberately unused.
+      return WindsockMarker(size: size ?? landingMarkerSize);
+    }
+
+    final outer = size ?? siteMarkerSize;
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        // White outline - what keeps the marker legible against terrain, so it
+        // scales with the glyph rather than being fixed.
+        Icon(Icons.location_on, color: Colors.white, size: outer),
+        Icon(
+          Icons.location_on,
+          color: color,
+          size: outer * (siteMarkerIconSize / siteMarkerSize),
+        ),
+      ],
+    );
   }
 
   /// Create a site marker icon with consistent styling.
@@ -96,29 +117,18 @@ class SiteMarkerUtils {
     Color borderColor = Colors.white,
     double borderWidth = 2.0,
   }) {
-    final shape = markerShapeFor(siteType);
+    final outer =
+        siteType == 'landing' ? landingMarkerSize : siteMarkerSize;
 
     return Stack(
       alignment: Alignment.center,
       children: [
-        // White outline - what keeps the marker legible against terrain, so it
-        // scales with the glyph rather than being fixed.
-        Icon(
-          shape.glyph,
-          color: Colors.white,
-          size: shape.size,
-        ),
-        // Colored marker
-        Icon(
-          shape.glyph,
-          color: color,
-          size: shape.iconSize,
-        ),
+        siteSymbol(siteType, color: color),
         // Optional border for special states
         if (showBorder)
           Container(
-            width: shape.size + (borderWidth * 2),
-            height: shape.size + (borderWidth * 2),
+            width: outer + (borderWidth * 2),
+            height: outer + (borderWidth * 2),
             decoration: BoxDecoration(
               shape: BoxShape.circle,
               border: Border.all(color: borderColor, width: borderWidth),
@@ -204,8 +214,8 @@ class SiteMarkerUtils {
   
   // buildLandingSiteMarkerIcon is gone: it was buildSiteMarkerIcon with a
   // different glyph, chosen by an `if` wherever a marker was built. A landing
-  // is still a flag - so it reads as somewhere to put down rather than another
-  // hill to launch from - but that is now one line in markerShapeFor rather
+  // is now a windsock rather than a flag - it says what the place is for, not
+  // just that something is there - and that is one branch in siteSymbol rather
   // than a second builder to keep in step with the first.
 
   /// Create a launch marker with consistent styling
@@ -243,6 +253,12 @@ class SiteMarkerUtils {
   }
   
   /// Create legend items for consistent styling across maps
+  ///
+  /// [swatch] is for rows describing a site marker: pass
+  /// `siteSymbol(type, color: ..., size: ...)` so the legend draws the marker
+  /// by calling the same function the map calls. It used to rebuild a site pin
+  /// here from its own pair of `Icon`s, which is how a legend ends up
+  /// describing a marker the map no longer draws.
   static Widget buildLegendItem(
     BuildContext context,
     IconData? icon,
@@ -251,11 +267,14 @@ class SiteMarkerUtils {
     bool isCircle = false,
     double iconSize = 16,
     double circleSize = launchMarkerSize,
+    Widget? swatch,
   }) {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (isCircle)
+        if (swatch != null)
+          swatch
+        else if (isCircle)
           Container(
             width: circleSize,
             height: circleSize,
@@ -264,15 +283,6 @@ class SiteMarkerUtils {
               shape: BoxShape.circle,
               border: _whiteCircleBorder,
             ),
-          )
-        else if (icon == Icons.location_on)
-          // Site markers need white outline like actual markers
-          Stack(
-            alignment: Alignment.center,
-            children: [
-              Icon(Icons.location_on, color: Colors.white, size: iconSize + 2),
-              Icon(Icons.location_on, color: color, size: iconSize),
-            ],
           )
         else
           Icon(icon!, color: color, size: iconSize),
@@ -391,16 +401,19 @@ class SiteMarkerUtils {
               const SizedBox(height: 4),
             ],
             if (showSites) ...[
-              // Glyphs from markerShapeFor, so a legend cannot describe a
-              // marker the map no longer draws.
-              buildLegendItem(context, markerShapeFor('launch').glyph,
-                  flownSiteColor, 'Flown Sites'),
+              // Symbols from siteSymbol - the same call the map makes - so a
+              // legend cannot describe a marker the map no longer draws.
+              buildLegendItem(context, null, flownSiteColor, 'Flown Sites',
+                  swatch: siteSymbol('launch',
+                      color: flownSiteColor, size: legendSymbolSize)),
               const SizedBox(height: 4),
-              buildLegendItem(context, markerShapeFor('launch').glyph,
-                  newSiteColor, 'New Sites'),
+              buildLegendItem(context, null, newSiteColor, 'New Sites',
+                  swatch: siteSymbol('launch',
+                      color: newSiteColor, size: legendSymbolSize)),
               const SizedBox(height: 4),
-              buildLegendItem(context, markerShapeFor('landing').glyph,
-                  landingSiteColor, 'Landings'),
+              buildLegendItem(context, null, landingSiteColor, 'Landings',
+                  swatch: siteSymbol('landing',
+                      color: landingSiteColor, size: legendSymbolSize)),
             ],
             // Add additional legend items if provided
             if (additionalLegendItems != null && additionalLegendItems.isNotEmpty) ...[

--- a/the_paragliding_app/test/windsock_landing_marker_test.dart
+++ b/the_paragliding_app/test/windsock_landing_marker_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:the_paragliding_app/presentation/widgets/windsock_marker.dart';
+import 'package:the_paragliding_app/utils/site_marker_utils.dart';
+
+/// A landing is drawn as a windsock, and the legend says the same thing.
+///
+/// The map and its legend used to state the landing's symbol separately - the
+/// map through `buildSiteMarkerIcon`, the legend by naming an `IconData` at the
+/// call site - so the legend could go on describing a marker the map no longer
+/// drew. #362 narrowed that to one glyph lookup; this pins the result of
+/// finishing the job, where both now ask `SiteMarkerUtils.siteSymbol` for the
+/// widget itself.
+///
+/// The launch case is here for the same reason: the windsock arrived by
+/// collapsing the legend's hand-built pin stack into the shared function, and
+/// that is exactly the kind of change that silently drops the white outline
+/// keeping a pin legible over satellite imagery.
+///
+/// These need no map, so they skip the hand-pumped frames that
+/// `landing_markers_test.dart` needs for its tile layer.
+void main() {
+  Future<void> pump(WidgetTester tester, Widget child) async {
+    await tester.pumpWidget(
+      MaterialApp(home: Scaffold(body: Center(child: child))),
+    );
+  }
+
+  testWidgets('a landing marker is a windsock, not a flag', (tester) async {
+    await pump(
+      tester,
+      SiteMarkerUtils.buildSiteMarkerIcon(
+        color: SiteMarkerUtils.landingSiteColor,
+        siteType: 'landing',
+      ),
+    );
+
+    expect(find.byType(WindsockMarker), findsOneWidget);
+    expect(find.byIcon(Icons.flag), findsNothing,
+        reason: 'the flag said "a spot", not "land here"');
+  });
+
+  testWidgets('a launch keeps its outlined pin', (tester) async {
+    await pump(
+      tester,
+      SiteMarkerUtils.buildSiteMarkerIcon(
+        color: SiteMarkerUtils.flyableSiteColor,
+        siteType: 'launch',
+      ),
+    );
+
+    expect(find.byType(WindsockMarker), findsNothing);
+    // Two: the white copy underneath is what keeps the pin readable against
+    // terrain, so its absence is a real regression rather than a detail.
+    expect(find.byIcon(Icons.location_on), findsNWidgets(2));
+  });
+
+  testWidgets('the legend shows the marker the map draws', (tester) async {
+    // buildMapLegend returns a Positioned, so it needs a Stack rather than the
+    // Center the marker cases use.
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Stack(
+            children: [
+              Builder(
+                builder: (context) => SiteMarkerUtils.buildMapLegend(
+                  context: context,
+                  showSites: true,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Landings'), findsOneWidget);
+    expect(find.byType(WindsockMarker), findsOneWidget,
+        reason: 'the legend must not go on advertising a flag');
+  });
+}


### PR DESCRIPTION
A landing was a flag — a generic map pin that marks a spot without saying what happens at it, and with no wind cue. It is now a windsock.

## Why it is painted

Material has no windsock: `wind_power` is a turbine, `air` is three motion lines. Both name the wind; neither names a place to land. So `WindsockMarker` is a `CustomPainter` on Material's 24×24 grid, following the `weather_station_marker.dart` pattern, so it sits correctly beside the stock `location_on` pin. No new dependency — there is no SVG pipeline in this app.

Two details are load-bearing, and both were settled by looking at the map rather than by argument:

- **The outline between the bands.** Without it the two white bands bleed into any pale ground, and what is left reads as two orange chunks adrift of a mast.
- **The white keyline under everything.** Dropping it was tried on screen: over Esri satellite imagery of dry paddock the slate mast and the slate outline both fall to about the value of the ground, and the marker goes from something you pick out to a smudge you hunt for. It does the job the flag's white halo did, in one paint pass rather than a second larger copy of the marker stacked underneath.

## One definition instead of two

`markerShapeFor` returned a glyph plus sizes, which cannot describe a painted marker. The obvious repair — a nullable glyph — would have made `null` mean both *"draw a circle"* and *"painted"* inside `buildLegendItem`, which is exactly the drift that method's doc comment exists to prevent.

Instead `siteSymbol` returns the **widget**, and the map and the legend differ only in the size they ask for. That let the legend's own copy of the pin go: it hand-built the white outline stack from a pair of `Icon`s, reached by four rows hardcoding `Icons.location_on`. Those rows now call `siteSymbol` like the map does, so a legend can no longer describe a marker the map does not draw. `landingMarkerIconSize` went with it — it existed only to size the halo pair the windsock does not have.

Net: **102 insertions, 68 deletions** across the three existing files.

## Scope

Only one map draws catalogue landings — `NearbySitesMap` is the sole caller that passes a site type. `EditSiteMap`, the inline map in `edit_site_screen.dart` and `SiteMarkerLayer` never do; the Cesium 3D view renders no site markers at all.

Sizes are unchanged: a landing stays two thirds of a launch, because you choose a launch and its landing follows from that choice. The colour already makes it easier to find than the grey flag was.

Flight-track endpoints keep their red circle — that means "where this flight ended", not "a landing zone".

## Verification

- `flutter analyze` clean; `flutter test` — **368 passed, 21 skipped** (network-tagged), 0 failed.
- **The new test was confirmed red first**, against the flag: two of its three cases failed on an assertion, not a compile error.
- `test/landing_markers_test.dart` finds landings by tooltip rather than by icon, so it pins the clustering decision through this change **untouched**.
- Driven on Linux desktop: both landings near Mt Bakewell, on Esri Satellite and on Street Map, plus the expanded legend — where the Landing row shows the windsock and the four flyability rows above it still show outlined pins, which is the deleted special case proving it was redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

