### PR TITLE
Release 1.0.9+21

### DIFF
--- a/distribution/whatsnew/whatsnew-en-GB
+++ b/distribution/whatsnew/whatsnew-en-GB
@@ -1,7 +1,8 @@
-• Flights now match the nearest launch rather than the first one found, and
-  Data Management can re-run that match across your whole log
-• Site altitudes say they are above sea level, the landing comes from the
-  site you opened, and duplicate markers on the map are gone
-• The site guide updates without an app update, and credits ParaglidingEarth's
-  licence and the Australian National Site Guide
-• Search fields in the top bar are readable again in the light theme
+• Landing areas are proper sites now: see where you are expected to land, how
+  far it is, and the rules that come with it. They are marked with a windsock
+  on the map
+• Site pages open straight away instead of waiting on the network, and links
+  to ParaglidingEarth, DHV and the Australian guide reach the right page
+• Launch altitudes come from one source, so they no longer disagree
+• Removing an airspace country really removes it, and maps start faster
+• Data Management dialogs scroll again

--- a/the_paragliding_app/pubspec.yaml
+++ b/the_paragliding_app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.8+20
+version: 1.0.9+21
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
Version bump and the notes users see. Fifteen commits since `v1.0.8+20`.

## Why 1.0.9 and not 1.0.8

The range is almost entirely user-visible. The commits a pilot cannot observe — worktree lore (#361), sandbox notes (#353), the network tests moving to a schedule (#360), the site-page assertion test (#359), the logcat quietening (#346) — are the minority. Holding the name would repeat the 1.0.2 problem, where builds 5 through 11 all shipped under one version and a months-old build was indistinguishable from a current one.

## The theme is landings

They stopped being an attribute of a launch and became sites in their own right:

- a launch page says where you are expected to land and how far away it is (#356)
- a landing has its own page carrying the rules that come with it (#357)
- the catalogue stopped claiming every row is a launch (#355)
- on the map it is a windsock rather than a flag (#363) — what the place is *for*, not just that something is there

## The rest a pilot will notice

- Site pages draw immediately instead of waiting on a network lookup (#362)
- Guide links reach the right page. PGE and ANSG links were built from the launch id where those guides publish per *site*, so 4,828 of them were wrong, and the PGE landing button vanished entirely rather than linking badly (#362)
- Launch altitudes come from the catalogue rather than whichever guide answered, so they stop disagreeing (#358)
- Removing an airspace country really removes it (#352), and the map no longer spends two seconds discovering an empty cache (#351)
- Data Management dialogs scroll (#350)

## Notes

`distribution/whatsnew/whatsnew-en-GB` rewritten wholesale — it held 1.0.8's, and a stale file passes every CI check.

**498 characters** against the 500 limit, counted as CI counts it (`LC_ALL=C.UTF-8 wc -m`).

## Verification

`flutter analyze` clean. `flutter test` — 368 passed, 21 skipped (network-tagged), 0 failed.

Tag is **not** pushed by this PR. That is the irreversible step and is done separately, after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
