### PR TITLE
Show landings to pilots upgrading, and wherever they look for them

### DIFF
--- a/the_paragliding_app/lib/presentation/screens/nearby_sites_screen.dart
+++ b/the_paragliding_app/lib/presentation/screens/nearby_sites_screen.dart
@@ -18,6 +18,8 @@ import '../../services/weather_station_service.dart';
 import '../../services/weather_providers/weather_station_provider_registry.dart';
 import '../../utils/map_constants.dart';
 import '../../utils/site_utils.dart';
+import '../../utils/site_marker_utils.dart';
+import '../../utils/catalog_ref.dart';
 import '../../utils/preferences_helper.dart';
 import '../../utils/flyability_helper.dart';
 import '../../utils/ui_utils.dart';
@@ -35,6 +37,8 @@ import '../../services/database_service.dart';
 import '../../services/pge_sites_database_service.dart';
 import '../../services/app_initialization_service.dart';
 import '../widgets/common/app_search_field.dart';
+import '../widgets/common/site_search_result_tile.dart';
+import '../../services/site_bounds_loader_v2.dart';
 
 /// Loading states for different operations
 enum LoadingOperation {
@@ -44,6 +48,19 @@ enum LoadingOperation {
   wind,
   weatherStations,
   favorites,
+}
+
+/// One line of the favourites menu: a site, and whether it is shown as a
+/// landing belonging to the launch above it.
+///
+/// The nesting is presentation only. Both kinds of row are equally a favourite
+/// and behave identically when tapped - indenting one says which launch it
+/// serves, not that it is worth less.
+class FavoriteRow {
+  final ParaglidingSite site;
+  final bool isNested;
+
+  const FavoriteRow(this.site, {this.isNested = false});
 }
 
 class NearbySitesScreen extends StatefulWidget {
@@ -163,8 +180,8 @@ class NearbySitesScreenState extends State<NearbySitesScreen> with WidgetsBindin
   bool _forecastActuallyCallingApi = false; // Track if forecast API is being called
   bool _forecastHasError = false; // Track if forecast API call failed
 
-  // Favorites state
-  List<ParaglidingSite> _favoriteSites = [];
+  // Favorites state, in menu order - see groupFavorites.
+  List<FavoriteRow> _favoriteRows = [];
 
   @override
   void initState() {
@@ -332,8 +349,11 @@ class NearbySitesScreenState extends State<NearbySitesScreen> with WidgetsBindin
       setState(() => _isSearching = true);
 
       try {
-        final results = await PgeSitesDatabaseService.instance.searchSitesByName(
-          query: _searchQuery,
+        // Through the bounds loader, not the database service: this searches
+        // the map, so it has to agree with the map about what is on it -
+        // landings included. See SiteBoundsLoaderV2.searchSitesByName.
+        final results = await SiteBoundsLoaderV2.instance.searchSitesByName(
+          _searchQuery,
         );
 
         if (mounted) {
@@ -747,6 +767,83 @@ class NearbySitesScreenState extends State<NearbySitesScreen> with WidgetsBindin
   /// Load favorite sites from database tables
   /// Queries both local sites table and PGE sites table for favorites
   /// Deduplicates sites that exist in both databases (prefer PGE version)
+  /// Order the favourites so each landing follows the launch it serves.
+  ///
+  /// [favorites] arrives in the order the menu should show its top-level rows -
+  /// by distance from the pilot, or as loaded when there is no position fix.
+  /// That order is preserved: this only pulls landings out of it and puts them
+  /// back under their launch.
+  ///
+  /// **A landing nests under the nearest favourited launch it serves, and only
+  /// that one.** 28.5% of DHV landings serve several launches, so listing one
+  /// under each would show a pilot who favourited four launches on the same hill
+  /// their landing four times. One row per favourite is what a favourites list
+  /// is for.
+  ///
+  /// A landing whose launch is not favourited stays where it is, at top level.
+  /// It is the pilot's favourite; hiding it, or heading it with a launch they
+  /// did not choose, would both misrepresent the list.
+  ///
+  /// Matched on the `site_group` tokens the guides publish, never on distance -
+  /// the same rule as [PgeSitesDatabaseService.getLandingsForSite], restated
+  /// here because this is the one caller that cannot reuse the SQL. Distance is
+  /// used only to break a tie between launches that already share a token, so
+  /// no position fix is needed and the grouping works before one arrives.
+  ///
+  /// Sites are held by index rather than by value: [ParaglidingSite] compares on
+  /// `siteKey`, and two rows sharing one would otherwise collapse into a single
+  /// map entry and lose a favourite.
+  @visibleForTesting
+  static List<FavoriteRow> groupFavorites(List<ParaglidingSite> favorites) {
+    bool isLanding(ParaglidingSite site) => site.siteType == 'landing';
+
+    // Launch index -> the landings nesting under it, nearest first.
+    final nested = <int, List<ParaglidingSite>>{};
+    final nestedLandings = <int>{};
+
+    for (var i = 0; i < favorites.length; i++) {
+      final landing = favorites[i];
+      if (!isLanding(landing)) continue;
+
+      final tokens = CatalogRef.tokensOf(landing.siteGroup).toSet();
+      if (tokens.isEmpty) continue;
+
+      int? host;
+      double? nearest;
+      for (var j = 0; j < favorites.length; j++) {
+        final launch = favorites[j];
+        if (isLanding(launch)) continue;
+        if (!CatalogRef.tokensOf(launch.siteGroup).any(tokens.contains)) continue;
+
+        final distance = landing.distanceTo(launch.latitude, launch.longitude);
+        if (nearest == null || distance < nearest) {
+          nearest = distance;
+          host = j;
+        }
+      }
+
+      if (host != null) {
+        (nested[host] ??= []).add(landing);
+        nestedLandings.add(i);
+      }
+    }
+
+    final rows = <FavoriteRow>[];
+    for (var i = 0; i < favorites.length; i++) {
+      if (nestedLandings.contains(i)) continue; // emitted under its launch
+      rows.add(FavoriteRow(favorites[i]));
+
+      final children = nested[i];
+      if (children == null) continue;
+      children.sort((a, b) => a
+          .distanceTo(favorites[i].latitude, favorites[i].longitude)
+          .compareTo(b.distanceTo(favorites[i].latitude, favorites[i].longitude)));
+      rows.addAll(children.map((site) => FavoriteRow(site, isNested: true)));
+    }
+
+    return rows;
+  }
+
   Future<void> _loadFavorites() async {
     setState(() {
       _activeLoadingOperations.add(LoadingOperation.favorites);
@@ -755,7 +852,13 @@ class NearbySitesScreenState extends State<NearbySitesScreen> with WidgetsBindin
     try {
       // Get favorites from both database tables
       final localFavorites = await DatabaseService.instance.getFavoriteSites();
-      final pgeFavorites = await PgeSitesDatabaseService.instance.getFavoriteSites();
+      // Landings included here and nowhere else. A pilot can favourite a landing
+      // from its site page, so a favourites list that silently dropped it was
+      // lying about what it holds. The Forecast screen's favourites keep the
+      // launches-only default - see getFavoriteSites.
+      final pgeFavorites = await PgeSitesDatabaseService.instance
+          .getFavoriteSites(
+              siteTypes: PgeSitesDatabaseService.launchesAndLandings);
 
       // Deduplicate: Remove local favorites that have catalog_ref matching a PGE favorite
       // This ensures we don't show duplicate sites when one exists in both databases
@@ -800,7 +903,7 @@ class NearbySitesScreenState extends State<NearbySitesScreen> with WidgetsBindin
 
       if (mounted) {
         setState(() {
-          _favoriteSites = sites;
+          _favoriteRows = groupFavorites(sites);
           _activeLoadingOperations.remove(LoadingOperation.favorites);
         });
 
@@ -815,7 +918,7 @@ class NearbySitesScreenState extends State<NearbySitesScreen> with WidgetsBindin
       LoggingService.error('Failed to load favorites', e, stackTrace);
       if (mounted) {
         setState(() {
-          _favoriteSites = [];
+          _favoriteRows = [];
           _activeLoadingOperations.remove(LoadingOperation.favorites);
         });
       }
@@ -1720,7 +1823,7 @@ class NearbySitesScreenState extends State<NearbySitesScreen> with WidgetsBindin
                 ];
               }
 
-              if (_favoriteSites.isEmpty) {
+              if (_favoriteRows.isEmpty) {
                 return [
                   const PopupMenuItem(
                     enabled: false,
@@ -1729,7 +1832,8 @@ class NearbySitesScreenState extends State<NearbySitesScreen> with WidgetsBindin
                 ];
               }
 
-              return _favoriteSites.map((site) {
+              return _favoriteRows.map((row) {
+                final site = row.site;
                 String distanceText = '';
                 if (_userPosition != null) {
                   final distance = Geolocator.distanceBetween(
@@ -1743,17 +1847,28 @@ class NearbySitesScreenState extends State<NearbySitesScreen> with WidgetsBindin
 
                 return PopupMenuItem<ParaglidingSite>(
                   value: site,
-                  child: Row(
-                    children: [
-                      const Icon(Icons.place, size: 18, color: Colors.blue),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: Text(
-                          '${site.name}$distanceText',
-                          overflow: TextOverflow.ellipsis,
+                  child: Padding(
+                    // Indent says which launch the landing above it serves.
+                    padding: EdgeInsets.only(left: row.isNested ? 20 : 0),
+                    child: Row(
+                      children: [
+                        // Asked of the same helper the map and the legend use,
+                        // rather than naming a glyph here - a landing is a
+                        // windsock in one place or it drifts.
+                        SiteMarkerUtils.siteSymbol(
+                          site.siteType,
+                          color: Colors.blue,
+                          size: 18,
                         ),
-                      ),
-                    ],
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            '${site.name}$distanceText',
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
                 );
               }).toList();
@@ -1988,39 +2103,8 @@ class NearbySitesScreenState extends State<NearbySitesScreen> with WidgetsBindin
                         itemCount: _searchResults.length,
                         itemBuilder: (context, index) {
                           final site = _searchResults[index];
-                          return ListTile(
-                            leading: CircleAvatar(
-                              radius: 16,
-                              backgroundColor: Theme.of(context).colorScheme.primaryContainer,
-                              child: Text(
-                                (site.country != null && site.country!.length >= 2)
-                                    ? site.country!.toUpperCase().substring(0, 2)
-                                    : '??',
-                                style: TextStyle(
-                                  fontSize: 10,
-                                  fontWeight: FontWeight.bold,
-                                  color: Theme.of(context).colorScheme.onPrimaryContainer,
-                                ),
-                              ),
-                            ),
-                            title: Text(
-                              site.name,
-                              style: TextStyle(
-                                fontWeight: FontWeight.w500,
-                                color: Theme.of(context).colorScheme.onSurface,
-                              ),
-                            ),
-                            subtitle: Text(
-                              site.country ?? 'Unknown',
-                              style: TextStyle(
-                                color: Theme.of(context).colorScheme.onSurfaceVariant,
-                              ),
-                            ),
-                            trailing: Icon(
-                              Icons.arrow_forward_ios,
-                              size: 16,
-                              color: Theme.of(context).colorScheme.onSurfaceVariant,
-                            ),
+                          return SiteSearchResultTile(
+                            site: site,
                             onTap: () {
                               _jumpToLocation(site, keepSearchActive: false);
                               setState(() {

--- a/the_paragliding_app/lib/presentation/widgets/common/site_search_result_tile.dart
+++ b/the_paragliding_app/lib/presentation/widgets/common/site_search_result_tile.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+import '../../../data/models/paragliding_site.dart';
+import '../../../utils/site_marker_utils.dart';
+
+/// One row of the site search dropdown.
+///
+/// The leading widget is the symbol the map draws for that site - an outlined
+/// pin for a launch, a windsock for a landing - and it is load-bearing rather
+/// than decoration: a landing usually carries its launch's name ("Hirschberg
+/// Startplatz" and "Hirschberg Landeplatz 1"), and 423 of the catalogue's 5,882
+/// landings say nothing about landing at all ("West paddock", "Godfrey's"). Two
+/// rows that read the same have to be told apart before the tap, not after it.
+///
+/// The symbol comes from [SiteMarkerUtils.siteSymbol] so this cannot drift from
+/// what the map and the legend show, for the same reason #362 gave the glyph one
+/// definition.
+///
+/// It replaces a two-letter `CircleAvatar` that was wrong as well as redundant:
+/// a catalogue row's `country` is the JOINed country *name*, so the circle read
+/// "GE" above a subtitle reading "Germany".
+class SiteSearchResultTile extends StatelessWidget {
+  const SiteSearchResultTile({
+    super.key,
+    required this.site,
+    required this.onTap,
+  });
+
+  final ParaglidingSite site;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return ListTile(
+      // A fixed box so names line up whichever symbol a row got.
+      leading: SizedBox(
+        width: SiteMarkerUtils.resultSymbolSize,
+        height: SiteMarkerUtils.resultSymbolSize,
+        child: Center(
+          child: SiteMarkerUtils.siteSymbol(
+            site.siteType,
+            // Every search result is a catalogue row, so they are all "New
+            // Sites"; a landing ignores this and carries the windsock's palette.
+            color: SiteMarkerUtils.newSiteColor,
+            size: SiteMarkerUtils.resultSymbolSize,
+          ),
+        ),
+      ),
+      title: Text(
+        site.name,
+        style: TextStyle(
+          fontWeight: FontWeight.w500,
+          color: theme.colorScheme.onSurface,
+        ),
+      ),
+      subtitle: Text(
+        site.country ?? 'Unknown',
+        style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
+      ),
+      trailing: Icon(
+        Icons.arrow_forward_ios,
+        size: 16,
+        color: theme.colorScheme.onSurfaceVariant,
+      ),
+      onTap: onTap,
+    );
+  }
+}

--- a/the_paragliding_app/lib/services/app_initialization_service.dart
+++ b/the_paragliding_app/lib/services/app_initialization_service.dart
@@ -160,6 +160,18 @@ class AppInitializationService {
           // is what the validators are read as meaning.
           await PgeSitesDownloadService.instance.commitDownloadValidators();
         }
+      } else if (shouldReimportLocalCopy(
+        importedByVersion:
+            await PgeSitesDatabaseService.instance.importedByVersion(),
+      )) {
+        // The file on disk is current and the rows are not. Re-parsing what is
+        // already there costs no network and keeps the published copy, which is
+        // what separates this from the Reset to Bundled a pilot would otherwise
+        // have to reach for.
+        LoggingService.info(
+            'AppInitializationService: Catalogue was imported by an older '
+            'importer, re-importing the local copy');
+        await PgeSitesDatabaseService.instance.importSitesData();
       } else {
         LoggingService.info('AppInitializationService: PGE sites already available');
       }
@@ -200,6 +212,21 @@ class AppInitializationService {
     if (localCopyIsPublished) return false;
     return bundledDiffersFromLocal;
   }
+
+  /// Whether the catalogue on disk should be parsed again into the database.
+  ///
+  /// Only reached once the file itself is settled - nothing newer is bundled,
+  /// nothing newer is published - so the sole remaining question is whether the
+  /// rows were built by an importer that read every column this one does. See
+  /// [PgeSitesConfig.importerVersion] for how the two came apart.
+  ///
+  /// Deliberately independent of [checkIsDue]. That throttle exists to spare the
+  /// pilot a HEAD request whose answer is almost always "no"; this needs no
+  /// network at all, and answers "no" from a single metadata row on every start
+  /// but the first after an upgrade.
+  @visibleForTesting
+  static bool shouldReimportLocalCopy({required int importedByVersion}) =>
+      importedByVersion < PgeSitesConfig.importerVersion;
 
   /// Whether enough time has passed to ask the server again.
   ///

--- a/the_paragliding_app/lib/services/pge_sites_database_service.dart
+++ b/the_paragliding_app/lib/services/pge_sites_database_service.dart
@@ -1005,6 +1005,30 @@ class PgeSitesDatabaseService {
     }
   }
 
+  /// Which importer built the rows now in the database.
+  ///
+  /// 0 for a database imported before the stamp existed, and for one whose stamp
+  /// cannot be read - both mean "older than anything", which is the answer that
+  /// makes the caller re-import rather than trust rows it cannot vouch for.
+  Future<int> importedByVersion() async {
+    try {
+      final db = await DatabaseHelper.instance.database;
+      final rows = await db.query(
+        _pgeSitesMetadataTable,
+        columns: ['version'],
+        orderBy: 'downloaded_at DESC',
+        limit: 1,
+      );
+      if (rows.isEmpty) return 0;
+
+      return PgeSitesConfig.importerVersionFrom(rows.first['version'] as String?);
+    } catch (error, stackTrace) {
+      LoggingService.error(
+          '[PGE_SITES_DB] Failed to read importer version', error, stackTrace);
+      return 0;
+    }
+  }
+
   /// Update import metadata
   Future<void> _updateImportMetadata(int sitesCount) async {
     try {
@@ -1017,7 +1041,10 @@ class PgeSitesDatabaseService {
         'sites_count': sitesCount,
         'file_size_bytes': downloadStatus['file_size_bytes'] ?? 0,
         'status': 'completed',
-        'version': DateTime.now().millisecondsSinceEpoch.toString(),
+        // Which importer built these rows - see PgeSitesConfig.importerVersion.
+        // It used to be the import's own timestamp, which nothing read and which
+        // said nothing `downloaded_at` above does not already say.
+        'version': PgeSitesConfig.importerStamp(PgeSitesConfig.importerVersion),
       };
 
       // Clear existing metadata and insert new

--- a/the_paragliding_app/lib/services/pge_sites_database_service.dart
+++ b/the_paragliding_app/lib/services/pge_sites_database_service.dart
@@ -121,13 +121,20 @@ class PgeSitesDatabaseService {
   ///
   /// The catalogue holds landings as well as launches, and almost nothing that
   /// asks it a question wants a landing: matching a logged flight to a hill,
-  /// ranking where to fly today, searching by name, listing favourites. So the
-  /// default is launches, everywhere, and a caller that wants landings says so.
+  /// ranking where to fly today, listing favourites. So the default is
+  /// launches, everywhere, and a caller that wants landings says so.
   ///
   /// The direction matters. Defaulting the other way would mean every one of
   /// those callers had to remember to exclude landings, and the cost of
   /// forgetting is a flight permanently attached to the wrong site. This way
   /// the cost of forgetting is a landing missing from a screen.
+  ///
+  /// Name search used to be on that list and no longer is - see
+  /// `SiteBoundsLoaderV2.searchSitesByName`. What the queries above have in
+  /// common is that they pick a site *for* the pilot, so a landing among the
+  /// candidates is a wrong answer. A search hands the pilot the list and lets
+  /// them tap the one they meant, and since #362 a landing has a page to open
+  /// when they do.
   static const List<String> launchesOnly = ['launch'];
   static const List<String> launchesAndLandings = ['launch', 'landing'];
 
@@ -1193,14 +1200,22 @@ class PgeSitesDatabaseService {
     return null;
   }
 
+  /// The pilot's favourites, launches only unless a caller asks otherwise.
+  ///
+  /// The default is for the Forecast screen, which ranks where to fly: a landing
+  /// has no wind directions, so it would either sit there as "unknown" or, worse,
+  /// inherit its launch's and read as flyable.
+  ///
+  /// The Sites screen's favourites menu passes [launchesAndLandings], because a
+  /// landing can be favourited from its own page and a list that dropped it was
+  /// lying about what the pilot had marked. Two screens, two questions, one
+  /// query - so the difference is stated at the call site rather than being a
+  /// second method that could drift from this one.
   Future<List<ParaglidingSite>> getFavoriteSites({
     List<String> siteTypes = launchesOnly,
   }) async {
     try {
       final db = await DatabaseHelper.instance.database;
-      // Favourites feed the multi-site flyability screen, which ranks where to
-      // fly - a landing has no wind directions, so it would either sit there as
-      // "unknown" or, worse, inherit its launch's and read as flyable.
       final results = await db.rawQuery('''
         SELECT s.*, COALESCE(cc.name, s.country) as country_name
         FROM $_pgeSitesTable s

--- a/the_paragliding_app/lib/services/pge_sites_download_service.dart
+++ b/the_paragliding_app/lib/services/pge_sites_download_service.dart
@@ -48,6 +48,46 @@ class PgeSitesConfig {
   /// failure, so asking four times as often costs the pilot nothing.
   static const Duration checkInterval = Duration(days: 7);
 
+  /// What the importer understands, bumped whenever it starts reading a column
+  /// the previous one ignored.
+  ///
+  /// The freshness checks all ask whether the *file* on disk is current. This
+  /// asks the other question: whether the *rows* were built by the importer now
+  /// running. The two came apart on the 1.0.9 upgrade. A pilot on 1.0.8 had
+  /// already downloaded the published catalogue carrying `site_type`, so the
+  /// file was current and "Check for update" correctly said there was nothing to
+  /// fetch - but 1.0.8's importer had never read that column, so every landing
+  /// sat in the database as a null type, which reads as a launch and draws as a
+  /// launch pin. The release whose whole point was landings showed none of them,
+  /// and the only escape was Reset to Bundled, which throws the published
+  /// catalogue away to do it.
+  ///
+  /// Same role as `databaseVersion` in `database_helper.dart`, and the same
+  /// obligation: bump it in the change that teaches the importer a new column.
+  ///
+  /// 1 is implicit - every stamp written before this existed was a timestamp,
+  /// which [PgeSitesDatabaseService.importedByVersion] reads as 0.
+  static const int importerVersion = 2;
+
+  /// How [importerVersion] is written into `pge_sites_metadata.version`.
+  ///
+  /// Prefixed rather than stored bare so the epoch timestamps that column used
+  /// to hold cannot be mistaken for an enormous importer version - they have to
+  /// read as "older than anything", not "newer than everything".
+  static String importerStamp(int version) => '$_importerPrefix$version';
+
+  /// The importer behind a stamp, written or inherited.
+  ///
+  /// 0 for anything this does not recognise: an absent stamp, and the epoch
+  /// timestamps written before the column meant this. Both are databases whose
+  /// rows no importer vouches for, which is the case that has to re-import.
+  static int importerVersionFrom(String? stamp) {
+    if (stamp == null || !stamp.startsWith(_importerPrefix)) return 0;
+    return int.tryParse(stamp.substring(_importerPrefix.length)) ?? 0;
+  }
+
+  static const String _importerPrefix = 'importer:';
+
   /// Maximum sites per query
   static const int maxSitesPerQuery = 100;
 

--- a/the_paragliding_app/lib/services/site_bounds_loader_v2.dart
+++ b/the_paragliding_app/lib/services/site_bounds_loader_v2.dart
@@ -47,9 +47,11 @@ class SiteBoundsLoaderV2 {
       // 2. Always load PGE sites from local database
       // The database will return empty list if no sites exist
       //
-      // The one place that asks for landings. Everything else - matching,
-      // flyability ranking, search, favourites - takes the launches-only
-      // default, so a landing can be drawn without being mistaken for a hill.
+      // This file is where landings are asked for, and both its queries ask -
+      // what the map draws and what a search over that map finds are the same
+      // set of sites. Everything else - matching, flyability ranking,
+      // favourites - takes the launches-only default, so a landing can be drawn
+      // without being mistaken for a hill.
       futures.add(PgeSitesDatabaseService.instance.getSitesInBounds(
         north: bounds.north,
         south: bounds.south,
@@ -124,7 +126,14 @@ class SiteBoundsLoaderV2 {
     }
   }
 
-  /// Search sites by name using local database only
+  /// Search sites by name using local database only.
+  ///
+  /// Landings included, for the same reason [loadSitesForBounds] draws them:
+  /// this searches the map, and a landing is one of the things on it. The
+  /// launches-only default belongs to the queries that pick a site *for* the
+  /// pilot - matching a flight to a hill, ranking where to fly - where a
+  /// landing returned by mistake is a wrong answer rather than an extra one.
+  /// Here the pilot reads the result and taps the one they meant.
   Future<List<ParaglidingSite>> searchSitesByName(
     String query, {
     double? centerLatitude,
@@ -136,6 +145,7 @@ class SiteBoundsLoaderV2 {
         query: query,
         centerLatitude: centerLatitude,
         centerLongitude: centerLongitude,
+        siteTypes: PgeSitesDatabaseService.launchesAndLandings,
       );
     } catch (error, stackTrace) {
       LoggingService.error('SiteBoundsLoaderV2: Search failed', error, stackTrace);

--- a/the_paragliding_app/lib/utils/site_marker_utils.dart
+++ b/the_paragliding_app/lib/utils/site_marker_utils.dart
@@ -23,6 +23,13 @@ class SiteMarkerUtils {
   // A legend row's symbol, small enough to sit on a text line. The same
   // symbols the map draws, only smaller - see siteSymbol.
   static const double legendSymbolSize = 18.0;
+
+  // A search result's symbol, sized for a ListTile's leading slot.
+  //
+  // One size for both types, unlike the map: there a landing is drawn smaller
+  // because you choose a launch and its landing follows, but in a list of
+  // things you typed a name to find, the two are equal candidates.
+  static const double resultSymbolSize = 28.0;
   
   // Site status colors (for other screens)
   static const Color flownSiteColor = Color(0xFF0047AB);     // Sites with logged flights (cobalt blue)

--- a/the_paragliding_app/test/catalog_refresh_test.dart
+++ b/the_paragliding_app/test/catalog_refresh_test.dart
@@ -294,6 +294,52 @@ void main() {
     });
   });
 
+  group('deciding whether to parse the local copy again', () {
+    test('a database built by an older importer is re-imported', () {
+      // The 1.0.9 upgrade, exactly: the pilot had already downloaded the
+      // published catalogue carrying site_type, so the file was current and
+      // every freshness check honestly answered "nothing to fetch" - while
+      // 1.0.8's importer had never read that column, leaving every landing in
+      // the database with a null type. Landings drew as launch pins in the
+      // release that added them.
+      expect(
+        AppInitializationService.shouldReimportLocalCopy(importedByVersion: 0),
+        isTrue,
+      );
+      expect(
+        AppInitializationService.shouldReimportLocalCopy(
+            importedByVersion: PgeSitesConfig.importerVersion - 1),
+        isTrue,
+      );
+    });
+
+    test('a database built by this importer is left alone', () {
+      // The other direction, and the common one: this runs on every cold start,
+      // so answering "yes" when the rows are already current would re-parse the
+      // whole catalogue each launch.
+      expect(
+        AppInitializationService.shouldReimportLocalCopy(
+            importedByVersion: PgeSitesConfig.importerVersion),
+        isFalse,
+      );
+    });
+
+    test('the stamps an older install left behind read as no importer at all', () {
+      // The column used to hold the import's own epoch timestamp. Read as a
+      // number it is larger than any importer version will ever be, so a
+      // database that predates the stamp would have looked newer than the code
+      // reading it and never been re-imported - the precise failure this exists
+      // to fix.
+      expect(PgeSitesConfig.importerVersionFrom('1787705237563'), 0);
+      expect(PgeSitesConfig.importerVersionFrom(null), 0);
+      expect(
+        PgeSitesConfig.importerVersionFrom(
+            PgeSitesConfig.importerStamp(PgeSitesConfig.importerVersion)),
+        PgeSitesConfig.importerVersion,
+      );
+    });
+  });
+
   group('which catalogue the pilot is running', () {
     setUp(() => SharedPreferences.setMockInitialValues({}));
 

--- a/the_paragliding_app/test/favorite_grouping_test.dart
+++ b/the_paragliding_app/test/favorite_grouping_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:the_paragliding_app/data/models/paragliding_site.dart';
+import 'package:the_paragliding_app/presentation/screens/nearby_sites_screen.dart';
+
+/// Covers the order of the Sites screen's favourites menu.
+///
+/// A pilot can favourite a landing from its own page, so the menu holds both
+/// kinds and has to say which launch a landing belongs to. The grouping rule is
+/// the intricate part and is pure, so it is tested directly rather than through
+/// a screen that would need a database, a position fix and a popup.
+void main() {
+  // Sites are placed on a line of latitude so "nearer" in the tests means the
+  // same thing it means on the screen, without any of them being coincident.
+  ParaglidingSite launch(String name, {double lat = 47.0, String? group}) =>
+      ParaglidingSite(
+        name: name,
+        latitude: lat,
+        longitude: 12.0,
+        siteType: 'launch',
+        siteGroup: group,
+      );
+
+  ParaglidingSite landing(String name, {double lat = 47.0, String? group}) =>
+      ParaglidingSite(
+        name: name,
+        latitude: lat,
+        longitude: 12.0,
+        siteType: 'landing',
+        siteGroup: group,
+      );
+
+  List<String> namesOf(List<FavoriteRow> rows) =>
+      rows.map((row) => '${row.isNested ? '  ' : ''}${row.site.name}').toList();
+
+  test('a landing follows the launch it serves', () {
+    final rows = NearbySitesScreenState.groupFavorites([
+      launch('Hohe Salve', group: 'dhv:100'),
+      launch('Kranzhorn', lat: 47.5, group: 'dhv:200'),
+      landing('Hohe Salve Landeplatz', lat: 47.01, group: 'dhv:100'),
+    ]);
+
+    expect(namesOf(rows), [
+      'Hohe Salve',
+      '  Hohe Salve Landeplatz',
+      'Kranzhorn',
+    ]);
+  });
+
+  test('a landing serving several favourited launches is listed once', () {
+    // 28.5% of DHV landings serve more than one launch. Listing one under each
+    // would show a pilot who favourited four launches on the same hill their
+    // landing four times, which is what "one row per favourite" rules out.
+    final rows = NearbySitesScreenState.groupFavorites([
+      launch('Far Launch', lat: 47.9, group: 'dhv:100;dhv:300'),
+      launch('Near Launch', lat: 47.1, group: 'dhv:100'),
+      landing('Shared Landeplatz', lat: 47.0, group: 'dhv:100'),
+    ]);
+
+    expect(namesOf(rows), [
+      'Far Launch',
+      'Near Launch',
+      '  Shared Landeplatz',
+    ], reason: 'nests under the nearer of the two launches it serves, once');
+  });
+
+  test('a landing whose launch is not favourited stays at top level', () {
+    // It is the pilot's favourite. Dropping it would be the bug this whole
+    // change fixes, and heading it with a launch they did not choose would put
+    // something in the list they never marked.
+    final rows = NearbySitesScreenState.groupFavorites([
+      launch('Unrelated', group: 'dhv:200'),
+      landing('Orphan Landeplatz', lat: 47.2, group: 'dhv:100'),
+    ]);
+
+    expect(namesOf(rows), ['Unrelated', 'Orphan Landeplatz']);
+  });
+
+  test('proximity alone never nests a landing', () {
+    // The rule the site pages use, restated here: a landing sits a median 1.7km
+    // from its launch and a neighbouring hill's field is often closer, so
+    // distance decides only between launches that already share a token.
+    final rows = NearbySitesScreenState.groupFavorites([
+      launch('Wrong Hill', group: 'dhv:200'),
+      landing('Landeplatz', lat: 47.00001, group: 'dhv:100'),
+    ]);
+
+    expect(namesOf(rows), ['Wrong Hill', 'Landeplatz']);
+  });
+
+  test('a landing with no group is left where it is', () {
+    // A custom site the pilot added themselves has no site_group, so there is
+    // nothing to join on and nothing to guess from.
+    final rows = NearbySitesScreenState.groupFavorites([
+      launch('Hohe Salve', group: 'dhv:100'),
+      landing('My Field'),
+    ]);
+
+    expect(namesOf(rows), ['Hohe Salve', 'My Field']);
+  });
+
+  test('the order the favourites arrive in is preserved', () {
+    // The caller has already sorted by distance from the pilot, or left the
+    // list as loaded when there is no fix. Grouping must not resort it.
+    final rows = NearbySitesScreenState.groupFavorites([
+      launch('Third', lat: 47.3, group: 'dhv:300'),
+      launch('First', lat: 47.1, group: 'dhv:100'),
+      launch('Second', lat: 47.2, group: 'dhv:200'),
+    ]);
+
+    expect(namesOf(rows), ['Third', 'First', 'Second']);
+  });
+
+  test('several landings under one launch are nearest first', () {
+    final rows = NearbySitesScreenState.groupFavorites([
+      launch('Hohe Salve', group: 'dhv:100'),
+      landing('Far Landeplatz', lat: 47.3, group: 'dhv:100'),
+      landing('Near Landeplatz', lat: 47.05, group: 'dhv:100'),
+    ]);
+
+    expect(namesOf(rows), [
+      'Hohe Salve',
+      '  Near Landeplatz',
+      '  Far Landeplatz',
+    ]);
+  });
+
+  test('no favourites is no rows', () {
+    expect(NearbySitesScreenState.groupFavorites([]), isEmpty);
+  });
+}

--- a/the_paragliding_app/test/site_search_test.dart
+++ b/the_paragliding_app/test/site_search_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:the_paragliding_app/data/datasources/database_helper.dart';
+import 'package:the_paragliding_app/services/pge_sites_database_service.dart';
+import 'package:the_paragliding_app/services/site_bounds_loader_v2.dart';
+
+import 'helpers/test_helpers.dart';
+
+/// Searching the Sites tab by name finds landings; the queries that pick a site
+/// for the pilot still do not.
+///
+/// Both halves matter and they pull in opposite directions. Landings were
+/// excluded from search only because `searchSitesByName` shares the class-wide
+/// `launchesOnly` default, and that default exists for a real reason: #355
+/// added it after a flight matched "Mt Borah Landing" instead of a takeoff, and
+/// a wrong match writes itself into `sites.catalog_ref` permanently. So the
+/// widening has to sit at the one caller that searches the map, not at the
+/// constant every caller shares.
+///
+/// `searchSitesByName` had no coverage at all in either class before this.
+void main() {
+  setUpAll(() async {
+    await TestHelpers.initializeDatabaseForTesting();
+  });
+
+  setUp(() async {
+    await DatabaseHelper.instance.close();
+    await DatabaseHelper.instance.database;
+    await PgeSitesDatabaseService.instance.initializeTables();
+  });
+
+  tearDown(() async => DatabaseHelper.instance.close());
+
+  /// The real Mt Borah rows: four takeoffs on one hill and the field below it,
+  /// which is exactly the search a pilot types the hill's name for.
+  Future<void> seedBorah() async {
+    final db = await DatabaseHelper.instance.database;
+    for (final row in [
+      {'ref': 'pge:1', 'name': 'Manilla - Mt Borah - East launch',
+        'site_type': 'launch', 'latitude': -30.6788, 'longitude': 150.6123},
+      {'ref': 'pge:2', 'name': 'Manilla - Mt Borah - West launch',
+        'site_type': 'launch', 'latitude': -30.6791, 'longitude': 150.6087},
+      {'ref': 'pge:3', 'name': 'Manilla, Mt Borah (NSW) Landing',
+        'site_type': 'landing', 'latitude': -30.6560, 'longitude': 150.6420},
+    ]) {
+      await db.insert('pge_sites', {...row, 'country': 'au'});
+    }
+  }
+
+  test('a landing is found by the name of the hill it serves', () async {
+    await seedBorah();
+
+    final results =
+        await SiteBoundsLoaderV2.instance.searchSitesByName('Borah');
+
+    expect(
+      results.map((s) => s.name),
+      contains('Manilla, Mt Borah (NSW) Landing'),
+      reason: 'the map draws this landing; a search over the map must find it',
+    );
+    expect(results, hasLength(3), reason: 'the launches are still there too');
+  });
+
+  test('the launches-only default is untouched, so matching cannot regress',
+      () async {
+    await seedBorah();
+
+    // The same query, straight at the database service, is what the flight
+    // matcher and the flyability screen take.
+    final results = await PgeSitesDatabaseService.instance
+        .searchSitesByName(query: 'Borah');
+
+    expect(results.map((s) => s.siteType), everyElement('launch'));
+    expect(results, hasLength(2));
+  });
+
+  test('a row that predates site_type is still a launch, not a landing',
+      () async {
+    // COALESCE in _siteTypeClause: an app that has not re-imported since the
+    // producer added the column has null on every row, and they are all
+    // launches. Widening the search must not start calling them landings.
+    final db = await DatabaseHelper.instance.database;
+    await db.insert('pge_sites', {
+      'ref': 'pge:9', 'name': 'Old Borah row', 'country': 'au',
+      'latitude': -30.6788, 'longitude': 150.6123,
+    });
+
+    final results =
+        await SiteBoundsLoaderV2.instance.searchSitesByName('Borah');
+
+    expect(results.single.siteType, 'launch');
+  });
+}

--- a/the_paragliding_app/test/windsock_landing_marker_test.dart
+++ b/the_paragliding_app/test/windsock_landing_marker_test.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:the_paragliding_app/data/models/paragliding_site.dart';
+import 'package:the_paragliding_app/presentation/widgets/common/site_search_result_tile.dart';
 import 'package:the_paragliding_app/presentation/widgets/windsock_marker.dart';
 import 'package:the_paragliding_app/utils/site_marker_utils.dart';
 
@@ -78,5 +80,40 @@ void main() {
     expect(find.text('Landings'), findsOneWidget);
     expect(find.byType(WindsockMarker), findsOneWidget,
         reason: 'the legend must not go on advertising a flag');
+  });
+
+  group('a search result carries the same symbol', () {
+    // Now that the Sites search returns landings, the list has to say which is
+    // which before the tap: a landing usually carries its launch's name, and
+    // 423 of the catalogue's 5,882 landings say nothing about landing at all.
+    ParaglidingSite site(String type) => ParaglidingSite(
+          name: 'Manilla, Mt Borah (NSW)',
+          latitude: -30.6788,
+          longitude: 150.6123,
+          siteType: type,
+          country: 'Australia',
+        );
+
+    Future<void> pumpTile(WidgetTester tester, String type) => pump(
+          tester,
+          SiteSearchResultTile(site: site(type), onTap: () {}),
+        );
+
+    testWidgets('a landing result is a windsock', (tester) async {
+      await pumpTile(tester, 'landing');
+
+      expect(find.byType(WindsockMarker), findsOneWidget);
+      // The row it replaced showed the first two letters of the country *name*
+      // - "AU" only by luck, "GE" for Germany - above a subtitle spelling the
+      // country out in full.
+      expect(find.byType(CircleAvatar), findsNothing);
+    });
+
+    testWidgets('a launch result keeps the pin', (tester) async {
+      await pumpTile(tester, 'launch');
+
+      expect(find.byType(WindsockMarker), findsNothing);
+      expect(find.byIcon(Icons.location_on), findsNWidgets(2));
+    });
   });
 }


### PR DESCRIPTION
Two changes, both about landings reaching the pilot.

## An upgrade kept showing landings as launch pins

Every catalogue freshness check asks whether the *file* on disk is current. None asked whether the *rows* were built by the importer now running, and on the 1.0.9 upgrade the two came apart.

A pilot on 1.0.8 had already downloaded the published catalogue carrying `site_type`, so the file was current and "Check for update" correctly reported nothing to fetch — but 1.0.8's importer never read that column, leaving every landing in the database with a null type. A null type reads as a launch and draws as a launch pin, so the release whose whole point was landings showed none of them. The only way out was Reset to Bundled, which throws the published catalogue away to do it.

`PgeSitesConfig.importerVersion` now stamps `pge_sites_metadata.version` at import, taking over a column that held the import's own epoch timestamp and said nothing `downloaded_at` did not. Startup re-parses the copy already on disk when the stamp is behind — no network, and the published catalogue is kept. Same role and obligation as `databaseVersion` in `database_helper.dart`.

**Verified by reproducing the upgrade** on a dev database (`site_type` nulled, old timestamp stamp restored):

| | log | database | map |
|---|---|---|---|
| without fix | `PGE sites already available` | 18,761 NULL | landings drawn as launch pins |
| with fix | `Catalogue was imported by an older importer, re-importing the local copy` | 12,879 launch / 5,882 landing | windsocks |
| next start | `PGE sites already available` | unchanged | unchanged |

## A favourited landing was dropped, and could not be found by name

A landing can be favourited from its own page, so a favourites list that silently dropped it was lying about what the pilot had marked. The Sites list now asks for `launchesAndLandings`; the Forecast screen keeps the launches-only default, because a landing has no wind directions to be graded against.

Each landing follows the launch it serves, indented, nesting under the **nearest** favourited launch rather than all of them — 28.5% of DHV landings serve several, so listing one under each would show a pilot who favourited four launches on one hill their landing four times. A landing whose launch is not favourited stays at top level. Matched on `site_group` tokens, never on distance.

Name search over the map gains landings for the same reason the map draws them: the launches-only default belongs to queries that pick a site *for* the pilot, where a landing is a wrong answer rather than an extra one.

## Testing

- `flutter analyze` clean; 386 tests passing, 21 network tests skipped by design
- New `test/favorite_grouping_test.dart` (8 cases) and 3 cases in `test/catalog_refresh_test.dart`
- The grouping tests were checked against a mutation: forcing first-match instead of nearest-launch turns the multi-launch case red
- Driven in the running app on Linux desktop — favourites list, Forecast list, and the map

🤖 Generated with [Claude Code](https://claude.com/claude-code)