### PR TITLE
Give a landing's header the windsock, where the rose would be

### DIFF
--- a/the_paragliding_app/lib/presentation/screens/site_details_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/site_details_screen.dart
@@ -17,6 +17,7 @@ import '../../services/database_service.dart';
 import '../../services/pge_sites_database_service.dart';
 import '../../utils/flyability_helper.dart';
 import '../widgets/wind_rose_widget.dart';
+import '../widgets/windsock_marker.dart';
 import '../widgets/site_forecast_table.dart';
 import '../widgets/forecast_attribution_bar.dart';
 
@@ -204,6 +205,11 @@ class SiteDetailsScreenState extends State<SiteDetailsScreen> with SingleTickerP
       _tabController = TabController(length: (_isLanding ? 0 : 1) + _sourceTabs.length, vsync: this);
     });
   }
+
+  /// The box the header's symbol is drawn in - the wind rose on a launch, the
+  /// windsock on a landing. One size for both, so the facts beside it start at
+  /// the same place and the header is the same height whichever site is open.
+  static const double _headerSymbolSize = 72.0;
 
   // Forecast table constants
   static const double _dayColumnWidth = 80.0;
@@ -919,26 +925,41 @@ class SiteDetailsScreenState extends State<SiteDetailsScreen> with SingleTickerP
     return tooltip == null ? fact : Tooltip(message: tooltip, child: fact);
   }
 
-  /// Wind rose on the left, whatever facts belong beside it on the right.
+  /// The site's symbol on the left, whatever facts belong beside it on the
+  /// right.
   ///
   /// Shared so the no-guides layout keeps the rose too - it is the one thing
   /// on this page that answers "is it on right now", and it should not
   /// disappear just because no guide has written the site up.
+  ///
+  /// A landing gets the windsock the map drew it with instead. It has no wind
+  /// directions to be graded against, so there is no rose to draw and the slot
+  /// used to be empty - the facts slid left and the header lost the anchor a
+  /// launch's page has. The sock is not answering the rose's question; it is
+  /// saying what the place is, with the same symbol the pilot just tapped.
   Widget _buildRoseHeader(List<String> windDirections, List<Widget> facts) {
+    // No tooltip on the sock: the facts beside it already write "Landing:" in
+    // words, so nothing here depends on a hover a phone does not have.
+    final Widget? symbol = _isLanding
+        ? const WindsockMarker(size: _headerSymbolSize)
+        : windDirections.isNotEmpty
+            ? WindRoseWidget(
+                launchableDirections: windDirections,
+                size: _headerSymbolSize,
+                windSpeed: _windData?.speedKmh,
+                windDirection: _windData?.directionDegrees,
+                centerDotColor: _getCenterDotColor(windDirections),
+                centerDotTooltip: _getCenterDotTooltip(windDirections),
+              )
+            : null;
+
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (windDirections.isNotEmpty)
+        if (symbol != null)
           Padding(
             padding: const EdgeInsets.only(right: 12.0),
-            child: WindRoseWidget(
-              launchableDirections: windDirections,
-              size: 72.0,
-              windSpeed: _windData?.speedKmh,
-              windDirection: _windData?.directionDegrees,
-              centerDotColor: _getCenterDotColor(windDirections),
-              centerDotTooltip: _getCenterDotTooltip(windDirections),
-            ),
+            child: symbol,
           ),
         Expanded(
           child: Column(

--- a/the_paragliding_app/test/site_details_layout_test.dart
+++ b/the_paragliding_app/test/site_details_layout_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:the_paragliding_app/data/models/guide.dart';
 import 'package:the_paragliding_app/data/models/paragliding_site.dart';
 import 'package:the_paragliding_app/presentation/screens/site_details_screen.dart';
+import 'package:the_paragliding_app/presentation/widgets/wind_rose_widget.dart';
+import 'package:the_paragliding_app/presentation/widgets/windsock_marker.dart';
 import 'package:the_paragliding_app/services/pge_sites_database_service.dart';
 
 /// Site details was a modal bottom sheet whose tabs lived in a fixed 450px
@@ -163,6 +165,15 @@ void main() {
     expect(find.byTooltip('Altitude above mean sea level'), findsOneWidget);
   });
 
+  testWidgets('a launch is anchored by its wind rose', (tester) async {
+    // The pair with the landing case below. Without it the windsock could
+    // leak onto launches and every other assertion here would still pass.
+    await pumpPage(tester);
+
+    expect(find.byType(WindRoseWidget), findsOneWidget);
+    expect(find.byType(WindsockMarker), findsNothing);
+  });
+
   group('a landing', () {
     // A landing opens the same screen a launch does. The one thing it cannot
     // answer is whether you can fly today, and that is the only thing this
@@ -186,6 +197,19 @@ void main() {
       await pumpPage(tester, which: landing);
 
       expect(find.text('Forecast'), findsNothing);
+    });
+
+    testWidgets('is anchored by a windsock, where the rose would be',
+        (tester) async {
+      // A landing has no wind directions, so the rose's slot in the header was
+      // simply empty and the facts slid left. The windsock is the symbol the
+      // map drew this marker with, and it answers the question a landing can
+      // answer - what the place is - rather than the one it cannot.
+      await pumpPage(tester, which: landing);
+
+      expect(find.byType(WindsockMarker), findsOneWidget);
+      expect(find.byType(WindRoseWidget), findsNothing,
+          reason: 'a rose with no directions reads as "unflyable"');
     });
 
     testWidgets('keeps the guide tab it is described by', (tester) async {


### PR DESCRIPTION
The site page anchors its header with a 72x72 wind rose and sets the facts
beside it. A landing has no wind directions to be graded against, and the rose
was gated on that alone - so on a landing the slot was simply empty, the facts
slid left, and the page lost the anchor a launch's page has.

It gets the windsock the map drew the marker with instead. The sock is not
answering the rose's question; it is saying what the place is, with the symbol
the pilot just tapped. Same 72px box for both, now named once as
`_headerSymbolSize`, so the facts start at the same place and the header is the
same height whichever site type is open.

No tooltip on it: the facts beside it already write "Landing:" in words, so
nothing here depends on a hover a phone does not have. `WindsockMarker` scales
off its size and carries its own fixed livery, so there is nothing else to pass.

## Verification

- `flutter test` — 370 passed, 21 skipped.
- `flutter analyze` — no issues.
- The new landing case was confirmed to go red against the unfixed screen
  (`Found 0 widgets with type "WindsockMarker"`), so it is coverage rather than
  a test that agrees with itself.
- Rendered the real page to PNG for both site types: the sock occupies the
  rose's box and the facts column starts at the same x in each.

The test asserts the pair — a landing has a sock and no rose, a launch a rose
and no sock. Without the second half the sock could leak onto launches and every
other assertion in that file would still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)