### PR TITLE
Release 1.0.10+22

### DIFF
--- a/distribution/whatsnew/whatsnew-en-GB
+++ b/distribution/whatsnew/whatsnew-en-GB
@@ -1,8 +1,8 @@
-• Landing areas are proper sites now: see where you are expected to land, how
-  far it is, and the rules that come with it. They are marked with a windsock
-  on the map
-• Site pages open straight away instead of waiting on the network, and links
-  to ParaglidingEarth, DHV and the Australian guide reach the right page
-• Launch altitudes come from one source, so they no longer disagree
-• Removing an airspace country really removes it, and maps start faster
-• Data Management dialogs scroll again
+• Landing areas now show as landings for everyone. If you upgraded and they
+  still looked like launches, this puts it right on its own - no need to
+  reset anything
+• Favourite a landing and it now appears in your favourites, tucked under
+  the launch it serves
+• Searching by name finds landing areas, not just launches
+• A landing's page is headed with a windsock, where a launch shows its wind
+  directions

--- a/the_paragliding_app/pubspec.yaml
+++ b/the_paragliding_app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.9+21
+version: 1.0.10+22
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
Version `1.0.9+21` → `1.0.10+22`, and the notes users see.

## Why the patch digit moves

The range since `v1.0.9+21` is user-visible on both counts, and one of them fixes what 1.0.9 shipped rather than adding to it.

| commit | what a pilot notices |
|---|---|
| #366 | landings appear after upgrading; a favourited landing is listed; a name search finds one |
| #365 | a landing's page is headed with a windsock |

#366 is the reason this release exists. A pilot who upgraded to 1.0.9 could still be looking at landings drawn as launch pins — their catalogue *file* was current, so nothing offered to refresh it, but the rows in it had been imported by a build that never read `site_type`. 1.0.9's headline feature was invisible to exactly the users who already had the app.

That is why the first bullet says it puts itself right with no reset needed: a pilot who saw the wrong thing needs to know it corrects itself, rather than going looking for Reset to Bundled.

## Notes

411 characters, within the 500 limit (`LC_ALL=C.UTF-8 wc -m`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)